### PR TITLE
Add circular dependency detection in DAG

### DIFF
--- a/src/utils/dag/buildGraph.js
+++ b/src/utils/dag/buildGraph.js
@@ -1,10 +1,9 @@
 const { Graph } = require('graphlib')
-const {
-  forEach, keys, forEachObjIndexed, not, isEmpty
-} = require('ramda')
+const { forEach, keys, forEachObjIndexed, not, isEmpty } = require('ramda')
+const detectCircularDeps = require('./detectCircularDeps')
 
 module.exports = async (componentsToUse, componentsToRemove, command) => {
-  const graph = new Graph()
+  let graph = new Graph()
 
   // the components to remove
   forEach((componentId) => {
@@ -28,6 +27,8 @@ module.exports = async (componentsToUse, componentsToRemove, command) => {
       }, component.dependencies)
     }
   }, componentsToUse)
+
+  graph = detectCircularDeps(graph)
 
   return graph
 }

--- a/src/utils/dag/detectCircularDeps.js
+++ b/src/utils/dag/detectCircularDeps.js
@@ -8,9 +8,9 @@ function detectCircularDeps(graph) {
     const cycles = graphlib.alg.findCycles(graph)
     let msg = [ 'Your serverless.yml file has circular dependencies:' ]
     forEachIndexed((cycle, index) => {
-      const [ node1, node2 ] = cycle
-      const fromAToB = `${(index += 1)}. ${node1} --> ${node2}`
-      const fromBToA = `${node1} <-- ${node2}`
+      let fromAToB = cycle.join(' --> ')
+      fromAToB = `${(index += 1)}. ${fromAToB}`
+      const fromBToA = cycle.reverse().join(' <-- ')
       const padLength = fromAToB.length + 4
       msg.push(fromAToB.padStart(padLength))
       msg.push(fromBToA.padStart(padLength))

--- a/src/utils/dag/detectCircularDeps.js
+++ b/src/utils/dag/detectCircularDeps.js
@@ -1,0 +1,24 @@
+const { not } = require('ramda')
+const forEachIndexed = require('../misc/forEachIndexed')
+const graphlib = require('graphlib')
+
+function detectCircularDeps(graph) {
+  const isAcyclic = graphlib.alg.isAcyclic(graph)
+  if (not(isAcyclic)) {
+    const cycles = graphlib.alg.findCycles(graph)
+    let msg = [ 'Your serverless.yml file has circular dependencies:' ]
+    forEachIndexed((cycle, index) => {
+      const [ node1, node2 ] = cycle
+      const fromAToB = `${(index += 1)}. ${node1} --> ${node2}`
+      const fromBToA = `${node1} <-- ${node2}`
+      const padLength = fromAToB.length + 4
+      msg.push(fromAToB.padStart(padLength))
+      msg.push(fromBToA.padStart(padLength))
+    }, cycles)
+    msg = msg.join('\n')
+    throw new Error(msg)
+  }
+  return graph
+}
+
+module.exports = detectCircularDeps

--- a/src/utils/dag/detectCircularDeps.test.js
+++ b/src/utils/dag/detectCircularDeps.test.js
@@ -1,0 +1,39 @@
+const graphlib = require('graphlib')
+const detectCircularDeps = require('./detectCircularDeps')
+
+describe('#detectCircularDeps()', () => {
+  let graph
+
+  beforeEach(() => {
+    graph = new graphlib.Graph()
+    graph.setNode('myFunction')
+    graph.setNode('myApiGateway')
+    graph.setNode('myRole')
+    graph.setEdge('myFunction', 'myRole')
+    graph.setEdge('myApiGateway', 'myRole')
+  })
+
+  describe('when not dealing with circular dependencies', () => {
+    it('should simply return the graph', () => {
+      const res = detectCircularDeps(graph)
+      expect(res).toEqual(graph)
+    })
+  })
+
+  describe('when dealing with circular dependencies', () => {
+    beforeEach(() => {
+      // circular dependency 1: myFunction <--> myRole
+      graph.setEdge('myRole', 'myFunction')
+      // circular dependency 2: myApiGateway <--> myRole
+      graph.setEdge('myRole', 'myApiGateway')
+    })
+
+    it('should throw if it detects circular dependencies', () => {
+      expect(() => detectCircularDeps(graph)).toThrow(/has circular dependencies/)
+    })
+
+    it('should print the nodes which introduce circular dependencies', () => {
+      expect(() => detectCircularDeps(graph)).toThrow(/.+ --> .+/)
+    })
+  })
+})

--- a/src/utils/dag/index.js
+++ b/src/utils/dag/index.js
@@ -1,7 +1,9 @@
 const buildGraph = require('./buildGraph')
+const detectCircularDeps = require('./detectCircularDeps')
 const executeGraph = require('./executeGraph')
 
 module.exports = {
   buildGraph,
+  detectCircularDeps,
   executeGraph
 }

--- a/src/utils/misc/forEachIndexed.js
+++ b/src/utils/misc/forEachIndexed.js
@@ -1,0 +1,5 @@
+const { addIndex, forEach } = require('ramda')
+
+const forEachIndexed = addIndex(forEach)
+
+module.exports = forEachIndexed

--- a/src/utils/misc/index.js
+++ b/src/utils/misc/index.js
@@ -1,5 +1,7 @@
+const forEachIndexed = require('./forEachIndexed')
 const getRandomId = require('./getRandomId')
 
 module.exports = {
+  forEachIndexed,
   getRandomId
 }


### PR DESCRIPTION
## What has been implemented?

Closes SC-211

Adds the functionality to detect circular dependencies in the DAG.

## Acceptance criteria

- [x] Implement handling for more than 2 layers of dependencies (e.g. `A --> B --> C`)

## Steps to verify

Use the following service and try to deploy it. You should see an error popping up which explains where the circular dependency was found.

```yml
type: circular-dependencies

components:
  myLambda:
    type: aws-lambda
    inputs:
      handler: code/index.handler
      name: ${lambdaRole.name}
      memory: 512
      timeout: 60
      role:
        arn: ${lambdaRole.arn}
  lambdaRole:
    type: aws-iam-role
    inputs:
      name: ${myLambda.name}
      service: lambda.amazonaws.com
```

## Todos:

* [x] Write tests
* [x] Run Prettier