### PR TITLE
Make cloudfront component removal idempotent

### DIFF
--- a/registry/aws-cloudfront/index.js
+++ b/registry/aws-cloudfront/index.js
@@ -203,18 +203,12 @@ const deleteDistribution = async (distributionId) => {
   // disable distribution first
   const res = await toggleEnabledForDistribution(distributionId, false)
 
-  // delete distribution
-  try {
-    await CloudFront.deleteDistribution({
-      Id: distributionId,
-      IfMatch: res.distribution.eTag
-    }).promise()
-    console.log(`CloudFront distribution '${distributionId}' deletion initiated`)
-    return {}
-  } catch (err) {
-    console.log(`Error in deleting CloudFront distribution '${distributionId}'`, err.message)
-    return { error: err }
-  }
+  await CloudFront.deleteDistribution({
+    Id: distributionId,
+    IfMatch: res.distribution.eTag
+  }).promise()
+
+  console.log(`CloudFront distribution '${distributionId}' deletion initiated`)
 }
 
 
@@ -248,14 +242,19 @@ const deploy = async (inputs, context) => {
 const remove = async (inputs, context) => {
   if (!context.state.name) return {}
 
-  context.log(`Removing CloudFront distribution: '${context.state.name}' with id: '${context.state.distribution.id}'`)
-  const res = await deleteDistribution(
-    context.state.distribution.id,
-    context.state.distribution.eTag
-  )
-  if (!res.error) {
-    context.saveState({})
+  try {
+    context.log(`Removing CloudFront distribution: '${context.state.name}' with id: '${context.state.distribution.id}'`)
+    await deleteDistribution(
+      context.state.distribution.id,
+      context.state.distribution.eTag
+    )
+  } catch (e) {
+    if (!e.message.includes('The specified distribution does not exist')) {
+      throw new Error(e)
+    }
   }
+
+  context.saveState({})
   return {}
 }
 

--- a/registry/aws-cloudfront/index.js
+++ b/registry/aws-cloudfront/index.js
@@ -249,12 +249,14 @@ const remove = async (inputs, context) => {
       context.state.distribution.eTag
     )
   } catch (e) {
-    if (!e.message.includes('The specified distribution does not exist')) {
-      throw new Error(e)
+    if (e.message.includes('The distribution you are trying to delete has not been disabled')) {
+      console.log('Could not delete distribution as it is not disabled or is still being disabled. Please disable it or try again later.')
+      e.code = 'RETAIN_STATE'
+      throw e
+    } else if (!e.message.includes('The specified distribution does not exist')) {
+      throw e
     }
   }
-
-  context.saveState({})
   return {}
 }
 

--- a/registry/aws-cloudfront/index.js
+++ b/registry/aws-cloudfront/index.js
@@ -250,7 +250,7 @@ const remove = async (inputs, context) => {
     )
   } catch (e) {
     if (e.message.includes('The distribution you are trying to delete has not been disabled')) {
-      console.log('Could not delete distribution as it is not disabled or is still being disabled. Please disable it or try again later.')
+      context.log('Could not delete distribution as it is not disabled or is still being disabled. Please disable it or try again later.')
       e.code = 'RETAIN_STATE'
       throw e
     } else if (!e.message.includes('The specified distribution does not exist')) {

--- a/registry/aws-cloudfront/index.test.js
+++ b/registry/aws-cloudfront/index.test.js
@@ -1,0 +1,73 @@
+const AWS = require('aws-sdk') // eslint-disable-line
+const cloudFrontComponent = require('./index')
+
+jest.mock('aws-sdk', () => {
+  const mocks = {
+    getDistributionMock: jest.fn().mockImplementation((params) => {
+      if (params.Id === 'doesNotExist') {
+        return Promise.reject(new Error('The specified distribution does not exist'))
+      } else if (params.Id === 'disabled') {
+        return Promise.reject(new Error('The distribution you are trying to delete has not been disabled'))
+      }
+      return Promise.resolve()
+    })
+  }
+
+  const CloudFront = {
+    getDistribution: (obj) => ({
+      promise: () => mocks.getDistributionMock(obj)
+    })
+  }
+  return {
+    mocks,
+    CloudFront: jest.fn().mockImplementation(() => CloudFront)
+  }
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('CloudFront Component Unit Tests', () => {
+  it('should throw a RETAIN_STATE error when aws throws a distribution not disabled error', async () => {
+    const cloudFrontContextMock = {
+      state: {
+        name: 'abc',
+        distribution: {
+          id: 'disabled',
+          eTag: 'abc'
+        }
+      },
+      archive: {},
+      log: () => {},
+      saveState: () => {}
+    }
+
+    const inputs = {}
+
+    await expect(cloudFrontComponent.remove(inputs, cloudFrontContextMock)).rejects.toHaveProperty('code', 'RETAIN_STATE')
+    expect(AWS.CloudFront).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.getDistributionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('should NOT throw an error if distribution does not exist', async () => {
+    const cloudFrontContextMock = {
+      state: {
+        name: 'abc',
+        distribution: {
+          id: 'doesNotExist',
+          eTag: 'abc'
+        }
+      },
+      archive: {},
+      log: () => {},
+      saveState: () => {}
+    }
+
+    const inputs = {}
+
+    await expect(cloudFrontComponent.remove(inputs, cloudFrontContextMock)).resolves.toEqual({})
+    expect(AWS.CloudFront).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.getDistributionMock).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
1. deploy the component
2. copy the state
3. run remove the component
4. after the remove is complete replace the state file with the original copy.
5. run remove again.
6. The removal should not throw an error and should complete successfully.
7. The state file should be updated to reflect the component has been removed.