### PR TITLE
Make IAM remove function idempotent

### DIFF
--- a/examples/basic/serverless.yml
+++ b/examples/basic/serverless.yml
@@ -12,4 +12,5 @@ components:
   myRole:
     type: aws-iam-role
     inputs:
+      name: my-idempotent-test
       service: lambda.amazonaws.com

--- a/examples/basic/serverless.yml
+++ b/examples/basic/serverless.yml
@@ -12,5 +12,4 @@ components:
   myRole:
     type: aws-iam-role
     inputs:
-      name: my-idempotent-test
       service: lambda.amazonaws.com

--- a/registry/aws-iam-role/index.js
+++ b/registry/aws-iam-role/index.js
@@ -161,14 +161,26 @@ const deploy = async (inputs, context) => {
 const remove = async (inputs, context) => {
   if (!context.state.name) return {}
 
-  context.log(`Removing Role: ${context.state.name}`)
-  const outputs = await deleteRole(context.state)
+  const outputs = {
+    policy: null,
+    service: null,
+    arn: null
+  }
+  try {
+    context.log(`Removing Role: ${context.state.name}`)
+    await deleteRole(context.state)
+  } catch (e) {
+    if (!e.message.includes('Role not found')) {
+      throw new Error(e)
+    }
+  }
   context.saveState({
     name: null,
     arn: null,
     service: null,
     policy: null
   })
+
   return outputs
 }
 

--- a/registry/aws-iam-role/index.test.js
+++ b/registry/aws-iam-role/index.test.js
@@ -11,7 +11,7 @@ jest.mock('aws-sdk', () => {
     createRoleMock: jest.fn().mockReturnValue({ Role: { Arn: 'abc:xyz' } }),
     deleteRoleMock: jest.fn().mockImplementation((params) => {
       if (params.RoleName === 'some-already-removed-role') {
-        Promise.reject(new Error('Role not found'))
+        return Promise.reject(new Error('Role not found'))
       }
       return Promise.resolve({ Role: { Arn: null } })
     }),


### PR DESCRIPTION
1. deploy an IAM component
2. copy the state
3. run remove the IAM component
4. after the remove is complete replace the state file with the original copy.
5. run remove again.
6. The removal should not throw an error and should complete successfully.
7. The state file should be updated to reflect the component has been removed.