### PR TITLE
Use Serverless Components as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Also please do join the _Components_ channel on our public [Serverless-Contrib S
     * [deploy](#deploy)
     * [info](#info)
     * [remove](#remove)
+  * [Programmatic usage](#programmatic-usage)
+    * [deploy](#deploy)
+    * [package](#package)
+    * [remove](#remove)
   * [Component Docs](#component-docs)
     * [aws-apigateway](./registry/aws-apigateway)
     * [aws-cloudfront](./registry/aws-cloudfront)
@@ -648,6 +652,70 @@ To remove your app, run
 ```sh
 components remove
 ```
+
+### Programmatic Usage
+
+Aside from using Serverless Components via the CLI you can also use the Framework programmatically.
+
+Different commands are available via an exposed API. Working with Serverless Components programmatically is as easy as:
+
+```js
+const path = require('path')
+const { pkg, deploy, remove } = require('serverless-components')
+
+const projectPath = path.join('my', 'project')
+
+async function runWorkflow() {
+  console.log('Packaging service...')
+  await pkg({ projectPath, path: projectPath })
+  console.log('Deploying service...')
+  await deploy({ projectPath })
+  console.log('Re-deploying service...')
+  await deploy({ projectPath })
+  console.log('Removing service...')
+  await remove({ projectPath })
+}
+
+runWorkflow()
+```
+
+#### deploy
+
+The `deploy` API makes it possible to deploy a service.
+
+`await deploy(options)`
+
+Options:
+
+* `projectPath` - `string` - Path to the root of the project (defaults to `cwd`)
+* `serverlessFileComponents` - `object` - Components usually coming from a `serverless.yml` file
+* `stateFileComponents` - `object` - Components usually coming from a `state.json` file
+
+#### package
+
+The `pkg` API makes it possible to package a project which creates a deployment artifact.
+
+`await pkg(options)`
+
+Options:
+
+* `projectPath` - `string` - Path to the root of the project (defaults to `cwd`)
+* `serverlessFileComponents` - `object` - Components usually coming from a `serverless.yml` file
+* `stateFileComponents` - `object` - Components usually coming from a `state.json` file
+* `path` - `string` - Path to the project where the `serverless.yml` file can be found
+* `format` - `string` - The desired file format (`zip` or `tar`)
+
+#### remove
+
+The `remove` API makes it possible to remove a deployed service.
+
+`await remove(options)`
+
+Options:
+
+* `projectPath` - `string` - Path to the root of the project (defaults to `cwd`)
+* `serverlessFileComponents` - `object` - Components usually coming from a `serverless.yml` file
+* `stateFileComponents` - `object` - Components usually coming from a `state.json` file
 
 ### Component Docs
 

--- a/README.md
+++ b/README.md
@@ -436,10 +436,13 @@ The framework supports variables from the following sources:
 The framework supports two types of environment variables:
 
 * **.env File:** Create a .env file in the root directory of your project. Add environment-specific variables on new lines in the form of NAME=VALUE. For example:
+
 ```
 SOME_ENV=foo
 ```
+
 * **CLI** Running the command like this:
+
 ```
 SOME_ENV=foo components deploy
 ```
@@ -657,7 +660,10 @@ components remove
 
 Aside from using Serverless Components via the CLI you can also use the Framework programmatically.
 
-Different commands are available via an exposed API. Working with Serverless Components programmatically is as easy as:
+Different commands are available via an exposed API.
+
+You can use an existing Serverless Components project by providing the `projectPath` option or you can define the structure
+of your `serverless.yml` file on the fly using the `serverlessFileObject` option:
 
 ```js
 const path = require('path')
@@ -665,7 +671,7 @@ const { pkg, deploy, remove } = require('serverless-components')
 
 const projectPath = path.join('my', 'project')
 
-async function runWorkflow() {
+async function withProjectPath() {
   console.log('Packaging service...')
   await pkg({ projectPath, path: projectPath })
   console.log('Deploying service...')
@@ -676,7 +682,32 @@ async function runWorkflow() {
   await remove({ projectPath })
 }
 
-runWorkflow()
+async function withServerlessFileObject() {
+  const serverlessFileObject = {
+    type: 'my-app',
+    version: '0.1.0',
+    components: {
+      myRole: {
+        type: 'tests-integration-iam-mock',
+        inputs: {
+          name: 'my-role-name',
+          service: 'my.function.service'
+        }
+      }
+    }
+  }
+
+  console.log('Deploying service...')
+  await deploy({ serverlessFileObject })
+  console.log('Re-deploying service...')
+  await deploy({ serverlessFileObject })
+  console.log('Removing service...')
+  await remove({ serverlessFileObject })
+}
+
+Promise.resolve()
+  .then(withProjectPath)
+  .then(withServerlessFileObject)
 ```
 
 #### deploy
@@ -688,8 +719,7 @@ The `deploy` API makes it possible to deploy a service.
 Options:
 
 * `projectPath` - `string` - Path to the root of the project (defaults to `cwd`)
-* `serverlessFileComponents` - `object` - Components usually coming from a `serverless.yml` file
-* `stateFileComponents` - `object` - Components usually coming from a `state.json` file
+* `serverlessFileObject` - `object` - The `serverless.yml` file representation as an object
 
 #### package
 
@@ -700,8 +730,7 @@ The `pkg` API makes it possible to package a project which creates a deployment 
 Options:
 
 * `projectPath` - `string` - Path to the root of the project (defaults to `cwd`)
-* `serverlessFileComponents` - `object` - Components usually coming from a `serverless.yml` file
-* `stateFileComponents` - `object` - Components usually coming from a `state.json` file
+* `serverlessFileObject` - `object` - The `serverless.yml` file representation as an object
 * `path` - `string` - Path to the project where the `serverless.yml` file can be found
 * `format` - `string` - The desired file format (`zip` or `tar`)
 
@@ -714,8 +743,7 @@ The `remove` API makes it possible to remove a deployed service.
 Options:
 
 * `projectPath` - `string` - Path to the root of the project (defaults to `cwd`)
-* `serverlessFileComponents` - `object` - Components usually coming from a `serverless.yml` file
-* `stateFileComponents` - `object` - Components usually coming from a `state.json` file
+* `serverlessFileObject` - `object` - The `serverless.yml` file representation as an object
 
 ### Component Docs
 

--- a/bin/components
+++ b/bin/components
@@ -8,10 +8,6 @@ const command = process.argv[2]
 const options = minimist(process.argv.slice(2))
 delete options._
 
-if (!options.projectPath) {
-  options.projectPath = process.cwd()
-}
-
 run(command, options).catch((error) => {
   console.error(error)
   process.exit(1)

--- a/bin/components
+++ b/bin/components
@@ -7,7 +7,12 @@ const { run } = require('../src/index')
 const command = process.argv[2]
 const options = minimist(process.argv.slice(2))
 delete options._
-run(process.cwd(), command, options).catch((error) => {
+
+if (!options.projectPath) {
+  options.projectPath = process.cwd()
+}
+
+run(command, options).catch((error) => {
   console.error(error)
   process.exit(1)
 })

--- a/bin/components
+++ b/bin/components
@@ -7,7 +7,7 @@ const { run } = require('../src/index')
 const command = process.argv[2]
 const options = minimist(process.argv.slice(2))
 delete options._
-run(command, options).catch((error) => {
+run(process.cwd(), command, options).catch((error) => {
   console.error(error)
   process.exit(1)
 })

--- a/registry/aws-lambda/index.js
+++ b/registry/aws-lambda/index.js
@@ -5,9 +5,11 @@ const lambda = new AWS.Lambda({ region: 'us-east-1' })
 
 async function createLambda(
   { name, handler, memory, timeout, runtime, env, description, root },
+  { projectPath },
   role
 ) {
-  const pkg = await pack(root)
+  const path = root || projectPath
+  const pkg = await pack(path)
 
   const params = {
     FunctionName: name,
@@ -35,9 +37,11 @@ async function createLambda(
 
 async function updateLambda(
   { name, handler, memory, timeout, runtime, env, description, root },
+  { projectPath },
   role
 ) {
-  const pkg = await pack(root)
+  const path = root || projectPath
+  const pkg = await pack(path)
   const functionCodeParams = {
     FunctionName: name,
     ZipFile: pkg,
@@ -95,7 +99,7 @@ async function deploy(inputs, context) {
 
   if (inputs.name && !context.state.name) {
     context.log(`Creating Lambda: ${inputs.name}`)
-    outputs = await createLambda(inputs, role)
+    outputs = await createLambda(inputs, context, role)
   } else if (context.state.name && !inputs.name) {
     context.log(`Removing Lambda: ${context.state.name}`)
     outputs = await deleteLambda(context.state.name)
@@ -103,10 +107,10 @@ async function deploy(inputs, context) {
     context.log(`Removing Lambda: ${context.state.name}`)
     await deleteLambda(context.state.name)
     context.log(`Creating Lambda: ${inputs.name}`)
-    outputs = await createLambda(inputs, role)
+    outputs = await createLambda(inputs, context, role)
   } else {
     context.log(`Updating Lambda: ${inputs.name}`)
-    outputs = await updateLambda(inputs, role)
+    outputs = await updateLambda(inputs, context, role)
   }
 
   if (configuredRole && defaultRole) {

--- a/registry/aws-lambda/pack.js
+++ b/registry/aws-lambda/pack.js
@@ -10,7 +10,6 @@ const fsp = BbPromise.promisifyAll(fs)
 module.exports = async (packagePath, tempPath) => {
   // Set defaults
   tempPath = tempPath || os.tmpdir()
-  packagePath = packagePath || process.cwd()
 
   /*
   * Ensure id includes datetime and unique string,

--- a/registry/mustache/index.js
+++ b/registry/mustache/index.js
@@ -4,9 +4,9 @@ const path = require('path')
 const mustache = require('mustache')
 const recursive = require('recursive-readdir')
 
-const deploy = async (inputs) => {
+const deploy = async (inputs, context) => {
   const values = inputs.values || {}
-  const sourcePath = inputs.sourcePath || process.cwd()
+  const sourcePath = inputs.sourcePath || context.projectPath
 
   const tmpDir = tmp.dirSync()
   const tmpPath = tmpDir.name

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -1,0 +1,7 @@
+const run = require('../run')
+
+async function deploy(options) {
+  return run('deploy', options)
+}
+
+module.exports = deploy

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,0 +1,9 @@
+const pkg = require('./pkg')
+const deploy = require('./deploy')
+const remove = require('./remove')
+
+module.exports = {
+  pkg,
+  deploy,
+  remove
+}

--- a/src/commands/pkg.js
+++ b/src/commands/pkg.js
@@ -1,0 +1,7 @@
+const run = require('../run')
+
+async function pkg(options) {
+  return run('package', options)
+}
+
+module.exports = pkg

--- a/src/commands/remove.js
+++ b/src/commands/remove.js
@@ -1,0 +1,7 @@
+const run = require('../run')
+
+async function remove(options) {
+  return run('remove', options)
+}
+
+module.exports = remove

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const run = require('./run')
-const utils = require('./utils')
+const commands = require('./commands')
 
 module.exports = {
-  ...utils,
-  run
+  run,
+  ...commands
 }

--- a/src/run.js
+++ b/src/run.js
@@ -19,7 +19,7 @@ const {
   // log
 } = utils
 
-const run = async (command, options) => {
+const run = async (projectDirPath, command, options) => {
   if (command === 'package') {
     return packageComponent(options)
   }
@@ -29,13 +29,16 @@ const run = async (command, options) => {
   let stateFile = {}
   let archive = {}
   try {
-    stateFile = await readStateFile()
+    stateFile = await readStateFile(projectDirPath)
     stateFile = setServiceId(stateFile)
     // TODO BRN: If we're using immutable data, we shouldn't need to clone here
     archive = clone(stateFile)
     let componentsToUse
     let orphanedComponents
-    const serverlessFileComponents = await getComponentsFromServerlessFile(stateFile)
+    const serverlessFileComponents = await getComponentsFromServerlessFile(
+      stateFile,
+      projectDirPath
+    )
     const stateFileComponents = getComponentsFromStateFile(stateFile)
     if (command === 'remove') {
       componentsToUse = stateFileComponents
@@ -78,7 +81,7 @@ const run = async (command, options) => {
 
     throw error
   } finally {
-    await writeStateFile(stateFile)
+    await writeStateFile(projectDirPath, stateFile)
   }
   return components
 }

--- a/src/run.js
+++ b/src/run.js
@@ -1,4 +1,4 @@
-const { clone } = require('ramda')
+const { clone, isNil, isEmpty } = require('ramda')
 
 const utils = require('./utils')
 
@@ -36,8 +36,14 @@ const run = async (command, options) => {
     archive = clone(stateFile)
     let componentsToUse
     let orphanedComponents
-    const serverlessFileComponents = await getComponentsFromServerlessFile(stateFile, projectPath)
-    const stateFileComponents = getComponentsFromStateFile(stateFile)
+    let serverlessFileComponents = options.serverlessFileComponents
+    let stateFileComponents = options.stateFileComponents
+    if (isNil(serverlessFileComponents) || isEmpty(serverlessFileComponents)) {
+      serverlessFileComponents = await getComponentsFromServerlessFile(stateFile, projectPath)
+    }
+    if (isNil(stateFileComponents) || isEmpty(stateFileComponents)) {
+      stateFileComponents = getComponentsFromStateFile(stateFile)
+    }
     if (command === 'remove') {
       componentsToUse = stateFileComponents
       orphanedComponents = {}

--- a/src/run.js
+++ b/src/run.js
@@ -21,9 +21,7 @@ const {
 
 const run = async (command, options) => {
   options.projectPath = options.projectPath || process.cwd()
-  const projectPath = options.projectPath
-  let serverlessFileComponents = options.serverlessFileComponents
-  let stateFileComponents = options.stateFileComponents
+  const { projectPath, serverlessFileObject } = options
   if (command === 'package') {
     return packageComponent(options)
   }
@@ -39,12 +37,17 @@ const run = async (command, options) => {
     archive = clone(stateFile)
     let componentsToUse
     let orphanedComponents
-    if (isNil(serverlessFileComponents) || isEmpty(serverlessFileComponents)) {
+    let serverlessFileComponents
+    if (!isNil(serverlessFileObject) && !isEmpty(serverlessFileObject)) {
+      serverlessFileComponents = await getComponentsFromServerlessFile(
+        stateFile,
+        projectPath,
+        serverlessFileObject
+      )
+    } else {
       serverlessFileComponents = await getComponentsFromServerlessFile(stateFile, projectPath)
     }
-    if (isNil(stateFileComponents) || isEmpty(stateFileComponents)) {
-      stateFileComponents = getComponentsFromStateFile(stateFile)
-    }
+    const stateFileComponents = getComponentsFromStateFile(stateFile)
     if (command === 'remove') {
       componentsToUse = stateFileComponents
       orphanedComponents = {}

--- a/src/run.js
+++ b/src/run.js
@@ -19,7 +19,8 @@ const {
   // log
 } = utils
 
-const run = async (projectDirPath, command, options) => {
+const run = async (command, options) => {
+  const { projectPath } = options
   if (command === 'package') {
     return packageComponent(options)
   }
@@ -29,16 +30,13 @@ const run = async (projectDirPath, command, options) => {
   let stateFile = {}
   let archive = {}
   try {
-    stateFile = await readStateFile(projectDirPath)
+    stateFile = await readStateFile(projectPath)
     stateFile = setServiceId(stateFile)
     // TODO BRN: If we're using immutable data, we shouldn't need to clone here
     archive = clone(stateFile)
     let componentsToUse
     let orphanedComponents
-    const serverlessFileComponents = await getComponentsFromServerlessFile(
-      stateFile,
-      projectDirPath
-    )
+    const serverlessFileComponents = await getComponentsFromServerlessFile(stateFile, projectPath)
     const stateFileComponents = getComponentsFromStateFile(stateFile)
     if (command === 'remove') {
       componentsToUse = stateFileComponents
@@ -81,7 +79,7 @@ const run = async (projectDirPath, command, options) => {
 
     throw error
   } finally {
-    await writeStateFile(projectDirPath, stateFile)
+    await writeStateFile(projectPath, stateFile)
   }
   return components
 }

--- a/src/run.js
+++ b/src/run.js
@@ -20,7 +20,10 @@ const {
 } = utils
 
 const run = async (command, options) => {
-  const { projectPath } = options
+  options.projectPath = options.projectPath || process.cwd()
+  const projectPath = options.projectPath
+  let serverlessFileComponents = options.serverlessFileComponents
+  let stateFileComponents = options.stateFileComponents
   if (command === 'package') {
     return packageComponent(options)
   }
@@ -36,8 +39,6 @@ const run = async (command, options) => {
     archive = clone(stateFile)
     let componentsToUse
     let orphanedComponents
-    let serverlessFileComponents = options.serverlessFileComponents
-    let stateFileComponents = options.stateFileComponents
     if (isNil(serverlessFileComponents) || isEmpty(serverlessFileComponents)) {
       serverlessFileComponents = await getComponentsFromServerlessFile(stateFile, projectPath)
     }

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -3,6 +3,8 @@ const utils = require('./utils')
 
 jest.mock('./utils')
 
+const projectDirPath = process.cwd()
+
 afterAll(() => {
   jest.restoreAllMocks()
 })
@@ -36,7 +38,7 @@ beforeEach(() => {
 
 describe('#run()', () => {
   it('should run the command on the graph', async () => {
-    const res = await run('some-command', {})
+    const res = await run(projectDirPath, 'some-command', {})
     expect(res).toEqual({
       iamMock: {
         id: 'iam-mock-id',
@@ -64,7 +66,7 @@ describe('#run()', () => {
   it('should report any errors to Sentry while still writing the state to disk', async () => {
     utils.executeGraph.mockImplementation(() => Promise.reject(new Error('something went wrong')))
 
-    await expect(run('some-command', {})).rejects.toThrow('something went wrong')
+    await expect(run(projectDirPath, 'some-command', {})).rejects.toThrow('something went wrong')
 
     expect(utils.handleSignalEvents).toHaveBeenCalled()
     expect(utils.getComponentsFromServerlessFile).toHaveBeenCalled()
@@ -81,7 +83,7 @@ describe('#run()', () => {
 
   describe('when running "deploy"', () => {
     it('should run "deploy", "info", track the deployment and write the state to disk', async () => {
-      const res = await run('deploy', {})
+      const res = await run(projectDirPath, 'deploy', {})
       expect(res).toEqual({
         iamMock: {
           id: 'iam-mock-id',
@@ -109,7 +111,7 @@ describe('#run()', () => {
 
   describe('when running "remove"', () => {
     it('should run "remove" but should not run "info" neither track the deployment', async () => {
-      const res = await run('remove', {})
+      const res = await run(projectDirPath, 'remove', {})
       expect(res).toEqual({
         iamMock: {
           id: 'iam-mock-id',

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -3,7 +3,7 @@ const utils = require('./utils')
 
 jest.mock('./utils')
 
-const projectDirPath = process.cwd()
+const projectPath = process.cwd()
 
 afterAll(() => {
   jest.restoreAllMocks()
@@ -38,7 +38,7 @@ beforeEach(() => {
 
 describe('#run()', () => {
   it('should run the command on the graph', async () => {
-    const res = await run(projectDirPath, 'some-command', {})
+    const res = await run('some-command', { projectPath })
     expect(res).toEqual({
       iamMock: {
         id: 'iam-mock-id',
@@ -66,7 +66,7 @@ describe('#run()', () => {
   it('should report any errors to Sentry while still writing the state to disk', async () => {
     utils.executeGraph.mockImplementation(() => Promise.reject(new Error('something went wrong')))
 
-    await expect(run(projectDirPath, 'some-command', {})).rejects.toThrow('something went wrong')
+    await expect(run('some-command', { projectPath })).rejects.toThrow('something went wrong')
 
     expect(utils.handleSignalEvents).toHaveBeenCalled()
     expect(utils.getComponentsFromServerlessFile).toHaveBeenCalled()
@@ -83,7 +83,7 @@ describe('#run()', () => {
 
   describe('when running "deploy"', () => {
     it('should run "deploy", "info", track the deployment and write the state to disk', async () => {
-      const res = await run(projectDirPath, 'deploy', {})
+      const res = await run('deploy', { projectPath })
       expect(res).toEqual({
         iamMock: {
           id: 'iam-mock-id',
@@ -111,7 +111,7 @@ describe('#run()', () => {
 
   describe('when running "remove"', () => {
     it('should run "remove" but should not run "info" neither track the deployment', async () => {
-      const res = await run(projectDirPath, 'remove', {})
+      const res = await run('remove', { projectPath })
       expect(res).toEqual({
         iamMock: {
           id: 'iam-mock-id',

--- a/src/run.test.js
+++ b/src/run.test.js
@@ -49,7 +49,8 @@ describe('#run()', () => {
     })
 
     expect(utils.handleSignalEvents).toHaveBeenCalled()
-    expect(utils.getComponentsFromServerlessFile).toHaveBeenCalled()
+    expect(utils.getComponentsFromServerlessFile.mock.calls[0][1]).toEqual(projectPath)
+    expect(utils.getComponentsFromServerlessFile.mock.calls[0][2]).toBeFalsy() // no serverlessFileObject
     expect(utils.getComponentsFromStateFile).toHaveBeenCalled()
     expect(utils.getOrphanedComponents).toHaveBeenCalled()
     expect(utils.trackDeployment).not.toHaveBeenCalled()
@@ -67,7 +68,8 @@ describe('#run()', () => {
     await expect(run('some-command', { projectPath })).rejects.toThrow('something went wrong')
 
     expect(utils.handleSignalEvents).toHaveBeenCalled()
-    expect(utils.getComponentsFromServerlessFile).toHaveBeenCalled()
+    expect(utils.getComponentsFromServerlessFile.mock.calls[0][1]).toEqual(projectPath)
+    expect(utils.getComponentsFromServerlessFile.mock.calls[0][2]).toBeFalsy() // no serverlessFileObject
     expect(utils.getComponentsFromStateFile).toHaveBeenCalled()
     expect(utils.getOrphanedComponents).toHaveBeenCalled()
     expect(utils.trackDeployment).not.toHaveBeenCalled()
@@ -79,11 +81,17 @@ describe('#run()', () => {
     expect(utils.errorReporter).toHaveBeenCalled()
   })
 
-  it('should prefer components passed in via options', async () => {
+  it('should support serverless.yml file object passed in via options', async () => {
+    const serverlessFileObject = {
+      type: 'my-app',
+      version: '0.1.0',
+      components: {
+        iamMock: { id: 'iam-mock-id', type: 'iam-mock' }
+      }
+    }
     const res = await run('some-commands', {
       projectPath,
-      serverlessFileComponents,
-      stateFileComponents
+      serverlessFileObject
     })
     expect(res).toEqual({
       iamMock: {
@@ -93,8 +101,11 @@ describe('#run()', () => {
     })
 
     expect(utils.handleSignalEvents).toHaveBeenCalled()
-    expect(utils.getComponentsFromServerlessFile).not.toHaveBeenCalled()
-    expect(utils.getComponentsFromStateFile).not.toHaveBeenCalled()
+    // NOTE: we don't check for the first argument (which is the state object) since the empty
+    // state object is created on the fly and differs from the one we'd check against here
+    expect(utils.getComponentsFromServerlessFile.mock.calls[0][1]).toEqual(projectPath)
+    expect(utils.getComponentsFromServerlessFile.mock.calls[0][2]).toEqual(serverlessFileObject)
+    expect(utils.getComponentsFromStateFile).toHaveBeenCalled()
     expect(utils.getOrphanedComponents).toHaveBeenCalled()
     expect(utils.trackDeployment).not.toHaveBeenCalled()
     expect(utils.buildGraph).toHaveBeenCalledTimes(1)
@@ -116,7 +127,8 @@ describe('#run()', () => {
       })
 
       expect(utils.handleSignalEvents).toHaveBeenCalled()
-      expect(utils.getComponentsFromServerlessFile).toHaveBeenCalled()
+      expect(utils.getComponentsFromServerlessFile.mock.calls[0][1]).toEqual(projectPath)
+      expect(utils.getComponentsFromServerlessFile.mock.calls[0][2]).toBeFalsy() // no serverlessFileObject
       expect(utils.getComponentsFromStateFile).toHaveBeenCalled()
       expect(utils.getOrphanedComponents).toHaveBeenCalled()
       expect(utils.trackDeployment).toHaveBeenCalled()
@@ -144,7 +156,8 @@ describe('#run()', () => {
       })
 
       expect(utils.handleSignalEvents).toHaveBeenCalled()
-      expect(utils.getComponentsFromServerlessFile).toHaveBeenCalled()
+      expect(utils.getComponentsFromServerlessFile.mock.calls[0][1]).toEqual(projectPath)
+      expect(utils.getComponentsFromServerlessFile.mock.calls[0][2]).toBeFalsy() // no serverlessFileObject
       expect(utils.getComponentsFromStateFile).toHaveBeenCalled()
       expect(utils.getOrphanedComponents).not.toHaveBeenCalled()
       expect(utils.trackDeployment).not.toHaveBeenCalled()

--- a/src/utils/components/generateContext.js
+++ b/src/utils/components/generateContext.js
@@ -19,6 +19,7 @@ const generateContext = (
   internallyManaged = false
 ) => {
   const { id, type, rootPath } = component
+  const { projectPath } = options
   const serviceId = getServiceId(stateFile)
   const instanceId = getInstanceId(stateFile, id)
   const inputs = prop('inputs', component)
@@ -31,6 +32,7 @@ const generateContext = (
     state: getState(stateFile, id),
     children: getChildrenPromises(component, components),
     rootPath,
+    projectPath,
     command,
     options,
     log,

--- a/src/utils/components/getComponent.js
+++ b/src/utils/components/getComponent.js
@@ -10,8 +10,10 @@ const setInputDefaults = require('./setInputDefaults')
 const validateCoreVersion = require('./validateCoreVersion')
 const validateTypes = require('./validateTypes')
 
-module.exports = async (componentRoot, componentId, inputs, stateFile) => {
-  let slsYml = await readFile(path.join(componentRoot, 'serverless.yml'))
+module.exports = async (componentRoot, componentId, inputs, stateFile, slsYml = null) => {
+  if (!slsYml) {
+    slsYml = await readFile(path.join(componentRoot, 'serverless.yml'))
+  }
 
   validateVarsUsage(slsYml)
   validateCoreVersion(slsYml.type, slsYml.core)

--- a/src/utils/components/getComponent.test.js
+++ b/src/utils/components/getComponent.test.js
@@ -154,4 +154,47 @@ describe('#getComponent()', () => {
       )
     ).rejects.toThrow('core is incompatible with component my-project')
   })
+
+  it('Test passed-in serverless.yml component object', async () => {
+    const myComponent = {
+      type: 'my-component',
+      version: '0.1.0',
+      inputTypes: {
+        foo: {
+          type: 'string',
+          required: true
+        },
+        bar: {
+          type: 'string',
+          required: false
+        }
+      }
+    }
+
+    const instance = await getComponent(
+      process.cwd(),
+      'test',
+      {
+        foo: 'bar',
+        baz: 'qux'
+      },
+      {
+        $: { serviceId: 'AsH3gefdfDSY' },
+        'my-component': {
+          type: 'my-component',
+          internallyManaged: false,
+          instanceId: 'AsH3gefdfDSY-cHA9jPi5lPQj',
+          state: {}
+        }
+      },
+      myComponent
+    )
+
+    expect(instance.type).toEqual('my-component')
+    expect(instance.version).toEqual('0.1.0')
+    expect(instance.inputs).toEqual({
+      foo: 'bar',
+      baz: 'qux'
+    })
+  })
 })

--- a/src/utils/components/getComponentRootPath.js
+++ b/src/utils/components/getComponentRootPath.js
@@ -11,9 +11,7 @@ const semVerDefinition =
 const registryRegex = new RegExp(`^${typeRegexDefinition}@${semVerDefinition}$`)
 
 async function getComponentRootPath(type = null) {
-  if (isNil(type)) {
-    return process.cwd()
-  } else if (urlRegex({ exact: true }).test(type)) {
+  if (urlRegex({ exact: true }).test(type)) {
     return getComponentFromUrl(type)
   } else if (type.match(registryRegex)) {
     const url = `${getComponentsBucketRoot()}/${type}.zip`

--- a/src/utils/components/getComponentRootPath.js
+++ b/src/utils/components/getComponentRootPath.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const { isNil } = require('ramda')
 const urlRegex = require('url-regex')
 const getComponentFromUrl = require('./getComponentFromUrl')
 const getComponentsBucketRoot = require('./getComponentsBucketRoot')

--- a/src/utils/components/getComponentRootPath.test.js
+++ b/src/utils/components/getComponentRootPath.test.js
@@ -17,24 +17,4 @@ describe('#getComponentRootPath()', () => {
     const expected = path.resolve(type)
     expect(res).toEqual(expected)
   })
-
-  describe('when no component "type" propert parameter is provided', () => {
-    let oldCwd
-    let tmpDirPath
-
-    beforeEach(async () => {
-      oldCwd = process.cwd()
-      process.chdir(await getTmpDir())
-      tmpDirPath = process.cwd()
-    })
-
-    afterEach(() => {
-      process.chdir(oldCwd)
-    })
-
-    it('should default to the cwd if no parameter is provided', async () => {
-      const res = await getComponentRootPath()
-      expect(res).toEqual(tmpDirPath)
-    })
-  })
 })

--- a/src/utils/components/getComponentRootPath.test.js
+++ b/src/utils/components/getComponentRootPath.test.js
@@ -1,4 +1,3 @@
-const { getTmpDir } = require('@serverless/utils')
 const path = require('path')
 const getRegistryRoot = require('../registry/getRegistryRoot')
 const getComponentRootPath = require('./getComponentRootPath')

--- a/src/utils/components/getComponentsFromServerlessFile.js
+++ b/src/utils/components/getComponentsFromServerlessFile.js
@@ -9,7 +9,7 @@ const getState = require('../state/getState')
 
 const getComponentsFromServerlessFile = async (
   stateFile,
-  componentRoot = process.cwd(),
+  componentRoot,
   inputs = {},
   componentId
 ) => {

--- a/src/utils/components/getComponentsFromServerlessFile.js
+++ b/src/utils/components/getComponentsFromServerlessFile.js
@@ -10,10 +10,11 @@ const getState = require('../state/getState')
 const getComponentsFromServerlessFile = async (
   stateFile,
   componentRoot,
+  slsYml = null,
   inputs = {},
   componentId
 ) => {
-  const component = await getComponent(componentRoot, componentId, inputs, stateFile)
+  const component = await getComponent(componentRoot, componentId, inputs, stateFile, slsYml)
 
   const nestedComponents = mergeAll(
     await Promise.all(
@@ -26,6 +27,7 @@ const getComponentsFromServerlessFile = async (
         return getComponentsFromServerlessFile(
           stateFile,
           nestedComponentRoot,
+          null,
           nestedComponentInputs,
           nestedComponentId
         )

--- a/src/utils/components/packageComponent.js
+++ b/src/utils/components/packageComponent.js
@@ -6,7 +6,7 @@ const validateCoreVersion = require('./validateCoreVersion')
 
 module.exports = async (options) => {
   const format = options.format || 'zip'
-  let componentPath = options.path || process.cwd()
+  let componentPath = options.path || options.projectPath
   if (!path.isAbsolute(componentPath)) {
     componentPath = path.resolve(process.cwd(), componentPath)
   }

--- a/src/utils/components/packageComponent.js
+++ b/src/utils/components/packageComponent.js
@@ -1,4 +1,5 @@
 const { fileExists, packDir, readFile } = require('@serverless/utils')
+const { isNil, isEmpty } = require('ramda')
 const path = require('path')
 const semver = require('semver')
 const log = require('../logging/log')
@@ -7,15 +8,22 @@ const validateCoreVersion = require('./validateCoreVersion')
 module.exports = async (options) => {
   const format = options.format || 'zip'
   let componentPath = options.path || options.projectPath
+  const { serverlessFileObject } = options
+
   if (!path.isAbsolute(componentPath)) {
     componentPath = path.resolve(process.cwd(), componentPath)
   }
-  const slsYmlFilePath = path.join(componentPath, 'serverless.yml')
-  if (!(await fileExists(slsYmlFilePath))) {
-    throw new Error(`Could not find a serverless.yml file in ${componentPath}`)
-  }
 
-  const slsYml = await readFile(slsYmlFilePath)
+  let slsYml
+  if (!isNil(serverlessFileObject) && !isEmpty(serverlessFileObject)) {
+    slsYml = serverlessFileObject
+  } else {
+    const slsYmlFilePath = path.join(componentPath, 'serverless.yml')
+    if (!(await fileExists(slsYmlFilePath))) {
+      throw new Error(`Could not find a serverless.yml file in ${componentPath}`)
+    }
+    slsYml = await readFile(slsYmlFilePath)
+  }
 
   validateCoreVersion(slsYml.type, slsYml.core)
 

--- a/src/utils/components/packageComponent.test.js
+++ b/src/utils/components/packageComponent.test.js
@@ -19,6 +19,7 @@ describe('#packageComponent', () => {
     utils.readFile.mockReturnValue(Promise.resolve({ type: 'my-project', version: '0.0.1' }))
 
     const options = {
+      projectPath: process.cwd(),
       path: './some-path',
       format: 'zip'
     }
@@ -38,6 +39,7 @@ describe('#packageComponent', () => {
     utils.readFile.mockReturnValue(Promise.resolve({ type: 'my-project', version: '0.0.1' }))
 
     const options = {
+      projectPath: process.cwd(),
       path: '/home/some-path',
       format: 'zip'
     }
@@ -57,6 +59,7 @@ describe('#packageComponent', () => {
 
     const componentPath = '/home/some-path'
     const options = {
+      projectPath: process.cwd(),
       path: componentPath,
       format: 'zip'
     }

--- a/src/utils/components/packageComponent.test.js
+++ b/src/utils/components/packageComponent.test.js
@@ -8,13 +8,42 @@ jest.mock('@serverless/utils', () => ({
   readFile: jest.fn()
 }))
 
-afterEach(() => {
+afterAll(() => {
   jest.restoreAllMocks()
 })
 
-describe('#packageComponent', () => {
-  it('should package component at given realtive path', async () => {
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('#packageComponent()', () => {
+  beforeEach(() => {
     utils.packDir.mockImplementation(() => Promise.resolve())
+  })
+
+  it('should package a component based on a serverlessFileObject', async () => {
+    const options = {
+      projectPath: process.cwd(),
+      path: './some-path',
+      format: 'zip',
+      serverlessFileObject: {
+        type: 'my-project',
+        version: '0.0.1',
+        components: {
+          iamMock: { id: 'iam-mock-id', type: 'iam-mock' }
+        }
+      }
+    }
+
+    await packageComponent(options)
+    const componentPath = path.join(process.cwd(), 'some-path')
+    const outputFilePath = path.resolve(componentPath, 'my-project@0.0.1.zip')
+    expect(utils.packDir).toBeCalledWith(componentPath, outputFilePath)
+    expect(utils.fileExists).not.toBeCalled()
+    expect(utils.readFile).not.toBeCalled()
+  })
+
+  it('should package component at given relative path', async () => {
     utils.fileExists.mockReturnValue(Promise.resolve(true))
     utils.readFile.mockReturnValue(Promise.resolve({ type: 'my-project', version: '0.0.1' }))
 
@@ -34,7 +63,6 @@ describe('#packageComponent', () => {
   })
 
   it('should package component at given absolute path', async () => {
-    utils.packDir.mockImplementation(() => Promise.resolve())
     utils.fileExists.mockReturnValue(Promise.resolve(true))
     utils.readFile.mockReturnValue(Promise.resolve({ type: 'my-project', version: '0.0.1' }))
 
@@ -54,7 +82,6 @@ describe('#packageComponent', () => {
   })
 
   it('validate package path', async () => {
-    utils.packDir.mockImplementation(() => Promise.resolve())
     utils.fileExists.mockReturnValue(Promise.resolve(false))
 
     const componentPath = '/home/some-path'

--- a/src/utils/state/readStateFile.js
+++ b/src/utils/state/readStateFile.js
@@ -1,8 +1,8 @@
 const path = require('path')
 const { fileExists, readFile } = require('@serverless/utils')
 
-module.exports = async (projectDirPath) => {
-  const stateFilePath = path.join(projectDirPath, 'state.json')
+module.exports = async (projectPath) => {
+  const stateFilePath = path.join(projectPath, 'state.json')
   if (!(await fileExists(stateFilePath))) {
     return {}
   }

--- a/src/utils/state/readStateFile.js
+++ b/src/utils/state/readStateFile.js
@@ -1,9 +1,8 @@
 const path = require('path')
 const { fileExists, readFile } = require('@serverless/utils')
 
-module.exports = async () => {
-  const stateFilePath = path.join(process.cwd(), 'state.json')
-
+module.exports = async (projectDirPath) => {
+  const stateFilePath = path.join(projectDirPath, 'state.json')
   if (!(await fileExists(stateFilePath))) {
     return {}
   }

--- a/src/utils/state/readStateFile.test.js
+++ b/src/utils/state/readStateFile.test.js
@@ -6,7 +6,7 @@ describe('#readStateFile()', () => {
   let oldCwd
   let tmpDirPath
   let stateFilePath
-  let projectDirPath
+  let projectPath
 
   const fileContent = {
     $: { serviceId: 'AsH3gefdfDSY' },
@@ -33,7 +33,7 @@ describe('#readStateFile()', () => {
     tmpDirPath = await getTmpDir()
     stateFilePath = path.join(tmpDirPath, 'state.json')
     await writeFile(stateFilePath, fileContent)
-    projectDirPath = tmpDirPath
+    projectPath = tmpDirPath
     oldCwd = process.cwd()
     process.chdir(tmpDirPath)
   })
@@ -43,13 +43,13 @@ describe('#readStateFile()', () => {
   })
 
   it('should read the projects state file if present', async () => {
-    const res = await readStateFile(projectDirPath)
+    const res = await readStateFile(projectPath)
     expect(res).toEqual(fileContent)
   })
 
   it('should return an empty object if the project does not contain a state file', async () => {
-    projectDirPath = await getTmpDir()
-    const res = await readStateFile(projectDirPath)
+    projectPath = await getTmpDir()
+    const res = await readStateFile(projectPath)
     expect(res).toEqual({})
   })
 })

--- a/src/utils/state/readStateFile.test.js
+++ b/src/utils/state/readStateFile.test.js
@@ -1,9 +1,8 @@
-const { getTmpDir } = require('@serverless/utils')
-const { readJson } = require('fs-extra')
+const { getTmpDir, writeFile } = require('@serverless/utils')
 const path = require('path')
-const writeStateFile = require('./writeStateFile')
+const readStateFile = require('./readStateFile')
 
-describe('#writeStateFile()', () => {
+describe('#readStateFile()', () => {
   let oldCwd
   let tmpDirPath
   let stateFilePath
@@ -33,6 +32,7 @@ describe('#writeStateFile()', () => {
   beforeEach(async () => {
     tmpDirPath = await getTmpDir()
     stateFilePath = path.join(tmpDirPath, 'state.json')
+    await writeFile(stateFilePath, fileContent)
     projectDirPath = tmpDirPath
     oldCwd = process.cwd()
     process.chdir(tmpDirPath)
@@ -42,9 +42,14 @@ describe('#writeStateFile()', () => {
     process.chdir(oldCwd)
   })
 
-  it('should write the content to disk', async () => {
-    await writeStateFile(projectDirPath, fileContent)
-    const stateFileContent = await readJson(stateFilePath)
-    expect(stateFileContent).toEqual(fileContent)
+  it('should read the projects state file if present', async () => {
+    const res = await readStateFile(projectDirPath)
+    expect(res).toEqual(fileContent)
+  })
+
+  it('should return an empty object if the project does not contain a state file', async () => {
+    projectDirPath = await getTmpDir()
+    const res = await readStateFile(projectDirPath)
+    expect(res).toEqual({})
   })
 })

--- a/src/utils/state/writeStateFile.js
+++ b/src/utils/state/writeStateFile.js
@@ -1,7 +1,7 @@
 const { writeFile } = require('@serverless/utils')
 const path = require('path')
 
-module.exports = async (content) => {
-  const stateFilePath = path.join(process.cwd(), 'state.json')
+module.exports = async (projectDirPath, content) => {
+  const stateFilePath = path.join(projectDirPath, 'state.json')
   return writeFile(stateFilePath, content)
 }

--- a/src/utils/state/writeStateFile.js
+++ b/src/utils/state/writeStateFile.js
@@ -1,7 +1,7 @@
 const { writeFile } = require('@serverless/utils')
 const path = require('path')
 
-module.exports = async (projectDirPath, content) => {
-  const stateFilePath = path.join(projectDirPath, 'state.json')
+module.exports = async (projectPath, content) => {
+  const stateFilePath = path.join(projectPath, 'state.json')
   return writeFile(stateFilePath, content)
 }

--- a/src/utils/state/writeStateFile.test.js
+++ b/src/utils/state/writeStateFile.test.js
@@ -7,7 +7,7 @@ describe('#writeStateFile()', () => {
   let oldCwd
   let tmpDirPath
   let stateFilePath
-  let projectDirPath
+  let projectPath
 
   const fileContent = {
     $: { serviceId: 'AsH3gefdfDSY' },
@@ -33,7 +33,7 @@ describe('#writeStateFile()', () => {
   beforeEach(async () => {
     tmpDirPath = await getTmpDir()
     stateFilePath = path.join(tmpDirPath, 'state.json')
-    projectDirPath = tmpDirPath
+    projectPath = tmpDirPath
     oldCwd = process.cwd()
     process.chdir(tmpDirPath)
   })
@@ -43,7 +43,7 @@ describe('#writeStateFile()', () => {
   })
 
   it('should write the content to disk', async () => {
-    await writeStateFile(projectDirPath, fileContent)
+    await writeStateFile(projectPath, fileContent)
     const stateFileContent = await readJson(stateFilePath)
     expect(stateFileContent).toEqual(fileContent)
   })

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,12 @@
+const fse = require('fs-extra')
+const BbPromise = require('bluebird')
+
+const fsp = BbPromise.promisifyAll(fse)
+
+async function removeFiles(files) {
+  return BbPromise.map(files, (file) => fsp.removeAsync(file))
+}
+
+module.exports = {
+  removeFiles
+}

--- a/tests/integration/await-child-components.test.js
+++ b/tests/integration/await-child-components.test.js
@@ -2,21 +2,11 @@ const path = require('path')
 const fse = require('fs-extra')
 const cp = require('child_process')
 const BbPromise = require('bluebird')
+const { fileExists } = require('@serverless/utils')
+const { removeFiles } = require('../helpers')
 
 const fsp = BbPromise.promisifyAll(fse)
 const cpp = BbPromise.promisifyAll(cp)
-
-// test helper methods
-async function hasFile(filePath) {
-  return fsp
-    .statAsync(filePath)
-    .then(() => true)
-    .catch(() => false)
-}
-
-async function removeStateFiles(stateFiles) {
-  return BbPromise.map(stateFiles, (stateFile) => fsp.removeAsync(stateFile))
-}
 
 describe('Integration Test - Await child components', () => {
   jest.setTimeout(40000)
@@ -27,16 +17,16 @@ describe('Integration Test - Await child components', () => {
   const testServiceStateFile = path.join(testServiceDir, 'state.json')
 
   beforeAll(async () => {
-    await removeStateFiles([testServiceStateFile])
+    await removeFiles([testServiceStateFile])
   })
 
   afterAll(async () => {
-    await removeStateFiles([testServiceStateFile])
+    await removeFiles([testServiceStateFile])
   })
 
   describe('our test setup', () => {
     it('should not have any state files', async () => {
-      const testServiceHasStateFile = await hasFile(testServiceStateFile)
+      const testServiceHasStateFile = await fileExists(testServiceStateFile)
 
       expect(testServiceHasStateFile).toEqual(false)
     })

--- a/tests/integration/await-child-components/serverless.yml
+++ b/tests/integration/await-child-components/serverless.yml
@@ -1,4 +1,5 @@
 type: await-child-components
+version: 0.0.1
 
 components:
   myFunction:

--- a/tests/integration/library-usage.test.js
+++ b/tests/integration/library-usage.test.js
@@ -4,7 +4,7 @@ const BbPromise = require('bluebird')
 const { fileExists } = require('@serverless/utils')
 const { removeFiles } = require('../helpers')
 
-const { run } = require('../../src')
+const { pkg, deploy, remove } = require('../../src')
 
 const fsp = BbPromise.promisifyAll(fse)
 
@@ -34,7 +34,7 @@ describe('Integration Test - Library Usage', () => {
 
   describe('when running through a typical component usage lifecycle', () => {
     it('should deploy the "iam" component', async () => {
-      await run('deploy', { projectPath: testServiceDir })
+      await deploy({ projectPath: testServiceDir })
       const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(3)
@@ -58,7 +58,7 @@ describe('Integration Test - Library Usage', () => {
     })
 
     it('should re-deploy the "iam" component', async () => {
-      await run('deploy', { projectPath: testServiceDir })
+      await deploy({ projectPath: testServiceDir })
       const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(3)
@@ -82,7 +82,7 @@ describe('Integration Test - Library Usage', () => {
     })
 
     it('should package the "iam" component', async () => {
-      await run('package', { path: testServiceDir, projectPath: testServiceDir })
+      await pkg({ path: testServiceDir, projectPath: testServiceDir })
       const testServiceHasZipFile = await fileExists(testServiceZipFile)
       expect(testServiceHasZipFile).toEqual(true)
       // the state should not change
@@ -109,7 +109,7 @@ describe('Integration Test - Library Usage', () => {
     })
 
     it('should remove the "iam" and "function" components', async () => {
-      await run('remove', { projectPath: testServiceDir })
+      await remove({ projectPath: testServiceDir })
       const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(3)

--- a/tests/integration/library-usage.test.js
+++ b/tests/integration/library-usage.test.js
@@ -34,7 +34,7 @@ describe('Integration Test - Library Usage', () => {
 
   describe('when running through a typical component usage lifecycle', () => {
     it('should deploy the "iam" component', async () => {
-      await run(testServiceDir, 'deploy')
+      await run('deploy', { projectPath: testServiceDir })
       const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(3)
@@ -58,7 +58,7 @@ describe('Integration Test - Library Usage', () => {
     })
 
     it('should re-deploy the "iam" component', async () => {
-      await run(testServiceDir, 'deploy')
+      await run('deploy', { projectPath: testServiceDir })
       const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(3)
@@ -82,7 +82,7 @@ describe('Integration Test - Library Usage', () => {
     })
 
     it('should package the "iam" component', async () => {
-      await run(testServiceDir, 'package', { path: testServiceDir })
+      await run('package', { path: testServiceDir, projectPath: testServiceDir })
       const testServiceHasZipFile = await fileExists(testServiceZipFile)
       expect(testServiceHasZipFile).toEqual(true)
       // the state should not change
@@ -109,7 +109,7 @@ describe('Integration Test - Library Usage', () => {
     })
 
     it('should remove the "iam" and "function" components', async () => {
-      await run(testServiceDir, 'remove')
+      await run('remove', { projectPath: testServiceDir })
       const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
       const stateFileKeys = Object.keys(stateFileContent)
       expect(stateFileKeys.length).toEqual(3)

--- a/tests/integration/library-usage.test.js
+++ b/tests/integration/library-usage.test.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const fse = require('fs-extra')
 const BbPromise = require('bluebird')
-const { fileExists } = require('@serverless/utils')
+const { fileExists, getTmpDir } = require('@serverless/utils')
 const { removeFiles } = require('../helpers')
 
 const { pkg, deploy, remove } = require('../../src')
@@ -11,10 +11,8 @@ const fsp = BbPromise.promisifyAll(fse)
 describe('Integration Test - Library Usage', () => {
   jest.setTimeout(40000)
 
-  const testDir = path.dirname(__filename)
-  const testServiceDir = path.join(testDir, 'library-usage')
-  const testServiceStateFile = path.join(testServiceDir, 'state.json')
-  const testServiceZipFile = path.join(testServiceDir, 'library-usage@0.0.1.zip')
+  let testServiceStateFile
+  let testServiceZipFile
 
   beforeAll(async () => {
     await removeFiles([testServiceStateFile, testServiceZipFile])
@@ -32,95 +30,239 @@ describe('Integration Test - Library Usage', () => {
     })
   })
 
-  describe('when running through a typical component usage lifecycle', () => {
-    it('should deploy the "iam" component', async () => {
-      await deploy({ projectPath: testServiceDir })
-      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
-      const stateFileKeys = Object.keys(stateFileContent)
-      expect(stateFileKeys.length).toEqual(3)
-      expect(stateFileContent).toHaveProperty('$.serviceId')
-      expect(stateFileContent).toHaveProperty('library-usage:myRole')
-      expect(stateFileContent.$.serviceId).not.toBeFalsy()
-      const myRole = stateFileContent['library-usage:myRole']
-      const myRoleObjectKeys = Object.keys(myRole)
-      expect(myRoleObjectKeys.length).toEqual(6)
-      expect(myRole).toHaveProperty('instanceId')
-      expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
-      expect(myRole).toHaveProperty('internallyManaged', false)
-      expect(myRole).toHaveProperty('rootPath')
-      expect(myRole).toHaveProperty('state', {
-        id: 'id:iam:role:my-role',
-        name: 'my-role',
-        service: 'my.role.service',
-        deploymentCounter: 1
-      })
-      expect(myRole.instanceId).not.toBeFalsy()
+  describe('when using a path to a project', () => {
+    const testDir = path.dirname(__filename)
+    const testServiceDir = path.join(testDir, 'library-usage')
+    testServiceStateFile = path.join(testServiceDir, 'state.json')
+    testServiceZipFile = path.join(testServiceDir, 'library-usage@0.0.1.zip')
+
+    beforeAll(async () => {
+      await removeFiles([testServiceStateFile, testServiceZipFile])
     })
 
-    it('should re-deploy the "iam" component', async () => {
-      await deploy({ projectPath: testServiceDir })
-      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
-      const stateFileKeys = Object.keys(stateFileContent)
-      expect(stateFileKeys.length).toEqual(3)
-      expect(stateFileContent).toHaveProperty('$.serviceId')
-      expect(stateFileContent).toHaveProperty('library-usage:myRole')
-      expect(stateFileContent.$.serviceId).not.toBeFalsy()
-      const myRole = stateFileContent['library-usage:myRole']
-      const myRoleObjectKeys = Object.keys(myRole)
-      expect(myRoleObjectKeys.length).toEqual(6)
-      expect(myRole).toHaveProperty('instanceId')
-      expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
-      expect(myRole).toHaveProperty('internallyManaged', false)
-      expect(myRole).toHaveProperty('rootPath')
-      expect(myRole).toHaveProperty('state', {
-        id: 'id:iam:role:my-role',
-        name: 'my-role',
-        service: 'my.role.service',
-        deploymentCounter: 2
-      })
-      expect(myRole.instanceId).not.toBeFalsy()
+    afterAll(async () => {
+      await removeFiles([testServiceStateFile, testServiceZipFile])
     })
 
-    it('should package the "iam" component', async () => {
-      await pkg({ path: testServiceDir, projectPath: testServiceDir })
-      const testServiceHasZipFile = await fileExists(testServiceZipFile)
-      expect(testServiceHasZipFile).toEqual(true)
-      // the state should not change
-      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
-      const stateFileKeys = Object.keys(stateFileContent)
-      expect(stateFileKeys.length).toEqual(3)
-      expect(stateFileContent).toHaveProperty('$.serviceId')
-      expect(stateFileContent).toHaveProperty('library-usage:myRole')
-      expect(stateFileContent.$.serviceId).not.toBeFalsy()
-      const myRole = stateFileContent['library-usage:myRole']
-      const myRoleObjectKeys = Object.keys(myRole)
-      expect(myRoleObjectKeys.length).toEqual(6)
-      expect(myRole).toHaveProperty('instanceId')
-      expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
-      expect(myRole).toHaveProperty('internallyManaged', false)
-      expect(myRole).toHaveProperty('rootPath')
-      expect(myRole).toHaveProperty('state', {
-        id: 'id:iam:role:my-role',
-        name: 'my-role',
-        service: 'my.role.service',
-        deploymentCounter: 2
+    describe('when running through a typical component usage lifecycle', () => {
+      it('should deploy the "iam" component', async () => {
+        await deploy({ projectPath: testServiceDir })
+        const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+        const stateFileKeys = Object.keys(stateFileContent)
+        expect(stateFileKeys.length).toEqual(3)
+        expect(stateFileContent).toHaveProperty('$.serviceId')
+        expect(stateFileContent).toHaveProperty('library-usage:myRole')
+        expect(stateFileContent.$.serviceId).not.toBeFalsy()
+        const myRole = stateFileContent['library-usage:myRole']
+        const myRoleObjectKeys = Object.keys(myRole)
+        expect(myRoleObjectKeys.length).toEqual(6)
+        expect(myRole).toHaveProperty('instanceId')
+        expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+        expect(myRole).toHaveProperty('internallyManaged', false)
+        expect(myRole).toHaveProperty('rootPath')
+        expect(myRole).toHaveProperty('state', {
+          id: 'id:iam:role:my-role',
+          name: 'my-role',
+          service: 'my.role.service',
+          deploymentCounter: 1
+        })
+        expect(myRole.instanceId).not.toBeFalsy()
       })
-      expect(myRole.instanceId).not.toBeFalsy()
+
+      it('should re-deploy the "iam" component', async () => {
+        await deploy({ projectPath: testServiceDir })
+        const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+        const stateFileKeys = Object.keys(stateFileContent)
+        expect(stateFileKeys.length).toEqual(3)
+        expect(stateFileContent).toHaveProperty('$.serviceId')
+        expect(stateFileContent).toHaveProperty('library-usage:myRole')
+        expect(stateFileContent.$.serviceId).not.toBeFalsy()
+        const myRole = stateFileContent['library-usage:myRole']
+        const myRoleObjectKeys = Object.keys(myRole)
+        expect(myRoleObjectKeys.length).toEqual(6)
+        expect(myRole).toHaveProperty('instanceId')
+        expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+        expect(myRole).toHaveProperty('internallyManaged', false)
+        expect(myRole).toHaveProperty('rootPath')
+        expect(myRole).toHaveProperty('state', {
+          id: 'id:iam:role:my-role',
+          name: 'my-role',
+          service: 'my.role.service',
+          deploymentCounter: 2
+        })
+        expect(myRole.instanceId).not.toBeFalsy()
+      })
+
+      it('should package the "iam" component', async () => {
+        await pkg({ path: testServiceDir, projectPath: testServiceDir })
+        const testServiceHasZipFile = await fileExists(testServiceZipFile)
+        expect(testServiceHasZipFile).toEqual(true)
+        // the state should not change
+        const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+        const stateFileKeys = Object.keys(stateFileContent)
+        expect(stateFileKeys.length).toEqual(3)
+        expect(stateFileContent).toHaveProperty('$.serviceId')
+        expect(stateFileContent).toHaveProperty('library-usage:myRole')
+        expect(stateFileContent.$.serviceId).not.toBeFalsy()
+        const myRole = stateFileContent['library-usage:myRole']
+        const myRoleObjectKeys = Object.keys(myRole)
+        expect(myRoleObjectKeys.length).toEqual(6)
+        expect(myRole).toHaveProperty('instanceId')
+        expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+        expect(myRole).toHaveProperty('internallyManaged', false)
+        expect(myRole).toHaveProperty('rootPath')
+        expect(myRole).toHaveProperty('state', {
+          id: 'id:iam:role:my-role',
+          name: 'my-role',
+          service: 'my.role.service',
+          deploymentCounter: 2
+        })
+        expect(myRole.instanceId).not.toBeFalsy()
+      })
+
+      it('should remove the "iam" and "function" components', async () => {
+        await remove({ projectPath: testServiceDir })
+        const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+        const stateFileKeys = Object.keys(stateFileContent)
+        expect(stateFileKeys.length).toEqual(3)
+        expect(stateFileContent).toHaveProperty('$.serviceId')
+        expect(stateFileContent).toHaveProperty('library-usage:myRole')
+        expect(stateFileContent.$.serviceId).not.toBeFalsy()
+        const myRole = stateFileContent['library-usage:myRole']
+        const myRoleObjectKeys = Object.keys(myRole)
+        expect(myRoleObjectKeys.length).toEqual(2)
+        expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+        expect(myRole).toHaveProperty('state', {})
+      })
+    })
+  })
+
+  describe('when using a serverless.yml file object', () => {
+    let oldCwd
+    let tmpDirPath
+    let testServiceDir
+
+    beforeAll(async () => {
+      await removeFiles([testServiceStateFile, testServiceZipFile])
+      oldCwd = process.cwd()
+      process.chdir(await getTmpDir())
+      tmpDirPath = process.cwd()
+      testServiceDir = tmpDirPath
+      testServiceStateFile = path.join(testServiceDir, 'state.json')
+      testServiceZipFile = path.join(testServiceDir, 'library-usage@0.0.1.zip')
     })
 
-    it('should remove the "iam" and "function" components', async () => {
-      await remove({ projectPath: testServiceDir })
-      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
-      const stateFileKeys = Object.keys(stateFileContent)
-      expect(stateFileKeys.length).toEqual(3)
-      expect(stateFileContent).toHaveProperty('$.serviceId')
-      expect(stateFileContent).toHaveProperty('library-usage:myRole')
-      expect(stateFileContent.$.serviceId).not.toBeFalsy()
-      const myRole = stateFileContent['library-usage:myRole']
-      const myRoleObjectKeys = Object.keys(myRole)
-      expect(myRoleObjectKeys.length).toEqual(2)
-      expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
-      expect(myRole).toHaveProperty('state', {})
+    afterAll(async () => {
+      process.chdir(oldCwd)
+      await removeFiles([testServiceStateFile, testServiceZipFile])
+    })
+
+    // NOTE: this is the JavaScript object representation of the same project we're
+    // using in the tests where we pass in the project path
+    const serverlessFileObject = {
+      type: 'library-usage',
+      version: '0.0.1',
+      components: {
+        myRole: {
+          type: 'tests-integration-iam-mock',
+          inputs: {
+            name: 'my-role',
+            service: 'my.role.service'
+          }
+        }
+      }
+    }
+
+    describe('when running through a typical component usage lifecycle', () => {
+      it('should deploy the "iam" component', async () => {
+        await deploy({ serverlessFileObject })
+        const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+        const stateFileKeys = Object.keys(stateFileContent)
+        expect(stateFileKeys.length).toEqual(3)
+        expect(stateFileContent).toHaveProperty('$.serviceId')
+        expect(stateFileContent).toHaveProperty('library-usage:myRole')
+        expect(stateFileContent.$.serviceId).not.toBeFalsy()
+        const myRole = stateFileContent['library-usage:myRole']
+        const myRoleObjectKeys = Object.keys(myRole)
+        expect(myRoleObjectKeys.length).toEqual(6)
+        expect(myRole).toHaveProperty('instanceId')
+        expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+        expect(myRole).toHaveProperty('internallyManaged', false)
+        expect(myRole).toHaveProperty('rootPath')
+        expect(myRole).toHaveProperty('state', {
+          id: 'id:iam:role:my-role',
+          name: 'my-role',
+          service: 'my.role.service',
+          deploymentCounter: 1
+        })
+        expect(myRole.instanceId).not.toBeFalsy()
+      })
+
+      it('should re-deploy the "iam" component', async () => {
+        await deploy({ serverlessFileObject })
+        const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+        const stateFileKeys = Object.keys(stateFileContent)
+        expect(stateFileKeys.length).toEqual(3)
+        expect(stateFileContent).toHaveProperty('$.serviceId')
+        expect(stateFileContent).toHaveProperty('library-usage:myRole')
+        expect(stateFileContent.$.serviceId).not.toBeFalsy()
+        const myRole = stateFileContent['library-usage:myRole']
+        const myRoleObjectKeys = Object.keys(myRole)
+        expect(myRoleObjectKeys.length).toEqual(6)
+        expect(myRole).toHaveProperty('instanceId')
+        expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+        expect(myRole).toHaveProperty('internallyManaged', false)
+        expect(myRole).toHaveProperty('rootPath')
+        expect(myRole).toHaveProperty('state', {
+          id: 'id:iam:role:my-role',
+          name: 'my-role',
+          service: 'my.role.service',
+          deploymentCounter: 2
+        })
+        expect(myRole.instanceId).not.toBeFalsy()
+      })
+
+      it('should package the "iam" component', async () => {
+        await pkg({ serverlessFileObject, path: testServiceDir })
+        const testServiceHasZipFile = await fileExists(testServiceZipFile)
+        expect(testServiceHasZipFile).toEqual(true)
+        // the state should not change
+        const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+        const stateFileKeys = Object.keys(stateFileContent)
+        expect(stateFileKeys.length).toEqual(3)
+        expect(stateFileContent).toHaveProperty('$.serviceId')
+        expect(stateFileContent).toHaveProperty('library-usage:myRole')
+        expect(stateFileContent.$.serviceId).not.toBeFalsy()
+        const myRole = stateFileContent['library-usage:myRole']
+        const myRoleObjectKeys = Object.keys(myRole)
+        expect(myRoleObjectKeys.length).toEqual(6)
+        expect(myRole).toHaveProperty('instanceId')
+        expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+        expect(myRole).toHaveProperty('internallyManaged', false)
+        expect(myRole).toHaveProperty('rootPath')
+        expect(myRole).toHaveProperty('state', {
+          id: 'id:iam:role:my-role',
+          name: 'my-role',
+          service: 'my.role.service',
+          deploymentCounter: 2
+        })
+        expect(myRole.instanceId).not.toBeFalsy()
+      })
+
+      it('should remove the "iam" and "function" components', async () => {
+        await remove({ serverlessFileObject })
+        const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+        const stateFileKeys = Object.keys(stateFileContent)
+        expect(stateFileKeys.length).toEqual(3)
+        expect(stateFileContent).toHaveProperty('$.serviceId')
+        expect(stateFileContent).toHaveProperty('library-usage:myRole')
+        expect(stateFileContent.$.serviceId).not.toBeFalsy()
+        const myRole = stateFileContent['library-usage:myRole']
+        const myRoleObjectKeys = Object.keys(myRole)
+        expect(myRoleObjectKeys.length).toEqual(2)
+        expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+        expect(myRole).toHaveProperty('state', {})
+      })
     })
   })
 })

--- a/tests/integration/library-usage.test.js
+++ b/tests/integration/library-usage.test.js
@@ -1,0 +1,126 @@
+const path = require('path')
+const fse = require('fs-extra')
+const BbPromise = require('bluebird')
+const { fileExists } = require('@serverless/utils')
+const { removeFiles } = require('../helpers')
+
+const { run } = require('../../src')
+
+const fsp = BbPromise.promisifyAll(fse)
+
+describe('Integration Test - Library Usage', () => {
+  jest.setTimeout(40000)
+
+  const testDir = path.dirname(__filename)
+  const testServiceDir = path.join(testDir, 'library-usage')
+  const testServiceStateFile = path.join(testServiceDir, 'state.json')
+  const testServiceZipFile = path.join(testServiceDir, 'library-usage@0.0.1.zip')
+
+  beforeAll(async () => {
+    await removeFiles([testServiceStateFile, testServiceZipFile])
+  })
+
+  afterAll(async () => {
+    await removeFiles([testServiceStateFile, testServiceZipFile])
+  })
+
+  describe('our test setup', () => {
+    it('should not have any state files', async () => {
+      const testServiceHasStateFile = await fileExists(testServiceStateFile)
+
+      expect(testServiceHasStateFile).toEqual(false)
+    })
+  })
+
+  describe('when running through a typical component usage lifecycle', () => {
+    it('should deploy the "iam" component', async () => {
+      await run(testServiceDir, 'deploy')
+      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+      const stateFileKeys = Object.keys(stateFileContent)
+      expect(stateFileKeys.length).toEqual(3)
+      expect(stateFileContent).toHaveProperty('$.serviceId')
+      expect(stateFileContent).toHaveProperty('library-usage:myRole')
+      expect(stateFileContent.$.serviceId).not.toBeFalsy()
+      const myRole = stateFileContent['library-usage:myRole']
+      const myRoleObjectKeys = Object.keys(myRole)
+      expect(myRoleObjectKeys.length).toEqual(6)
+      expect(myRole).toHaveProperty('instanceId')
+      expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+      expect(myRole).toHaveProperty('internallyManaged', false)
+      expect(myRole).toHaveProperty('rootPath')
+      expect(myRole).toHaveProperty('state', {
+        id: 'id:iam:role:my-role',
+        name: 'my-role',
+        service: 'my.role.service',
+        deploymentCounter: 1
+      })
+      expect(myRole.instanceId).not.toBeFalsy()
+    })
+
+    it('should re-deploy the "iam" component', async () => {
+      await run(testServiceDir, 'deploy')
+      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+      const stateFileKeys = Object.keys(stateFileContent)
+      expect(stateFileKeys.length).toEqual(3)
+      expect(stateFileContent).toHaveProperty('$.serviceId')
+      expect(stateFileContent).toHaveProperty('library-usage:myRole')
+      expect(stateFileContent.$.serviceId).not.toBeFalsy()
+      const myRole = stateFileContent['library-usage:myRole']
+      const myRoleObjectKeys = Object.keys(myRole)
+      expect(myRoleObjectKeys.length).toEqual(6)
+      expect(myRole).toHaveProperty('instanceId')
+      expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+      expect(myRole).toHaveProperty('internallyManaged', false)
+      expect(myRole).toHaveProperty('rootPath')
+      expect(myRole).toHaveProperty('state', {
+        id: 'id:iam:role:my-role',
+        name: 'my-role',
+        service: 'my.role.service',
+        deploymentCounter: 2
+      })
+      expect(myRole.instanceId).not.toBeFalsy()
+    })
+
+    it('should package the "iam" component', async () => {
+      await run(testServiceDir, 'package', { path: testServiceDir })
+      const testServiceHasZipFile = await fileExists(testServiceZipFile)
+      expect(testServiceHasZipFile).toEqual(true)
+      // the state should not change
+      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+      const stateFileKeys = Object.keys(stateFileContent)
+      expect(stateFileKeys.length).toEqual(3)
+      expect(stateFileContent).toHaveProperty('$.serviceId')
+      expect(stateFileContent).toHaveProperty('library-usage:myRole')
+      expect(stateFileContent.$.serviceId).not.toBeFalsy()
+      const myRole = stateFileContent['library-usage:myRole']
+      const myRoleObjectKeys = Object.keys(myRole)
+      expect(myRoleObjectKeys.length).toEqual(6)
+      expect(myRole).toHaveProperty('instanceId')
+      expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+      expect(myRole).toHaveProperty('internallyManaged', false)
+      expect(myRole).toHaveProperty('rootPath')
+      expect(myRole).toHaveProperty('state', {
+        id: 'id:iam:role:my-role',
+        name: 'my-role',
+        service: 'my.role.service',
+        deploymentCounter: 2
+      })
+      expect(myRole.instanceId).not.toBeFalsy()
+    })
+
+    it('should remove the "iam" and "function" components', async () => {
+      await run(testServiceDir, 'remove')
+      const stateFileContent = await fsp.readJsonAsync(testServiceStateFile)
+      const stateFileKeys = Object.keys(stateFileContent)
+      expect(stateFileKeys.length).toEqual(3)
+      expect(stateFileContent).toHaveProperty('$.serviceId')
+      expect(stateFileContent).toHaveProperty('library-usage:myRole')
+      expect(stateFileContent.$.serviceId).not.toBeFalsy()
+      const myRole = stateFileContent['library-usage:myRole']
+      const myRoleObjectKeys = Object.keys(myRole)
+      expect(myRoleObjectKeys.length).toEqual(2)
+      expect(myRole).toHaveProperty('type', 'tests-integration-iam-mock')
+      expect(myRole).toHaveProperty('state', {})
+    })
+  })
+})

--- a/tests/integration/library-usage/serverless.yml
+++ b/tests/integration/library-usage/serverless.yml
@@ -1,0 +1,9 @@
+type: library-usage
+version: 0.0.1
+
+components:
+  myRole:
+    type: tests-integration-iam-mock
+    inputs:
+      name: my-role
+      service: my.role.service

--- a/tests/integration/programmatic-usage.test.js
+++ b/tests/integration/programmatic-usage.test.js
@@ -2,21 +2,11 @@ const path = require('path')
 const fse = require('fs-extra')
 const cp = require('child_process')
 const BbPromise = require('bluebird')
+const { fileExists } = require('@serverless/utils')
+const { removeFiles } = require('../helpers')
 
 const fsp = BbPromise.promisifyAll(fse)
 const cpp = BbPromise.promisifyAll(cp)
-
-// test helper methods
-async function hasFile(filePath) {
-  return fsp
-    .statAsync(filePath)
-    .then(() => true)
-    .catch(() => false)
-}
-
-async function removeStateFiles(stateFiles) {
-  return BbPromise.map(stateFiles, (stateFile) => fsp.removeAsync(stateFile))
-}
 
 describe('Integration Test - Programmatic usage', () => {
   jest.setTimeout(40000)
@@ -27,16 +17,16 @@ describe('Integration Test - Programmatic usage', () => {
   const testServiceStateFile = path.join(testServiceDir, 'state.json')
 
   beforeAll(async () => {
-    await removeStateFiles([testServiceStateFile])
+    await removeFiles([testServiceStateFile])
   })
 
   afterAll(async () => {
-    await removeStateFiles([testServiceStateFile])
+    await removeFiles([testServiceStateFile])
   })
 
   describe('our test setup', () => {
     it('should not have any state files', async () => {
-      const testServiceHasStateFile = await hasFile(testServiceStateFile)
+      const testServiceHasStateFile = await fileExists(testServiceStateFile)
 
       expect(testServiceHasStateFile).toEqual(false)
     })

--- a/tests/integration/programmatic-usage/serverless.yml
+++ b/tests/integration/programmatic-usage/serverless.yml
@@ -1,4 +1,5 @@
 type: programmatic-usage
+version: 0.0.1
 
 components:
   myFunction:

--- a/tests/integration/simple.test.js
+++ b/tests/integration/simple.test.js
@@ -2,21 +2,11 @@ const path = require('path')
 const fse = require('fs-extra')
 const cp = require('child_process')
 const BbPromise = require('bluebird')
+const { fileExists } = require('@serverless/utils')
+const { removeFiles } = require('../helpers')
 
 const fsp = BbPromise.promisifyAll(fse)
 const cpp = BbPromise.promisifyAll(cp)
-
-// test helper methods
-async function hasFile(filePath) {
-  return fsp
-    .statAsync(filePath)
-    .then(() => true)
-    .catch(() => false)
-}
-
-async function removeStateFiles(stateFiles) {
-  return BbPromise.map(stateFiles, (stateFile) => fsp.removeAsync(stateFile))
-}
 
 describe('Integration Test - Simple', () => {
   jest.setTimeout(40000)
@@ -28,16 +18,16 @@ describe('Integration Test - Simple', () => {
   const FUNCTION_NAME = 'my-function'
 
   beforeAll(async () => {
-    await removeStateFiles([testServiceStateFile])
+    await removeFiles([testServiceStateFile])
   })
 
   afterAll(async () => {
-    await removeStateFiles([testServiceStateFile])
+    await removeFiles([testServiceStateFile])
   })
 
   describe('our test setup', () => {
     it('should not have any state files', async () => {
-      const testServiceHasStateFile = await hasFile(testServiceStateFile)
+      const testServiceHasStateFile = await fileExists(testServiceStateFile)
 
       expect(testServiceHasStateFile).toEqual(false)
     })

--- a/tests/integration/simple/serverless.yml
+++ b/tests/integration/simple/serverless.yml
@@ -1,4 +1,5 @@
 type: simple
+version: 0.0.1
 
 components:
   myFunction:


### PR DESCRIPTION
## What has been implemented?

Implements the functionality to pull in Serverless Components as a library and use it programatically.

Closes #SC-265

## Steps to verify

### Pointing to a project path

Create a `workflow-with-path.js` file a new directory called `library-usage` in the `examples` directory:

```js
// examples/library-usage/workflow-with-path.js

const { join } = require('path')
const { log } = require('../../src/utils')
const { pkg, deploy, remove } = require('../../src')

const projectPath = join('..', '..', 'tests', 'integration', 'library-usage')

async function run() {
  log('Packaging service...')
  await pkg({ projectPath, path: servicePath })
  log('Deploying service...')
  await deploy({ projectPath })
  log('Re-deploying service...')
  await deploy({ projectPath })
  log('Removing service...')
  await remove({ projectPath })
}

run()
```

Run `node workflow-with-path.js`.

### Providing a `serverless.yml` file object

Create a `workflow-with-serverless-file-object.js` file a new directory called `library-usage` in the `examples` directory:

```js
// examples/library-usage/workflow-with-serverless-file-object.js

const { log } = require('../../src/utils')
const { pkg, deploy, remove } = require('../../src')

const serverlessFileObject = {
  type: 'my-app',
  version: '0.0.1',
  components: {
    myRole: {
      type: 'tests-integration-iam-mock',
      inputs: {
        name: 'my-role-name',
        service: 'my.function.service'
      }
    }
  }
}

async function run() {
  // NOTE: right now the cwd() is packaged. Not sure how this behavior is desired / if we
  // should support packaging when using a serverlessFileObject
  // log('Packaging service...')
  // await pkg({ path: process.cwd(), serverlessFileObject })
  log('Deploying service...')
  await deploy({ serverlessFileObject })
  log('Re-deploying service...')
  await deploy({ serverlessFileObject })
  log('Removing service...')
  await remove({ serverlessFileObject })
}

run()

```

Run `node workflow-with-serverless-file-object.js`.

## Todos:

* [x] Fix issue when re-deploying with projectPath
* [x] Write tests
* [x] Run Prettier
* [x] Add documentation