### PR TITLE
Remove unsupported Node versions from AppVeyor config file

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-    - NODEJS_VERSION: '4'
-    - NODEJS_VERSION: '6'
     - NODEJS_VERSION: '8'
 
 install:


### PR DESCRIPTION
## What has been implemented?

Remove Node 4 and 6 since they're not supported ATM.

## Todos:

* [x] Run Prettier