### PR TITLE
Extend linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,8 +11,8 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module',
     ecmaFeatures: {
-      experimentalObjectRestSpread: true,
-    },
+      experimentalObjectRestSpread: true
+    }
   },
   rules: {
     'array-bracket-spacing': [
@@ -26,10 +26,13 @@ module.exports = {
     'arrow-parens': ['error', 'always'],
     'comma-dangle': ['error', 'never'],
     'func-names': 'off',
-    'no-param-reassign': 'off',
     'no-use-before-define': 'off',
     'prefer-destructuring': 'off',
+    'no-console': 'error',
+    'no-shadow': 'error',
+    'no-undef': 'error',
     'object-curly-newline': 'off',
+    'no-unused-vars': 'error',
     semi: ['error', 'never'],
     'object-shorthand': 'off',
     'prettier/prettier': 'error'

--- a/registry/aws-cloudfront/index.js
+++ b/registry/aws-cloudfront/index.js
@@ -13,6 +13,7 @@ const getDistribution = async (distributionId) => {
   return distRes
 }
 
+// eslint-disable-next-line no-unused-vars
 const getDistributionConfig = async (distributionId) => {
   const distConfigRes = await CloudFront.getDistributionConfig({
     Id: distributionId

--- a/registry/s3-sync/index.js
+++ b/registry/s3-sync/index.js
@@ -19,7 +19,7 @@ const syncDirFiles = async ({ contentPath, bucketName }) => {
     }
   }
   const uploader = client.uploadDir(params)
-  uploader.on('fileUploadEnd', (localFilePath, s3Key) => {
+  uploader.on('fileUploadEnd', (localFilePath) => {
     // eslint-disable-line no-unused-vars
     console.log(`Uploading file: '${localFilePath}' ...`)
   })

--- a/registry/s3-website-config/index.js
+++ b/registry/s3-website-config/index.js
@@ -8,7 +8,7 @@ const setBucketForWebsiteConfig = async ({
   rootBucketName,
   indexDocument,
   errorDocument,
-  redirectBucketName,
+  redirectBucketName, // eslint-disable-line no-unused-vars
   redirectToHostName // eslint-disable-line no-unused-vars
 }) => {
   const params = {
@@ -27,8 +27,8 @@ const setBucketForWebsiteConfig = async ({
 }
 
 const setBucketForRedirection = async ({
-  rootBucketName,
-  indexDocument,
+  rootBucketName, // eslint-disable-line no-unused-vars
+  indexDocument, // eslint-disable-line no-unused-vars
   errorDocument, // eslint-disable-line no-unused-vars
   redirectBucketName,
   redirectToHostName


### PR DESCRIPTION
## What has been implemented?

In https://github.com/serverless/components/pull/205 we've replaced the "airbnb" liniting rules with "prettier" linting rules to tightly integrate both, ESLint as well as Prettier.

However some really helpful rules from the airbnb plugin are missing.

I added those via this PR. Might add more via other PRs if something else is missing.

## Todos:

* [x] Run Prettier