### PR TITLE
Remove Node.js 4 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - NODEJS_VERSION: '4'
     - NODEJS_VERSION: '6'
     - NODEJS_VERSION: '8'
     - NODEJS_VERSION: '10'

--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "env",
       {
         "targets": {
-          "node": "4"
+          "node": "6"
         }
       }
     ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: node_js
 sudo: false
 matrix:
   include:
-    - node_js: 4
-      env:
-        - SENTRY_DSN: https://17031d90871a4daebd4f261f2359b38f:9ce69587851c448b96893fb3794df20e@sentry.io/300239
-        - SEGMENT_WRITE_KEY: jvOP27GTlIJubkJpRcDAa4uSfwCD03NI
     - node_js: 6
       env:
         - SENTRY_DSN: https://17031d90871a4daebd4f261f2359b38f:9ce69587851c448b96893fb3794df20e@sentry.io/300239

--- a/registry/.babelrc
+++ b/registry/.babelrc
@@ -4,7 +4,7 @@
       "env",
       {
         "targets": {
-          "node": "4"
+          "node": "6"
         }
       }
     ]

--- a/registry/postinstall.js
+++ b/registry/postinstall.js
@@ -12,7 +12,7 @@ const buildComponents = require('./buildComponents')
 const rootPath = __dirname
 const componentDirs = fs.readdirSync(rootPath)
 const npmCmd = os.platform().startsWith('win') ? 'npm.cmd' : 'npm'
-const concurrency = process.version.startsWith('v4') ? 8 : 0
+const concurrency = 0
 
 function installComponents() {
   return BbPromise.map(

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -34,29 +34,6 @@ function trackInstall() {
   })
 }
 
-function installNode4Support() {
-  if (process.version.startsWith('v4')) {
-    console.log('Installing older Jest version to support tests for Node 4...')
-
-    return new BbPromise((resolve, reject) => {
-      const command = cp.spawn(
-        npmCmd,
-        ['install', '--save-dev', 'jest@21', 'babel-jest@21', 'jest-environment-node@21'],
-        {
-          env: process.env,
-          cwd: rootPath
-        }
-      )
-      command.stdout.on('data', (data) => {
-        console.log(data.toString())
-      })
-      command.stdout.on('close', () => resolve())
-      command.stdout.on('end', () => resolve())
-      command.stdout.on('error', (error) => reject(error))
-    })
-  }
-}
-
 function installRegistryDependencies() {
   return new BbPromise((resolve, reject) => {
     const command = cp.spawn(npmCmd, ['install'], {
@@ -76,6 +53,5 @@ function installRegistryDependencies() {
   return BbPromise.resolve()
     .then(build)
     .then(trackInstall)
-    .then(installNode4Support)
     .then(installRegistryDependencies)
 })()


### PR DESCRIPTION
Our tests are flaky, slow and some npm packages we rely on were updated and break with Node.js 4. Removing Node.js 4 support since it was sunsetted and AWS Lambda doesn't support the creation of Node.js 4 runtimes anymore.