### PR TITLE
Make Route53 component remove function idempotent

### DIFF
--- a/registry/aws-route53/index.js
+++ b/registry/aws-route53/index.js
@@ -190,12 +190,18 @@ const deploy = async (inputs, context) => {
 const remove = async (inputs, context) => {
   if (!context.state.name) return {}
 
-  context.log(`Removing Route53 mapping: '${context.state.hostedZone.name}' with id: '${context.state.hostedZone.id}'`)
-  await removeRoute53ToCloudFrontDomainMapping(
-    inputs.domainName,
-    inputs.dnsName,
-    context.state.hostedZone.id
-  )
+  try {
+    context.log(`Removing Route53 mapping: '${context.state.hostedZone.name}' with id: '${context.state.hostedZone.id}'`)
+    await removeRoute53ToCloudFrontDomainMapping(
+      inputs.domainName,
+      inputs.dnsName,
+      context.state.hostedZone.id
+    )
+  } catch (e) {
+    if (!e.message.includes('No hosted zone found with ID')) {
+      throw new Error(e)
+    }
+  }
   context.saveState({})
   return {}
 }

--- a/registry/aws-route53/index.js
+++ b/registry/aws-route53/index.js
@@ -199,7 +199,7 @@ const remove = async (inputs, context) => {
     )
   } catch (e) {
     if (!e.message.includes('No hosted zone found with ID')) {
-      throw new Error(e)
+      throw e
     }
   }
   context.saveState({})

--- a/registry/aws-route53/indext.test.js
+++ b/registry/aws-route53/indext.test.js
@@ -1,0 +1,53 @@
+const AWS = require('aws-sdk') // eslint-disable-line
+const route53Component = require('./index')
+
+jest.mock('aws-sdk', () => {
+  const mocks = {
+    changeResourceRecordSetsMock: jest.fn().mockImplementation((params) => {
+      if (params.HostedZoneId === 'doesNotExist') {
+        return Promise.reject(new Error('No hosted zone found with ID'))
+      }
+      return Promise.resolve()
+    })
+  }
+
+  const Route53 = {
+    changeResourceRecordSets: (obj) => ({
+      promise: () => mocks.changeResourceRecordSetsMock(obj)
+    })
+  }
+  return {
+    mocks,
+    Route53: jest.fn().mockImplementation(() => Route53)
+  }
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('Route53 Component Unit Tests', () => {
+  it('should NOT throw an error if distribution does not exist', async () => {
+    const route53ContextMock = {
+      state: {
+        name: 'abc',
+        hostedZone: {
+          name: 'abc',
+          id: 'doesNotExist'
+        }
+      },
+      archive: {},
+      log: () => {},
+      saveState: () => {}
+    }
+
+    const inputs = {
+      domainName: 'abc',
+      dnsName: 'abc'
+    }
+
+    await expect(route53Component.remove(inputs, route53ContextMock)).resolves.toEqual({})
+    expect(AWS.Route53).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.changeResourceRecordSetsMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
1. deploy component
2. copy the state
3. run remove the component
4. after the remove is complete replace the state file with the original copy.
5. run remove again.
6. The removal should not throw an error and should complete successfully.
7. The state file should be updated to reflect the component has been removed.