### PR TITLE
Fixed AWS Tests

### DIFF
--- a/registry/aws-cloudfront/index.test.js
+++ b/registry/aws-cloudfront/index.test.js
@@ -24,6 +24,10 @@ jest.mock('aws-sdk', () => {
   }
 })
 
+afterEach(() => {
+  AWS.mocks.getDistributionMock.mockClear()
+})
+
 afterAll(() => {
   jest.restoreAllMocks()
 })
@@ -68,6 +72,6 @@ describe('CloudFront Component Unit Tests', () => {
 
     await expect(cloudFrontComponent.remove(inputs, cloudFrontContextMock)).resolves.toEqual({})
     expect(AWS.CloudFront).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.getDistributionMock).toHaveBeenCalledTimes(2)
+    expect(AWS.mocks.getDistributionMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/registry/aws-iam-role/index.test.js
+++ b/registry/aws-iam-role/index.test.js
@@ -39,6 +39,13 @@ jest.mock('aws-sdk', () => {
   }
 })
 
+afterEach(() => {
+  AWS.mocks.createRoleMock.mockClear()
+  AWS.mocks.deleteRoleMock.mockClear()
+  AWS.mocks.attachRolePolicyMock.mockClear()
+  AWS.mocks.detachRolePolicyMock.mockClear()
+})
+
 afterAll(() => {
   BbPromise.delay.mockRestore()
 })
@@ -86,8 +93,8 @@ describe('aws-iam-role unit tests', () => {
     }
     const outputs = await iamComponent.deploy(inputs, iamContextMock)
     expect(AWS.IAM).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.createRoleMock).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.attachRolePolicyMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.createRoleMock).not.toBeCalled()
+    expect(AWS.mocks.attachRolePolicyMock).not.toBeCalled()
     expect(outputs.name).toEqual(inputs.name)
     expect(outputs.arn).toEqual('abc:xyz')
     expect(outputs.service).toEqual(inputs.service)
@@ -162,8 +169,8 @@ describe('aws-iam-role unit tests', () => {
     const outputs = await iamComponent.remove(inputs, iamContextMock)
 
     expect(AWS.IAM).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.deleteRoleMock).toHaveBeenCalledTimes(2)
-    expect(AWS.mocks.detachRolePolicyMock).toHaveBeenCalledTimes(2)
+    expect(AWS.mocks.deleteRoleMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.detachRolePolicyMock).toHaveBeenCalledTimes(1)
     expect(iamContextMock.saveState).toBeCalledWith({
       name: null,
       arn: null,

--- a/registry/aws-lambda/index.test.js
+++ b/registry/aws-lambda/index.test.js
@@ -36,6 +36,13 @@ jest.mock('aws-sdk', () => {
   }
 })
 
+afterEach(() => {
+  AWS.mocks.createFunctionMock.mockClear()
+  AWS.mocks.updateFunctionConfigurationMock.mockClear()
+  AWS.mocks.updateFunctionCodeMock.mockClear()
+  AWS.mocks.deleteFunctionMock.mockClear()
+})
+
 afterAll(() => {
   jest.restoreAllMocks()
 })
@@ -120,12 +127,12 @@ describe('aws-lambda tests', () => {
     const outputs = await lambdaComponent.deploy(inputs, lambdaContextMock)
 
     expect(AWS.Lambda).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.createFunctionMock).toHaveBeenCalledTimes(2)
+    expect(AWS.mocks.createFunctionMock).toHaveBeenCalledTimes(1)
     expect(AWS.mocks.deleteFunctionMock).toHaveBeenCalledTimes(1)
     expect(outputs.arn).toEqual('abc:xyz')
     expect(outputs.roleArn).toEqual('abc:xyz')
     expect(lambdaContextMock.saveState).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.createFunctionMock.mock.calls[1][0].FunctionName)
+    expect(AWS.mocks.createFunctionMock.mock.calls[0][0].FunctionName)
       .toEqual(inputs.name)
     expect(AWS.mocks.deleteFunctionMock.mock.calls[0][0].FunctionName)
       .toEqual(lambdaContextMock.state.name)
@@ -153,7 +160,7 @@ describe('aws-lambda tests', () => {
     const outputs = await lambdaComponent.remove(inputs, lambdaContextMock)
 
     expect(AWS.Lambda).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.deleteFunctionMock).toHaveBeenCalledTimes(2)
+    expect(AWS.mocks.deleteFunctionMock).toHaveBeenCalledTimes(1)
     expect(outputs.arn).toEqual(null)
     expect(lambdaContextMock.saveState).toHaveBeenCalledTimes(1)
   })
@@ -180,7 +187,7 @@ describe('aws-lambda tests', () => {
     const outputs = await lambdaComponent.remove(inputs, lambdaContextMock)
 
     expect(AWS.Lambda).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.deleteFunctionMock).toHaveBeenCalledTimes(2)
+    expect(AWS.mocks.deleteFunctionMock).toHaveBeenCalledTimes(0)
     expect(outputs.arn).toEqual(null)
     expect(lambdaContextMock.saveState).toHaveBeenCalledTimes(0)
   })
@@ -211,7 +218,7 @@ describe('aws-lambda tests', () => {
       service: 'lambda.amazonaws.com'
     })
     expect(loadDeployMock).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.createFunctionMock).toHaveBeenCalledTimes(3)
+    expect(AWS.mocks.createFunctionMock).toHaveBeenCalledTimes(1)
     expect(outputs.arn).toEqual('abc:xyz')
     expect(outputs.roleArn).toEqual('abc:xyz')
     expect(lambdaContextMock.saveState).toHaveBeenCalledTimes(1)
@@ -250,7 +257,7 @@ describe('aws-lambda tests', () => {
       service: 'lambda.amazonaws.com'
     })
     expect(loadRemoveMock).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.deleteFunctionMock).toHaveBeenCalledTimes(3)
+    expect(AWS.mocks.deleteFunctionMock).toHaveBeenCalledTimes(1)
     expect(outputs.arn).toEqual(null)
     expect(lambdaContextMock.saveState).toHaveBeenCalledTimes(1)
   })
@@ -275,7 +282,7 @@ describe('aws-lambda tests', () => {
     const outputs = await lambdaComponent.remove(inputs, lambdaContextMock)
 
     expect(AWS.Lambda).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.deleteFunctionMock).toHaveBeenCalledTimes(4)
+    expect(AWS.mocks.deleteFunctionMock).toHaveBeenCalledTimes(1)
     expect(outputs.arn).toEqual(null)
     expect(lambdaContextMock.saveState).toHaveBeenCalledTimes(1)
   })

--- a/registry/aws-route53/indext.test.js
+++ b/registry/aws-route53/indext.test.js
@@ -22,6 +22,10 @@ jest.mock('aws-sdk', () => {
   }
 })
 
+afterEach(() => {
+  AWS.mocks.changeResourceRecordSetsMock.mockClear()
+})
+
 afterAll(() => {
   jest.restoreAllMocks()
 })

--- a/registry/aws-s3-bucket/index.test.js
+++ b/registry/aws-s3-bucket/index.test.js
@@ -34,6 +34,13 @@ jest.mock('aws-sdk', () => {
   }
 })
 
+afterEach(() => {
+  AWS.mocks.createBucketMock.mockClear()
+  AWS.mocks.deleteBucketMock.mockClear()
+  AWS.mocks.listObjectsV2Mock.mockClear()
+  AWS.mocks.deleteObjectsMock.mockClear()
+})
+
 afterAll(() => {
   jest.restoreAllMocks()
 })
@@ -74,7 +81,7 @@ describe('aws-s3-bucket tests', () => {
     const outputs = await s3Component.deploy(inputs, s3ContextMock)
 
     expect(AWS.S3).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.createBucketMock).toHaveBeenCalledTimes(1) // from the previous deploy
+    expect(AWS.mocks.createBucketMock).toHaveBeenCalledTimes(0)
     expect(outputs.name).toEqual(inputs.name)
     expect(s3ContextMock.saveState).toHaveBeenCalledTimes(0)
   })
@@ -138,16 +145,16 @@ describe('aws-s3-bucket tests', () => {
     const outputs = await s3Component.deploy(inputs, s3ContextMock)
 
     expect(AWS.S3).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.createBucketMock).toHaveBeenCalledTimes(2)
-    expect(AWS.mocks.deleteBucketMock).toHaveBeenCalledTimes(2)
-    expect(AWS.mocks.listObjectsV2Mock).toHaveBeenCalledTimes(2)
-    expect(AWS.mocks.deleteObjectsMock).toHaveBeenCalledTimes(2)
+    expect(AWS.mocks.createBucketMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.deleteBucketMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.listObjectsV2Mock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.deleteObjectsMock).toHaveBeenCalledTimes(1)
     expect(s3ContextMock.saveState).toHaveBeenCalledTimes(1)
     expect(outputs).toEqual({ name: inputs.name })
 
-    expect(AWS.mocks.createBucketMock.mock.calls[1][0])
+    expect(AWS.mocks.createBucketMock.mock.calls[0][0])
       .toEqual({ Bucket: inputs.name })
-    expect(AWS.mocks.deleteBucketMock.mock.calls[1][0])
+    expect(AWS.mocks.deleteBucketMock.mock.calls[0][0])
       .toEqual({ Bucket: s3ContextMock.state.name })
   })
 
@@ -165,7 +172,7 @@ describe('aws-s3-bucket tests', () => {
     const outputs = await s3Component.remove(inputs, s3ContextMock)
 
     expect(AWS.S3).toHaveBeenCalledTimes(1)
-    expect(AWS.mocks.listObjectsV2Mock).toHaveBeenCalledTimes(3)
+    expect(AWS.mocks.listObjectsV2Mock).toHaveBeenCalledTimes(1)
     expect(s3ContextMock.saveState).toBeCalledWith({})
     expect(outputs).toEqual({ name: null })
   })


### PR DESCRIPTION
AWS tests were previously impacting each other and cannot be run individually. This PR fixes this by clearing the mocks after each test.