### PR TITLE
Validate variables usage

### DIFF
--- a/registry/tests-invalid-variables-usage/index.js
+++ b/registry/tests-invalid-variables-usage/index.js
@@ -1,0 +1,13 @@
+const deploy = (inputs, context) => {
+  context.saveState({ inputs })
+  return {}
+}
+
+const remove = (inputs, context) => {
+  context.saveState({ })
+}
+
+module.exports = {
+  deploy,
+  remove
+}

--- a/registry/tests-invalid-variables-usage/serverless.yml
+++ b/registry/tests-invalid-variables-usage/serverless.yml
@@ -1,0 +1,7 @@
+type: ${env.TYPE_NAME}
+version: ${env.VERSION_NUMBER}
+
+inputTypes:
+  name:
+    type: string
+    default: my-function

--- a/src/utils/components/getComponent.js
+++ b/src/utils/components/getComponent.js
@@ -4,12 +4,15 @@ const { readFile } = require('../fs')
 const getServiceId = require('../state/getServiceId')
 const transformPostExecutionVars = require('../variables/transformPostExecutionVars')
 const resolvePreExecutionVars = require('../variables/resolvePreExecutionVars')
+const validateVarsUsage = require('../variables/validateVarsUsage')
 const getInstanceId = require('./getInstanceId')
 const setInputDefaults = require('./setInputDefaults')
 const validateInputs = require('./validateInputs')
 
 module.exports = async (componentRoot, componentId, inputs, stateFile) => {
   let slsYml = await readFile(path.join(componentRoot, 'serverless.yml'))
+
+  validateVarsUsage(slsYml)
 
   slsYml.id = componentId || slsYml.type
 

--- a/src/utils/components/getComponent.test.js
+++ b/src/utils/components/getComponent.test.js
@@ -108,5 +108,30 @@ describe('#getComponent()', () => {
         message: expect.stringMatching(/Type error in component/)
       })
     })
+
+    it('Test invalid variables usage', async () => {
+      let error
+      try {
+        await getComponent(
+          path.resolve(__dirname, '../../../registry/tests-invalid-variables-usage'),
+          'test',
+          {},
+          {
+            $: { serviceId: 'AsH3gefdfDSY' },
+            'my-component': {
+              type: 'aws-function',
+              internallyManaged: false,
+              instanceId: 'AsH3gefdfDSY-cHA9jPi5lPQj',
+              state: {}
+            }
+          }
+        )
+      } catch (err) {
+        error = err
+      }
+      expect(error).toMatchObject({
+        message: expect.stringMatching(/variable syntax cannot be used/)
+      })
+    })
   })
 })

--- a/src/utils/variables/index.js
+++ b/src/utils/variables/index.js
@@ -3,11 +3,13 @@ const resolvePostExecutionVars = require('./resolvePostExecutionVars')
 const transformPostExecutionVars = require('./transformPostExecutionVars')
 const getDependencies = require('./getDependencies')
 const getVariableSyntax = require('./getVariableSyntax')
+const validateVarsUsage = require('./validateVarsUsage')
 
 module.exports = {
   resolvePreExecutionVars,
   resolvePostExecutionVars,
   transformPostExecutionVars,
   getDependencies,
-  getVariableSyntax
+  getVariableSyntax,
+  validateVarsUsage
 }

--- a/src/utils/variables/validateVarsUsage.js
+++ b/src/utils/variables/validateVarsUsage.js
@@ -1,0 +1,23 @@
+const getVariableSyntax = require('./getVariableSyntax')
+
+// "private" functions
+function checkForViolations(serverlessYml) {
+  const forbiddenProperties = [ 'type', 'version' ]
+  const varSyntax = getVariableSyntax()
+
+  return forbiddenProperties.some((property) => {
+    const value = serverlessYml[property]
+    return value && value.match(varSyntax)
+  })
+}
+
+// "public" functions
+function validateVarsUsage(serverlessYml) {
+  const violationsFound = checkForViolations(serverlessYml)
+  if (violationsFound) {
+    throw new Error('The variable syntax cannot be used in "type" or "version" properties')
+  }
+  return true
+}
+
+module.exports = validateVarsUsage

--- a/src/utils/variables/validateVarsUsage.test.js
+++ b/src/utils/variables/validateVarsUsage.test.js
@@ -1,0 +1,42 @@
+const validateVarsUsage = require('./validateVarsUsage')
+
+describe('#validateVarsUsage()', () => {
+  it('should return true if variables are used correctly', () => {
+    const serverlessYml = {
+      type: 'my-component',
+      version: '0.1.0'
+    }
+
+    const res = validateVarsUsage(serverlessYml)
+    expect(res).toEqual(true)
+  })
+
+  it('should skip validation if a property is not present', () => {
+    const serverlessYml = {
+      type: 'my-component'
+    }
+
+    const res = validateVarsUsage(serverlessYml)
+    expect(res).toEqual(true)
+  })
+
+  describe('when violating variable usage', () => {
+    it('should throw if variables are used in the "type" property', () => {
+      const serverlessYml = {
+        type: '${self.foo}', // eslint-disable-line no-template-curly-in-string
+        version: '0.1.0'
+      }
+
+      expect(() => validateVarsUsage(serverlessYml)).toThrow(/cannot be used in "type"/)
+    })
+
+    it('should throw if variables are used in the "version" property', () => {
+      const serverlessYml = {
+        type: 'my-component',
+        version: '${self.foo}' // eslint-disable-line no-template-curly-in-string
+      }
+
+      expect(() => validateVarsUsage(serverlessYml)).toThrow(/or "version"/)
+    })
+  })
+})


### PR DESCRIPTION
## What has been implemented?

Validates variables usage so that it throws an error if serverless variables are used in the `type` or `version` property.

Closes SC-259

## Steps to verify

Use the following service and run `components deploy`. You should see an error saying that you cannot use variables in the "type" or "version" property.

```yml
type: ${env.COMPONENT_TYPE}
version: ${env.COMPONENT_VERSION}

components:
  myRole:
    type: aws-iam-role
    inputs:
      service: lambda.amazonaws.com
```

## Todos:

* [x] Write tests
* [x] Run Prettier