### PR TITLE
Extend timeout for integration tests since they keep timing out

### DIFF
--- a/tests/integration/await-child-components.test.js
+++ b/tests/integration/await-child-components.test.js
@@ -19,7 +19,7 @@ async function removeStateFiles(stateFiles) {
 }
 
 describe('Integration Test - Await child components', () => {
-  jest.setTimeout(20000)
+  jest.setTimeout(40000)
 
   const testDir = path.dirname(__filename)
   const componentsExec = path.join(testDir, '..', '..', 'bin', 'components')
@@ -57,14 +57,20 @@ describe('Integration Test - Await child components', () => {
       const awaitChildComponentsObjectKeys = Object.keys(awaitChildComponents)
       expect(awaitChildComponentsObjectKeys.length).toEqual(6)
       expect(awaitChildComponents).toHaveProperty('instanceId')
-      expect(awaitChildComponents).toHaveProperty('type', 'await-child-components')
+      expect(awaitChildComponents).toHaveProperty(
+        'type',
+        'await-child-components'
+      )
       expect(awaitChildComponents).toHaveProperty('internallyManaged', false)
       expect(awaitChildComponents).toHaveProperty('rootPath')
       expect(awaitChildComponents).toHaveProperty(
         'state.myFunction.state.id',
         'id:function:my-function'
       )
-      expect(awaitChildComponents).toHaveProperty('state.myFunction.state.deploymentCounter', 1)
+      expect(awaitChildComponents).toHaveProperty(
+        'state.myFunction.state.deploymentCounter',
+        1
+      )
       expect(awaitChildComponents).toHaveProperty('state.myFunction.outputs', {
         id: 'id:function:my-function',
         name: 'my-function',
@@ -101,7 +107,10 @@ describe('Integration Test - Await child components', () => {
       const awaitChildComponents = stateFileContent['await-child-components']
       const awaitChildComponentsObjectKeys = Object.keys(awaitChildComponents)
       expect(awaitChildComponentsObjectKeys.length).toEqual(2)
-      expect(awaitChildComponents).toHaveProperty('type', 'await-child-components')
+      expect(awaitChildComponents).toHaveProperty(
+        'type',
+        'await-child-components'
+      )
       expect(awaitChildComponents).toHaveProperty('state', {})
     })
   })

--- a/tests/integration/programmatic-usage.test.js
+++ b/tests/integration/programmatic-usage.test.js
@@ -19,7 +19,7 @@ async function removeStateFiles(stateFiles) {
 }
 
 describe('Integration Test - Programmatic usage', () => {
-  jest.setTimeout(20000)
+  jest.setTimeout(40000)
 
   const testDir = path.dirname(__filename)
   const componentsExec = path.join(testDir, '..', '..', 'bin', 'components')
@@ -53,7 +53,8 @@ describe('Integration Test - Programmatic usage', () => {
       expect(stateFileContent).toHaveProperty('$.serviceId')
       expect(stateFileContent).toHaveProperty('programmatic-usage:myFunction:defaultRole')
       expect(stateFileContent.$.serviceId).not.toBeFalsy()
-      const defaultRole = stateFileContent['programmatic-usage:myFunction:defaultRole']
+      const defaultRole =
+        stateFileContent['programmatic-usage:myFunction:defaultRole']
       const defaultRoleObjectKeys = Object.keys(defaultRole)
       expect(defaultRoleObjectKeys.length).toEqual(6)
       expect(defaultRole).toHaveProperty('instanceId')
@@ -71,7 +72,10 @@ describe('Integration Test - Programmatic usage', () => {
       const myFunctionObjectKeys = Object.keys(myFunction)
       expect(myFunctionObjectKeys.length).toEqual(6)
       expect(myFunction).toHaveProperty('instanceId')
-      expect(myFunction).toHaveProperty('type', 'tests-integration-function-mock')
+      expect(myFunction).toHaveProperty(
+        'type',
+        'tests-integration-function-mock'
+      )
       expect(myFunction).toHaveProperty('internallyManaged', false)
       expect(myFunction).toHaveProperty('rootPath')
       expect(myFunction).toHaveProperty('state', {
@@ -107,7 +111,8 @@ describe('Integration Test - Programmatic usage', () => {
       expect(stateFileContent).toHaveProperty('$.serviceId')
       expect(stateFileContent).toHaveProperty('programmatic-usage:myFunction:defaultRole')
       expect(stateFileContent.$.serviceId).not.toBeFalsy()
-      const defaultRole = stateFileContent['programmatic-usage:myFunction:defaultRole']
+      const defaultRole =
+        stateFileContent['programmatic-usage:myFunction:defaultRole']
       const defaultRoleObjectKeys = Object.keys(defaultRole)
       expect(defaultRoleObjectKeys.length).toEqual(6)
       expect(defaultRole).toHaveProperty('instanceId')
@@ -125,7 +130,10 @@ describe('Integration Test - Programmatic usage', () => {
       const myFunctionObjectKeys = Object.keys(myFunction)
       expect(myFunctionObjectKeys.length).toEqual(6)
       expect(myFunction).toHaveProperty('instanceId')
-      expect(myFunction).toHaveProperty('type', 'tests-integration-function-mock')
+      expect(myFunction).toHaveProperty(
+        'type',
+        'tests-integration-function-mock'
+      )
       expect(myFunction).toHaveProperty('internallyManaged', false)
       expect(myFunction).toHaveProperty('rootPath')
       expect(myFunction).toHaveProperty('state', {
@@ -161,7 +169,8 @@ describe('Integration Test - Programmatic usage', () => {
       expect(stateFileContent).toHaveProperty('$.serviceId')
       expect(stateFileContent).toHaveProperty('programmatic-usage:myFunction:defaultRole')
       expect(stateFileContent.$.serviceId).not.toBeFalsy()
-      const defaultRole = stateFileContent['programmatic-usage:myFunction:defaultRole']
+      const defaultRole =
+        stateFileContent['programmatic-usage:myFunction:defaultRole']
       const defaultRoleObjectKeys = Object.keys(defaultRole)
       expect(defaultRoleObjectKeys.length).toEqual(6)
       expect(defaultRole).toHaveProperty('type', 'tests-integration-iam-mock')
@@ -169,7 +178,10 @@ describe('Integration Test - Programmatic usage', () => {
       const myFunction = stateFileContent['programmatic-usage:myFunction']
       const myFunctionObjectKeys = Object.keys(myFunction)
       expect(myFunctionObjectKeys.length).toEqual(2)
-      expect(myFunction).toHaveProperty('type', 'tests-integration-function-mock')
+      expect(myFunction).toHaveProperty(
+        'type',
+        'tests-integration-function-mock'
+      )
       expect(myFunction).toHaveProperty('state', {})
     })
   })

--- a/tests/integration/simple.test.js
+++ b/tests/integration/simple.test.js
@@ -19,7 +19,7 @@ async function removeStateFiles(stateFiles) {
 }
 
 describe('Integration Test - Simple', () => {
-  jest.setTimeout(20000)
+  jest.setTimeout(40000)
 
   const testDir = path.dirname(__filename)
   const componentsExec = path.join(testDir, '..', '..', 'bin', 'components')
@@ -76,7 +76,10 @@ describe('Integration Test - Simple', () => {
       const myFunctionObjectKeys = Object.keys(myFunction)
       expect(myFunctionObjectKeys.length).toEqual(6)
       expect(myFunction).toHaveProperty('instanceId')
-      expect(myFunction).toHaveProperty('type', 'tests-integration-function-mock')
+      expect(myFunction).toHaveProperty(
+        'type',
+        'tests-integration-function-mock'
+      )
       expect(myFunction).toHaveProperty('internallyManaged', false)
       expect(myFunction).toHaveProperty('rootPath')
       expect(myFunction).toHaveProperty('state', {
@@ -129,7 +132,10 @@ describe('Integration Test - Simple', () => {
       const myFunctionObjectKeys = Object.keys(myFunction)
       expect(myFunctionObjectKeys.length).toEqual(6)
       expect(myFunction).toHaveProperty('instanceId')
-      expect(myFunction).toHaveProperty('type', 'tests-integration-function-mock')
+      expect(myFunction).toHaveProperty(
+        'type',
+        'tests-integration-function-mock'
+      )
       expect(myFunction).toHaveProperty('internallyManaged', false)
       expect(myFunction).toHaveProperty('rootPath')
       expect(myFunction).toHaveProperty('state', {
@@ -151,13 +157,16 @@ describe('Integration Test - Simple', () => {
     })
 
     it('should invoke the "function" component with CLI options', async () => {
-      await cpp.execAsync(`node ${componentsExec} invoke --data "Hello World"`, {
-        cwd: testServiceDir,
-        env: {
-          ...process.env,
-          FUNCTION_NAME
+      await cpp.execAsync(
+        `node ${componentsExec} invoke --data "Hello World"`,
+        {
+          cwd: testServiceDir,
+          env: {
+            ...process.env,
+            FUNCTION_NAME
+          }
         }
-      })
+      )
       const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(4)
@@ -182,7 +191,10 @@ describe('Integration Test - Simple', () => {
       const myFunctionObjectKeys = Object.keys(myFunction)
       expect(myFunctionObjectKeys.length).toEqual(6)
       expect(myFunction).toHaveProperty('instanceId')
-      expect(myFunction).toHaveProperty('type', 'tests-integration-function-mock')
+      expect(myFunction).toHaveProperty(
+        'type',
+        'tests-integration-function-mock'
+      )
       expect(myFunction).toHaveProperty('internallyManaged', false)
       expect(myFunction).toHaveProperty('rootPath')
       expect(myFunction).toHaveProperty('state', {
@@ -242,7 +254,10 @@ describe('Integration Test - Simple', () => {
       const myFunctionObjectKeys = Object.keys(myFunction)
       expect(myFunctionObjectKeys.length).toEqual(6)
       expect(myFunction).toHaveProperty('instanceId')
-      expect(myFunction).toHaveProperty('type', 'tests-integration-function-mock')
+      expect(myFunction).toHaveProperty(
+        'type',
+        'tests-integration-function-mock'
+      )
       expect(myFunction).toHaveProperty('internallyManaged', false)
       expect(myFunction).toHaveProperty('rootPath')
       expect(myFunction).toHaveProperty('state', {
@@ -286,7 +301,10 @@ describe('Integration Test - Simple', () => {
       const myFunction = stateFileContent['simple:myFunction']
       const myFunctionObjectKeys = Object.keys(myFunction)
       expect(myFunctionObjectKeys.length).toEqual(2)
-      expect(myFunction).toHaveProperty('type', 'tests-integration-function-mock')
+      expect(myFunction).toHaveProperty(
+        'type',
+        'tests-integration-function-mock'
+      )
       expect(myFunction).toHaveProperty('state', {})
     })
   })


### PR DESCRIPTION
## What has been implemented?

Tests keep timing out on travis. Extended the timeouts.

## Todos:

* [x] Write tests
* [x] Write / update documentation
* [x] Run Prettier
