### PR TITLE
fix typo in Dynamo DB component serverless.yml

### DIFF
--- a/registry/aws-dynamodb/serverless.yml
+++ b/registry/aws-dynamodb/serverless.yml
@@ -10,7 +10,7 @@ inputTypes:
   tables:
     type: object[]
     required: true
-    displayName: DynamoDB Table Defintions
+    displayName: DynamoDB Table Definitions
     description: Array of AWS DynamoDB table definitions
     example:
       - name: BlogPost


### PR DESCRIPTION
## What has been implemented?

This Pull Request fixes a minor typo in the description field for the Dynamo DB component

## Steps to verify

* Line 13 should now read
```yaml
DynamoDB Table Definitions
```