### PR TITLE
Add AppVeyor CI support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,19 @@
+environment:
+  matrix:
+    - NODEJS_VERSION: '4'
+    - NODEJS_VERSION: '6'
+    - NODEJS_VERSION: '8'
+
+install:
+  # get the version of Node.js
+  - ps: Install-Product node $Env:NODEJS_VERSION
+  # install modules
+  - npm install
+  - node --version
+  - npm --version
+
+test_script:
+  - npm test
+
+# don't actually build.
+build: off


### PR DESCRIPTION
## What has been implemented?

Adds AppVeyor to our CI tooling so that we can run the tests for Windows systems as well.

Closes SC-242

---

I tried to add the addon / app to the GitHub repository, but it looks like I'm not authorized to do that. Would be nice if @brianneisler could take a quick look at it and set it up (Aside: we already did the same for the `serverless/serverless` repository).

## Todos:

* [x] Run Prettier