### PR TITLE
Fix issues in postinstall causing significant slow down in the install time

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
     "components": "./bin/components"
   },
   "scripts": {
+    "cleanse": "node ./scripts/cleanse.js",
     "components": "./bin/components",
     "lint": "eslint . --cache",
     "test": "jest .",
-    "docs": "node scripts/doc-gen.js",
+    "docs": "node ./scripts/doc-gen.js",
     "postinstall": "node ./scripts/postinstall.js",
     "prepublishOnly": "node ./scripts/prepublish.js"
   },

--- a/scripts/cleanse.js
+++ b/scripts/cleanse.js
@@ -1,0 +1,23 @@
+const fs = require('fs')
+const { join, resolve } = require('path')
+const cp = require('child_process')
+
+// get registry path
+const registry = resolve(__dirname, join('..', 'registry'))
+
+fs.readdirSync(registry).forEach((mod) => {
+  const modPath = join(registry, mod)
+
+  // ensure path has a node_modules folder
+  if (fs.existsSync(join(modPath, 'node_modules'))) {
+    const remove = cp.spawn('rm', [ '-rf',  join(modPath, 'node_modules')], { env: process.env })
+    remove.stdout.on('data', (data) => {
+      console.log(data.toString())
+    })
+  }
+})
+
+const remove = cp.spawn('rm', [ '-rf',  resolve(__dirname, '..', 'node_modules')], { env: process.env })
+remove.stdout.on('data', (data) => {
+  console.log(data.toString())
+})

--- a/scripts/cleanse.js
+++ b/scripts/cleanse.js
@@ -10,14 +10,14 @@ fs.readdirSync(registry).forEach((mod) => {
 
   // ensure path has a node_modules folder
   if (fs.existsSync(join(modPath, 'node_modules'))) {
-    const remove = cp.spawn('rm', [ '-rf',  join(modPath, 'node_modules')], { env: process.env })
+    const remove = cp.spawn('rm', [ '-rf', join(modPath, 'node_modules') ], { env: process.env })
     remove.stdout.on('data', (data) => {
-      console.log(data.toString())
+      console.log(data.toString()) // eslint-disable-line no-console
     })
   }
 })
 
-const remove = cp.spawn('rm', [ '-rf',  resolve(__dirname, '..', 'node_modules')], { env: process.env })
+const remove = cp.spawn('rm', [ '-rf', resolve(__dirname, '..', 'node_modules') ], { env: process.env })
 remove.stdout.on('data', (data) => {
-  console.log(data.toString())
+  console.log(data.toString()) // eslint-disable-line no-console
 })

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -23,5 +23,8 @@ fs.readdirSync(registry).forEach((mod) => {
   const npmCmd = os.platform().startsWith('win') ? 'npm.cmd' : 'npm'
 
   // install folder
-  cp.spawn(npmCmd, [ 'i' ], { env: process.env, cwd: modPath, stdio: 'inherit' })
+  const install = cp.spawn(npmCmd, [ 'i' ], { env: process.env, cwd: modPath })
+  install.stdout.on('data', (data) => {
+    console.log(data.toString())
+  })
 })

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -25,6 +25,6 @@ fs.readdirSync(registry).forEach((mod) => {
   // install folder
   const install = cp.spawn(npmCmd, [ 'i' ], { env: process.env, cwd: modPath })
   install.stdout.on('data', (data) => {
-    console.log(data.toString())
+    console.log(data.toString()) // eslint-disable-line no-console
   })
 })


### PR DESCRIPTION
## What has been implemented?

This PR removes the reuse of stdio between all child processes which slows down the installs significantly. It also adds a cleanse script that can be used to wipe out all node_modules folders when necessary.

For reference this issue is documented here https://github.com/nodejs/node/issues/3429