### PR TITLE
Add Codecov support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,23 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ node_js:
 - 8
 install:
 - npm install
+- npm install -g codecov
 - pushd examples/restapi/code && npm install && popd
 script:
 - npm run lint
 - npm test
+- codecov
 env:
   SENTRY_DSN: https://17031d90871a4daebd4f261f2359b38f:9ce69587851c448b96893fb3794df20e@sentry.io/300239
   SEGMENT_WRITE_KEY: jvOP27GTlIJubkJpRcDAa4uSfwCD03NI

--- a/package.json
+++ b/package.json
@@ -62,5 +62,9 @@
     "jest": "^22.4.2",
     "markdown-magic": "^0.1.21",
     "prettier": "^1.10.2"
+  },
+  "jest": {
+    "coverageDirectory": "./coverage/",
+    "collectCoverage": true
   }
 }


### PR DESCRIPTION
## What has been implemented?

Adds Codecov support so that we can see the actual code coverage and add guards to prevent untested code from being merged.

Closes SC-236

---

I tried to add the GitHub integration, but it looks like I'm not authorized to do that. @brianneisler it would be nice if you could add that to the repo so that we can have PR / Branch checks.

## Todos:

* [x] Run Prettier