### PR TITLE
Manage own state on removal

### DIFF
--- a/examples/basic/serverless.yml
+++ b/examples/basic/serverless.yml
@@ -7,8 +7,7 @@ components:
       memory: 512
       timeout: 10
       handler: handler.handler
-      role:
-        arn: ${myRole.arn}
+      role: ${myRole}
   myRole:
     type: aws-iam-role
     inputs:

--- a/src/utils/components/executeComponent.js
+++ b/src/utils/components/executeComponent.js
@@ -39,7 +39,7 @@ const executeComponent = async (
 
   component.promise.resolve(component)
 
-  if (command === 'remove') {
+  if (command === 'remove' && !is(Function, func)) {
     stateFile[componentId] = {
       type: component.type,
       state: {}

--- a/src/utils/components/executeComponent.js
+++ b/src/utils/components/executeComponent.js
@@ -1,4 +1,6 @@
-const { is, isNil, isEmpty } = require('ramda')
+const {
+  not, is, isNil, isEmpty
+} = require('ramda')
 const generateContext = require('./generateContext')
 const resolvePostExecutionVars = require('../variables/resolvePostExecutionVars')
 const { getInputs, getState } = require('../state')
@@ -49,7 +51,7 @@ const executeComponent = async (
   kind of hackiness. There may be edge cases where this does not work, e.g.
   if the scripted component did not have any state keys to save in the first
   place, but for some reason still has complex removal logic. */
-  if (command === 'remove' && (!is(Function, func) || isNil(component.state))) {
+  if (command === 'remove' && (not(is(Function, func)) || isNil(component.state))) {
     stateFile[componentId] = {
       type: component.type,
       state: {}

--- a/src/utils/components/executeComponent.js
+++ b/src/utils/components/executeComponent.js
@@ -49,10 +49,7 @@ const executeComponent = async (
   kind of hackiness. There may be edge cases where this does not work, e.g.
   if the scripted component did not have any state keys to save in the first
   place, but for some reason still has complex removal logic. */
-  if (
-    command === 'remove' &&
-    (!is(Function, func) || (isNil(component.state) || isEmpty(component.state)))
-  ) {
+  if (command === 'remove' && (!is(Function, func) || isNil(component.state))) {
     stateFile[componentId] = {
       type: component.type,
       state: {}

--- a/src/utils/components/executeComponent.test.js
+++ b/src/utils/components/executeComponent.test.js
@@ -141,7 +141,7 @@ describe('#executeComponent()', () => {
   describe('when running "remove"', () => {
     const command = 'remove'
 
-    it('should treat removals differently', async () => {
+    it('should use the inputs stored in the state file', async () => {
       const res = await executeComponent(
         componentId,
         components,

--- a/tests/integration/await-child-components.test.js
+++ b/tests/integration/await-child-components.test.js
@@ -98,8 +98,6 @@ describe('Integration Test - Await child components', () => {
       expect(stateFileContent).toHaveProperty('await-child-components')
       expect(stateFileContent.$.serviceId).not.toBeFalsy()
       const awaitChildComponents = stateFileContent['await-child-components']
-      const awaitChildComponentsObjectKeys = Object.keys(awaitChildComponents)
-      expect(awaitChildComponentsObjectKeys.length).toEqual(2)
       expect(awaitChildComponents).toHaveProperty('type', 'await-child-components')
       expect(awaitChildComponents).toHaveProperty('state', {})
     })

--- a/tests/integration/programmatic-usage.test.js
+++ b/tests/integration/programmatic-usage.test.js
@@ -163,8 +163,6 @@ describe('Integration Test - Programmatic usage', () => {
       expect(defaultRole).toHaveProperty('type', 'tests-integration-iam-mock')
       expect(defaultRole).toHaveProperty('state', {})
       const myFunction = stateFileContent['programmatic-usage:myFunction']
-      const myFunctionObjectKeys = Object.keys(myFunction)
-      expect(myFunctionObjectKeys.length).toEqual(2)
       expect(myFunction).toHaveProperty('type', 'tests-integration-function-mock')
       expect(myFunction).toHaveProperty('state', {})
     })

--- a/tests/integration/retry-remove/index.js
+++ b/tests/integration/retry-remove/index.js
@@ -1,0 +1,16 @@
+module.exports = {
+  async deploy(inputs, context) {
+    throw new Error('aaaah')
+    console.log('what....')
+    context.saveState({ deployed: true, triedToRemove: false })
+    console.log('why....')
+  }
+
+  async remove(inputs, context) {
+    if(triedToRemove) {
+      context.saveState()
+    } else {
+      context.saveState({ ...context.state, triedToRemove: true })
+    }
+  }
+}

--- a/tests/integration/retry-remove/index.js
+++ b/tests/integration/retry-remove/index.js
@@ -1,16 +1,20 @@
-module.exports = {
-  async deploy(inputs, context) {
-    throw new Error('aaaah')
-    console.log('what....')
-    context.saveState({ deployed: true, triedToRemove: false })
-    console.log('why....')
-  }
+async function deploy(inputs, context) {
+  context.saveState({ deployed: true, triedToRemove: false })
+  throw new Error('Soemthing went wrong during deployment...')
+}
 
-  async remove(inputs, context) {
-    if(triedToRemove) {
-      context.saveState()
-    } else {
-      context.saveState({ ...context.state, triedToRemove: true })
-    }
+async function remove(inputs, context) {
+  if (context.state.triedToRemove) {
+    context.saveState()
+  } else {
+    context.saveState({
+      ...context.state,
+      triedToRemove: true
+    })
   }
+}
+
+module.exports = {
+  deploy,
+  remove
 }

--- a/tests/integration/retry-remove/serverless.yml
+++ b/tests/integration/retry-remove/serverless.yml
@@ -1,0 +1,1 @@
+type: retry-remove

--- a/tests/integration/simple.test.js
+++ b/tests/integration/simple.test.js
@@ -276,7 +276,7 @@ describe('Integration Test - Simple', () => {
       expect(stateFileContent.$.serviceId).not.toBeFalsy()
       const myRole = stateFileContent['simple:myRole']
       const myRoleObjectKeys = Object.keys(myRole)
-      expect(myRoleObjectKeys.length).toEqual(2)
+      expect(myRoleObjectKeys.length).toEqual(5)
       expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
       expect(myRole).toHaveProperty('state', {})
       const myFunction = stateFileContent['simple:myFunction']

--- a/tests/integration/simple.test.js
+++ b/tests/integration/simple.test.js
@@ -23,23 +23,25 @@ describe('Integration Test - Simple', () => {
 
   const testDir = path.dirname(__filename)
   const componentsExec = path.join(testDir, '..', '..', 'bin', 'components')
-  const testServiceDir = path.join(testDir, 'simple')
-  const testServiceStateFile = path.join(testServiceDir, 'state.json')
-  const testRemovalDir = path.join(testDir, 'retry-remove')
-  const testRemovalStateFile = path.join(testServiceDir, 'state.json')
   const FUNCTION_NAME = 'my-function'
+  // The "simple" service
+  const simpleServiceDir = path.join(testDir, 'simple')
+  const simpleServiceStateFile = path.join(simpleServiceDir, 'state.json')
+  // the "restry-remove" service
+  const retryRemoveServiceDir = path.join(testDir, 'retry-remove')
+  const retryRemoveStateFile = path.join(retryRemoveServiceDir, 'state.json')
 
   beforeAll(async () => {
-    await removeStateFiles([ testServiceStateFile, testRemovalStateFile ])
+    await removeStateFiles([ simpleServiceStateFile, retryRemoveStateFile ])
   })
 
   afterAll(async () => {
-    await removeStateFiles([ testServiceStateFile, testRemovalStateFile ])
+    await removeStateFiles([ simpleServiceStateFile, retryRemoveStateFile ])
   })
 
   describe('our test setup', () => {
     it('should not have any state files', async () => {
-      const testServiceHasStateFile = await hasFile(testServiceStateFile)
+      const testServiceHasStateFile = await hasFile(simpleServiceStateFile)
 
       expect(testServiceHasStateFile).toEqual(false)
     })
@@ -48,13 +50,13 @@ describe('Integration Test - Simple', () => {
   describe('when running through a typical component usage lifecycle', () => {
     it('should deploy the "iam" and "function" components', async () => {
       await cpp.execAsync(`${componentsExec} deploy`, {
-        cwd: testServiceDir,
+        cwd: simpleServiceDir,
         env: {
           ...process.env,
           FUNCTION_NAME
         }
       })
-      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+      const stateFileContent = await fsp.readJsonAsync(simpleServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(4)
       expect(stateFileContent).toHaveProperty('$.serviceId')
@@ -99,13 +101,13 @@ describe('Integration Test - Simple', () => {
 
     it('should re-deploy the "iam" and "function" components', async () => {
       await cpp.execAsync(`${componentsExec} deploy`, {
-        cwd: testServiceDir,
+        cwd: simpleServiceDir,
         env: {
           ...process.env,
           FUNCTION_NAME
         }
       })
-      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+      const stateFileContent = await fsp.readJsonAsync(simpleServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(4)
       expect(stateFileContent).toHaveProperty('$.serviceId')
@@ -150,13 +152,13 @@ describe('Integration Test - Simple', () => {
 
     it('should invoke the "function" component with CLI options', async () => {
       await cpp.execAsync(`${componentsExec} invoke --data "Hello World"`, {
-        cwd: testServiceDir,
+        cwd: simpleServiceDir,
         env: {
           ...process.env,
           FUNCTION_NAME
         }
       })
-      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+      const stateFileContent = await fsp.readJsonAsync(simpleServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(4)
       expect(stateFileContent).toHaveProperty('$.serviceId')
@@ -206,7 +208,7 @@ describe('Integration Test - Simple', () => {
       // NOTE: the order of this test here is important since we're keeping and checking the
       // state file throughout the whole test suite
       const cmd = cpp.execAsync(`${componentsExec} deploy`, {
-        cwd: testServiceDir,
+        cwd: simpleServiceDir,
         env: {
           ...process.env,
           FUNCTION_NAME
@@ -214,7 +216,7 @@ describe('Integration Test - Simple', () => {
       })
       await expect(cmd).rejects.toThrow('Failed to deploy function "my-function"')
 
-      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+      const stateFileContent = await fsp.readJsonAsync(simpleServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(4)
       expect(stateFileContent).toHaveProperty('$.serviceId')
@@ -260,13 +262,13 @@ describe('Integration Test - Simple', () => {
 
     it('should remove the "iam" and "function" components', async () => {
       await cpp.execAsync(`${componentsExec} remove`, {
-        cwd: testServiceDir,
+        cwd: simpleServiceDir,
         env: {
           ...process.env,
           FUNCTION_NAME
         }
       })
-      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+      const stateFileContent = await fsp.readJsonAsync(simpleServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(4)
       expect(stateFileContent).toHaveProperty('$.serviceId')
@@ -284,27 +286,27 @@ describe('Integration Test - Simple', () => {
   })
 
   describe('when a component requires multiple removal attempts', () => {
-    it('deploys successfully', async () => {
-      await cpp.execAsync(`${componentsExec} deploy`, {
-        cwd: testRemovalDir
-      })
-      const stateFileContent = await fsp.readJsonAsync(testRemovalStateFile)
+    it('saves the state if deployment fails', async () => {
+      await expect(cpp.execAsync(`${componentsExec} deploy`, {
+        cwd: retryRemoveServiceDir
+      })).rejects.toThrow(/during deployment/)
+      const stateFileContent = await fsp.readJsonAsync(retryRemoveStateFile)
       expect(stateFileContent).toHaveProperty('retry-remove.state.deployed', true)
     })
 
     it('keeps its state after the first remove', async () => {
       await cpp.execAsync(`${componentsExec} remove`, {
-        cwd: testRemovalDir
+        cwd: retryRemoveServiceDir
       })
-      const stateFileContent = await fsp.readJsonAsync(testRemovalStateFile)
+      const stateFileContent = await fsp.readJsonAsync(retryRemoveStateFile)
       expect(stateFileContent).toHaveProperty('retry-remove.state.deployed', true)
     })
 
     it('clears its state after the second remove', async () => {
       await cpp.execAsync(`${componentsExec} remove`, {
-        cwd: testRemovalDir
+        cwd: retryRemoveServiceDir
       })
-      const stateFileContent = await fsp.readJsonAsync(testRemovalStateFile)
+      const stateFileContent = await fsp.readJsonAsync(retryRemoveStateFile)
       expect(stateFileContent).not.toHaveProperty('retry-remove.state.deployed')
     })
   })


### PR DESCRIPTION
## What has been implemented?

Prevent state-removals when errors occur during command execution.

## Steps to verify

Use the following service:

```yml
type: test-project

components:
  myTable:
    type: aws-dynamodb
    inputs:
      region: us-east-1
      tables:
        - name: my-table-${self.serviceId}
          hashKey: id
          indexes:
            - name: IdIndex
              type: global
              hashKey: id
          schema:
            id: number
            firstName: string
            lastName: string
          options:
            timestamps: true
```

Run `components deploy` (your table is not in a "create in progress" state) and after that immediately run `components remove`. You should see an error that the table could not be removed since it's in a pending state. The state shouldn't be wiped out if you look at the `state.json` file.

## Todos:

* [x] Write tests
* [x] Run Prettier