### PR TITLE
Add signal event (SIGINT, SIGTERM, SIGBREAK) handling

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -11,11 +11,13 @@ const {
   setServiceId,
   readStateFile,
   writeStateFile,
-  trackDeployment
+  trackDeployment,
+  handleSignalEvents
   // log
 } = utils
 
 const run = async (command, options) => {
+  handleSignalEvents()
   const reporter = await errorReporter()
   let components = {}
   let stateFile = {}

--- a/src/run.js
+++ b/src/run.js
@@ -11,14 +11,11 @@ const {
   setServiceId,
   readStateFile,
   writeStateFile,
-  trackDeployment,
-  handleSignalEvents
+  trackDeployment
   // log
 } = utils
 
 const run = async (command, options) => {
-  handleSignalEvents()
-
   const reporter = await errorReporter()
   let components = {}
   let stateFile = {}

--- a/src/run.js
+++ b/src/run.js
@@ -11,11 +11,14 @@ const {
   setServiceId,
   readStateFile,
   writeStateFile,
-  trackDeployment
+  trackDeployment,
+  handleSignalEvents
   // log
 } = utils
 
 const run = async (command, options) => {
+  handleSignalEvents()
+
   const reporter = await errorReporter()
   let components = {}
   let stateFile = {}

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -12,6 +12,7 @@ afterEach(() => {
 })
 
 beforeEach(() => {
+  utils.handleSignalEvents.mockImplementation(() => {})
   utils.getComponentsToUse.mockImplementation(() =>
     Promise.resolve({ componentToUse: { id: 'component1', type: 'function' } }))
   utils.getComponentsToRemove.mockImplementation(() =>
@@ -39,6 +40,7 @@ describe('#run()', () => {
       }
     })
 
+    expect(utils.handleSignalEvents).toHaveBeenCalled()
     expect(utils.getComponentsToUse).toHaveBeenCalled()
     expect(utils.getComponentsToRemove).toHaveBeenCalled()
     expect(utils.trackDeployment).not.toHaveBeenCalled()
@@ -55,6 +57,7 @@ describe('#run()', () => {
 
     await expect(run('some-command', {})).rejects.toThrow('something went wrong')
 
+    expect(utils.handleSignalEvents).toHaveBeenCalled()
     expect(utils.getComponentsToUse).toHaveBeenCalled()
     expect(utils.getComponentsToRemove).toHaveBeenCalled()
     expect(utils.trackDeployment).not.toHaveBeenCalled()
@@ -80,6 +83,7 @@ describe('#run()', () => {
         }
       })
 
+      expect(utils.handleSignalEvents).toHaveBeenCalled()
       expect(utils.getComponentsToUse).toHaveBeenCalled()
       expect(utils.getComponentsToRemove).toHaveBeenCalled()
       expect(utils.trackDeployment).toHaveBeenCalled()

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -23,6 +23,7 @@ beforeEach(() => {
   utils.executeGraph.mockImplementation(() => Promise.resolve())
   utils.writeStateFile.mockImplementation(() => Promise.resolve())
   utils.errorReporter.mockImplementation(() => Promise.resolve())
+  utils.handleSignalEvents.mockImplementation(() => {})
 })
 
 describe('#run()', () => {
@@ -39,6 +40,7 @@ describe('#run()', () => {
       }
     })
 
+    expect(utils.handleSignalEvents).toHaveBeenCalled()
     expect(utils.getComponentsToUse).toHaveBeenCalled()
     expect(utils.getComponentsToRemove).toHaveBeenCalled()
     expect(utils.trackDeployment).not.toHaveBeenCalled()
@@ -55,6 +57,7 @@ describe('#run()', () => {
 
     await expect(run('some-command', {})).rejects.toThrow('something went wrong')
 
+    expect(utils.handleSignalEvents).toHaveBeenCalled()
     expect(utils.getComponentsToUse).toHaveBeenCalled()
     expect(utils.getComponentsToRemove).toHaveBeenCalled()
     expect(utils.trackDeployment).not.toHaveBeenCalled()
@@ -80,6 +83,7 @@ describe('#run()', () => {
         }
       })
 
+      expect(utils.handleSignalEvents).toHaveBeenCalled()
       expect(utils.getComponentsToUse).toHaveBeenCalled()
       expect(utils.getComponentsToRemove).toHaveBeenCalled()
       expect(utils.trackDeployment).toHaveBeenCalled()

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -23,7 +23,6 @@ beforeEach(() => {
   utils.executeGraph.mockImplementation(() => Promise.resolve())
   utils.writeStateFile.mockImplementation(() => Promise.resolve())
   utils.errorReporter.mockImplementation(() => Promise.resolve())
-  utils.handleSignalEvents.mockImplementation(() => {})
 })
 
 describe('#run()', () => {
@@ -40,7 +39,6 @@ describe('#run()', () => {
       }
     })
 
-    expect(utils.handleSignalEvents).toHaveBeenCalled()
     expect(utils.getComponentsToUse).toHaveBeenCalled()
     expect(utils.getComponentsToRemove).toHaveBeenCalled()
     expect(utils.trackDeployment).not.toHaveBeenCalled()
@@ -57,7 +55,6 @@ describe('#run()', () => {
 
     await expect(run('some-command', {})).rejects.toThrow('something went wrong')
 
-    expect(utils.handleSignalEvents).toHaveBeenCalled()
     expect(utils.getComponentsToUse).toHaveBeenCalled()
     expect(utils.getComponentsToRemove).toHaveBeenCalled()
     expect(utils.trackDeployment).not.toHaveBeenCalled()
@@ -83,7 +80,6 @@ describe('#run()', () => {
         }
       })
 
-      expect(utils.handleSignalEvents).toHaveBeenCalled()
       expect(utils.getComponentsToUse).toHaveBeenCalled()
       expect(utils.getComponentsToRemove).toHaveBeenCalled()
       expect(utils.trackDeployment).toHaveBeenCalled()

--- a/src/utils/dag/executeGraph.js
+++ b/src/utils/dag/executeGraph.js
@@ -31,14 +31,11 @@ const execute = async (
       rollback
     )
     graph.removeNode(componentId)
-    return new Promise((resolve, reject) => {
-      const shouldGracefullyExit = getGracefulExitStatus()
-      if (shouldGracefullyExit) {
-        reject(new Error('Operation gracefully exited. State successfully persistet...'))
-      } else {
-        resolve(componentId)
-      }
-    })
+    const shouldGracefullyExit = getGracefulExitStatus()
+    if (shouldGracefullyExit) {
+      throw new Error('Operation gracefully exited. State successfully persistet...')
+    }
+    return componentId
   }, leaves)
 
   // allow all executions to complete without terminating

--- a/src/utils/dag/executeGraph.js
+++ b/src/utils/dag/executeGraph.js
@@ -1,8 +1,5 @@
 const { isEmpty, map } = require('ramda')
-const handleSignalEvents = require('../misc/handleSignalEvents')
 const executeComponent = require('../components/executeComponent')
-
-const { getGracefulExitStatus } = handleSignalEvents()
 
 const execute = async (
   graph,
@@ -31,9 +28,8 @@ const execute = async (
       rollback
     )
     graph.removeNode(componentId)
-    const shouldGracefullyExit = getGracefulExitStatus()
-    if (shouldGracefullyExit) {
-      throw new Error('Operation gracefully exited. State successfully persistet...')
+    if (global.signalEventHandling && global.signalEventHandling.shouldExitGracefully) {
+      throw new Error('Operation gracefully exited. State successfully persisted...')
     }
     return componentId
   }, leaves)

--- a/src/utils/misc/handleSignalEvents.js
+++ b/src/utils/misc/handleSignalEvents.js
@@ -1,7 +1,9 @@
 const readline = require('readline')
 
 function handleSignalEvents() {
-  let count = 0
+  let gracefulExitStatus = false
+  let SIGINTCount = 0
+
   if (process.platform === 'win32') {
     const rl = readline.createInterface({
       input: process.stdin,
@@ -14,17 +16,33 @@ function handleSignalEvents() {
   }
 
   process.on('SIGINT', () => {
-    count += 1
+    gracefulExitStatus = true
+    SIGINTCount += 1
     const msg = [
-      'Waiting for current operations to finish... Press CTRL + C again to force an exit',
+      'Waiting for current operation to gracefully finish (this might take some seconds)... Press CTRL + C again to force an exit',
       'NOTE: Doing so might corrupt the applications state information!'
     ].join('\n')
-    if (count < 2) {
+    if (SIGINTCount < 2) {
       console.log(msg) // eslint-disable-line no-console
     } else {
+      gracefulExitStatus = false
       process.exit()
     }
   })
+
+  // "public" functions which expose the state variables
+  function getGracefulExitStatus() {
+    return gracefulExitStatus
+  }
+
+  function getSIGINTCount() {
+    return SIGINTCount
+  }
+
+  return {
+    getGracefulExitStatus,
+    getSIGINTCount
+  }
 }
 
 module.exports = handleSignalEvents

--- a/src/utils/misc/handleSignalEvents.js
+++ b/src/utils/misc/handleSignalEvents.js
@@ -1,0 +1,30 @@
+const readline = require('readline')
+
+function handleSignalEvents() {
+  let count = 0
+  if (process.platform === 'win32') {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    })
+
+    rl.on('SIGINT', () => {
+      process.emit('SIGINT')
+    })
+  }
+
+  process.on('SIGINT', () => {
+    count += 1
+    const msg = [
+      'Waiting for current operations to finish... Press CTRL + C again to force an exit',
+      'NOTE: Doing so might corrupt the applications state information!'
+    ].join('\n')
+    if (count < 2) {
+      console.log(msg) // eslint-disable-line no-console
+    } else {
+      process.exit()
+    }
+  })
+}
+
+module.exports = handleSignalEvents

--- a/src/utils/misc/handleSignalEvents.test.js
+++ b/src/utils/misc/handleSignalEvents.test.js
@@ -27,40 +27,33 @@ describe('#handleSignalEvents()', () => {
     global.console = oldConsole
   })
 
-  describe('when dealing with SIGINT events', () => {
-    let getSIGINTCount
-    let getGracefulExitStatus
+  describe('when dealing with a SIGINT signal', () => {
     const SIGNAL = 'SIGINT'
 
     beforeEach(() => {
       process.removeAllListeners([ SIGNAL ])
-      const res = handleSignalEvents()
-      getSIGINTCount = res.getSIGINTCount
-      getGracefulExitStatus = res.getGracefulExitStatus
     })
 
     it('should ask for a confirmation (emitting signal a second time) before exiting', (done) => {
+      handleSignalEvents()
       process.on(SIGNAL, () => {
-        const SIGINTCount = getSIGINTCount()
-        const gracefulExitStatus = getGracefulExitStatus()
         expect(logMock).toHaveBeenCalledTimes(1)
         expect(exitMock).not.toHaveBeenCalled()
-        expect(SIGINTCount).toEqual(1)
-        expect(gracefulExitStatus).toEqual(true)
+        expect(global.signalEventHandling.SIGINTCount).toEqual(1)
+        expect(global.signalEventHandling.shouldExitGracefully).toEqual(true)
         done()
       })
       process.emit(SIGNAL)
     })
 
     it('should exit the process after receiving the second signal', (done) => {
+      handleSignalEvents()
       process.on(SIGNAL, (numEmitted) => {
         if (numEmitted === 2) {
-          const SIGINTCount = getSIGINTCount()
-          const gracefulExitStatus = getGracefulExitStatus()
           expect(logMock).toHaveBeenCalledTimes(1)
           expect(exitMock).toHaveBeenCalled()
-          expect(SIGINTCount).toEqual(2)
-          expect(gracefulExitStatus).toEqual(false)
+          expect(global.signalEventHandling.SIGINTCount).toEqual(2)
+          expect(global.signalEventHandling.shouldExitGracefully).toEqual(true)
           done()
         }
       })
@@ -69,20 +62,89 @@ describe('#handleSignalEvents()', () => {
     })
 
     it('should support windows systems', (done) => {
+      handleSignalEvents()
       process.platform = 'win32'
       process.on(SIGNAL, (numEmitted) => {
         if (numEmitted === 2) {
-          const SIGINTCount = getSIGINTCount()
-          const gracefulExitStatus = getGracefulExitStatus()
           expect(logMock).toHaveBeenCalledTimes(1)
           expect(exitMock).toHaveBeenCalled()
-          expect(SIGINTCount).toEqual(2)
-          expect(gracefulExitStatus).toEqual(false)
+          expect(global.signalEventHandling.SIGINTCount).toEqual(2)
+          expect(global.signalEventHandling.shouldExitGracefully).toEqual(true)
           done()
         }
       })
       process.emit(SIGNAL, 1)
       process.emit(SIGNAL, 2)
+    })
+  })
+
+  describe('when dealing with a SIGTERM signal', () => {
+    const SIGNAL = 'SIGTERM'
+
+    beforeEach(() => {
+      process.removeAllListeners([ SIGNAL ])
+    })
+
+    it('should exit the process after receiving the signal', (done) => {
+      handleSignalEvents()
+      process.on(SIGNAL, (numEmitted) => {
+        if (numEmitted === 1) {
+          expect(logMock).toHaveBeenCalledTimes(1)
+          expect(exitMock).not.toHaveBeenCalled()
+          expect(global.signalEventHandling.shouldExitGracefully).toEqual(true)
+          done()
+        }
+      })
+      process.emit(SIGNAL, 1)
+    })
+
+    it('should support windows systems', (done) => {
+      handleSignalEvents()
+      process.platform = 'win32'
+      process.on(SIGNAL, (numEmitted) => {
+        if (numEmitted === 1) {
+          expect(logMock).toHaveBeenCalledTimes(1)
+          expect(exitMock).not.toHaveBeenCalled()
+          expect(global.signalEventHandling.shouldExitGracefully).toEqual(true)
+          done()
+        }
+      })
+      process.emit(SIGNAL, 1)
+    })
+  })
+
+  describe('when dealing with a SIGBREAK signal', () => {
+    const SIGNAL = 'SIGBREAK'
+
+    beforeEach(() => {
+      process.removeAllListeners([ SIGNAL ])
+    })
+
+    it('should exit the process after receiving the signal', (done) => {
+      handleSignalEvents()
+      process.on(SIGNAL, (numEmitted) => {
+        if (numEmitted === 1) {
+          expect(logMock).toHaveBeenCalledTimes(1)
+          expect(exitMock).not.toHaveBeenCalled()
+          expect(global.signalEventHandling.shouldExitGracefully).toEqual(true)
+          done()
+        }
+      })
+      process.emit(SIGNAL, 1)
+    })
+
+    it('should support windows systems', (done) => {
+      handleSignalEvents()
+      process.platform = 'win32'
+      process.on(SIGNAL, (numEmitted) => {
+        if (numEmitted === 1) {
+          expect(logMock).toHaveBeenCalledTimes(1)
+          expect(exitMock).not.toHaveBeenCalled()
+          expect(global.signalEventHandling.shouldExitGracefully).toEqual(true)
+          done()
+        }
+      })
+      process.emit(SIGNAL, 1)
     })
   })
 })

--- a/src/utils/misc/handleSignalEvents.test.js
+++ b/src/utils/misc/handleSignalEvents.test.js
@@ -1,0 +1,67 @@
+const handleSignalEvents = require('./handleSignalEvents')
+
+const log = jest.spyOn(console, 'log')
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#handleSignalEvents()', () => {
+  let oldProcess
+  let exitMock
+
+  beforeEach(() => {
+    oldProcess = process
+    exitMock = jest.fn()
+    global.process = oldProcess
+    global.process.exit = exitMock
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  afterAll(() => {
+    global.process = oldProcess
+  })
+
+  describe('when dealing with SIGINT events', () => {
+    const SIGNAL = 'SIGINT'
+
+    it('should ask for a confirmation (emitting signal a second time) before exiting', (done) => {
+      handleSignalEvents()
+
+      process.once(SIGNAL, () => {
+        expect(log).toHaveBeenCalledTimes(1)
+        expect(exitMock).not.toHaveBeenCalled()
+        done()
+      })
+      process.emit(SIGNAL)
+    })
+
+    it('should exit the process after receiving the second signal', (done) => {
+      handleSignalEvents()
+
+      process.once(SIGNAL, () => {
+        expect(log).toHaveBeenCalledTimes(1)
+        expect(exitMock).toHaveBeenCalled()
+        done()
+      })
+      process.emit(SIGNAL)
+      process.emit(SIGNAL)
+    })
+
+    it('should support windows systems', (done) => {
+      handleSignalEvents()
+
+      process.platform = 'win32'
+      process.once(SIGNAL, () => {
+        expect(log).toHaveBeenCalledTimes(1)
+        expect(exitMock).toHaveBeenCalled()
+        done()
+      })
+      process.emit(SIGNAL)
+      process.emit(SIGNAL)
+    })
+  })
+})

--- a/src/utils/misc/index.js
+++ b/src/utils/misc/index.js
@@ -1,7 +1,9 @@
 const forEachIndexed = require('./forEachIndexed')
 const getRandomId = require('./getRandomId')
+const handleSignalEvents = require('./handleSignalEvents')
 
 module.exports = {
   forEachIndexed,
-  getRandomId
+  getRandomId,
+  handleSignalEvents
 }


### PR DESCRIPTION
## What has been implemented?

Implements the functionality to check again whether the user wants to force an exit when using `ctrl + c`.

Closes SC-208
Closes SC-223

## Acceptance criteria

- [x] Implement graceful shutdown --> Still interrupt process execution, but wrap up so that the state is still saved to disk

## Steps to verify

Deploy a service which might take some time to finish and hit `ctrl + c`. You should see a warning. Hitting `ctrl + c` again should force an exit.

## Todos:

* [x] Write tests
* [x] Run Prettier