### PR TITLE
Add "runtime" configuration option to awsLambda component 

### DIFF
--- a/registry/aws-lambda/index.js
+++ b/registry/aws-lambda/index.js
@@ -8,7 +8,6 @@ async function createLambda(
   role
 ) {
   const pkg = await pack(root)
-  console.log('here', runtime)
   const params = {
     FunctionName: name,
     Code: {

--- a/registry/aws-lambda/serverless.yml
+++ b/registry/aws-lambda/serverless.yml
@@ -16,10 +16,10 @@ inputTypes:
     example: myProject-functionName-${self.instanceId}
   runtime:
     type: string
-    default: node8.10
+    default: nodejs8.10
     displayName: AWS Lambda Runtime
     description: The runtime or language of your AWS Lambda function
-    example: node.js8.10
+    example: nodejs8.10
   memory:
     type: number
     required: true

--- a/registry/aws-lambda/serverless.yml
+++ b/registry/aws-lambda/serverless.yml
@@ -14,6 +14,12 @@ inputTypes:
     displayName: Lambda function name
     description: The Lambda function name
     example: myProject-functionName-${self.instanceId}
+  runtime:
+    type: string
+    default: node8.10
+    displayName: AWS Lambda Runtime
+    description: The runtime or language of your AWS Lambda function
+    example: node.js8.10
   memory:
     type: number
     required: true


### PR DESCRIPTION
## What has been implemented?
Add "runtime" configuration option to awsLambda component and sets `nodejs8.10` as the new default.