### PR TITLE
Docker image component

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,7 @@ RUN apt-get update -y \
   && apt-get upgrade -y \
   && apt-get install -y nodejs build-essential \
   && npm install npm@latest -g
+
+# install Docker
+RUN curl -fsSL get.docker.com -o get-docker.sh
+RUN sh get-docker.sh

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Also please do join the _Components_ channel on our public [Serverless-Contrib S
     * [aws-sns-platform-endpoint](./registry/aws-sns-platform-endpoint)
     * [aws-sns-subscription](./registry/aws-sns-subscription)
     * [aws-sns-topic](./registry/aws-sns-topic)
+    * [docker-image](./registry/docker-image)
     * [eventgateway](./registry/eventgateway)
     * [github-webhook](./registry/github-webhook)
     * [github-webhook-aws](./registry/github-webhook-aws)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,5 @@ services:
       - .:/app
       - ~/.aws/:/root/.aws
       - ~/.gitconfig:/root/.gitconfig
+      # run Docker in Docker...
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/registry/docker-image/README.md
+++ b/registry/docker-image/README.md
@@ -1,0 +1,50 @@
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_HEADER) -->
+# Docker Image
+
+Create and publish Docker images
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (TOC) -->
+- [Input Types](#input-types)
+- [Output Types](#output-types)
+- [Example](#example)
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_INPUT_TYPES) -->
+## Input Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **username**| `string` | The username used when logging in to the Docker registry
+| **password**| `string` | The password used when logging in to the Docker registry
+| **dockerfilePath**| `string`<br/>*required* | The Dockerfile which should be used to assemble the image
+| **contextPath**| `string`<br/>*required* | The build context path which is used when building the Docker image
+| **tag**| `string`<br/>*required* | The tag which should be used to tag the Docker image
+| **registryUrl**| `string`<br/>*required* | The Docker registry URL which should be used to push the image
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_OUTPUT_TYPES) -->
+## Output Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **tag**| `string` | The Docker image tag used when performing the given operation
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_EXAMPLES) -->
+## Example
+```yml
+type: my-application
+components:
+  myDockerImage:
+    type: docker-image
+    inputs:
+      username: jdoe
+      password: s0m3p455w0rd
+      dockerfilePath: ./Dockerfile
+      contextPath: .
+      tag: 'jdoe/my-image:latest'
+      registryUrl: 'https://my-registry.com:8080'
+
+```
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/registry/docker-image/package-lock.json
+++ b/registry/docker-image/package-lock.json
@@ -1,0 +1,151 @@
+{
+  "name": "@serverless-components/docker-image",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bluebird": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
+      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "get-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.0.0.tgz",
+      "integrity": "sha512-FneLKMENeOR7wOK0/ZXCh+lwqtnPwkeunJjRN28LPqzGvNAhYvrTAhXv6xDm4vsJ0M7lcRbIYHQudKsSy2RtSQ==",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-fetch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "semver": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/registry/docker-image/package.json
+++ b/registry/docker-image/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@serverless-components/docker-image",
+  "version": "0.2.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "bluebird": "^3.5.2",
+    "execa": "^1.0.0",
+    "node-fetch": "^2.2.0",
+    "which": "^1.3.1"
+  }
+}

--- a/registry/docker-image/serverless.yml
+++ b/registry/docker-image/serverless.yml
@@ -1,0 +1,50 @@
+type: docker-image
+version: 0.2.0
+core: 0.2.x
+
+description: "Create and publish Docker images"
+license: Apache-2.0
+author: "Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
+repository: "github:serverless/components"
+
+inputTypes:
+  dockerfilePath:
+    type: string
+    required: true
+    displayName: Dockerfile
+    description: The Dockerfile which should be used to assemble the image
+    example: ./Dockerfile
+  contextPath:
+    type: string
+    required: true
+    displayName: Build context
+    description: The build context path which is used when building the Docker image
+    example: .
+  tag:
+    type: string
+    required: true
+    displayName: Tag
+    description: The tag which should be used to tag the Docker image
+    example: jdoe/my-image:latest
+  registryUrl:
+    type: string
+    required: true
+    default: https://hub.docker.com
+    displayName: Registry URL
+    description: The Docker registry URL which should be used to push the image
+    example: https://my-registry.com:8080
+  username:
+    type: string
+    displayName: Username
+    description: The username used when logging in to the Docker registry
+    example: jdoe
+  password:
+    type: string
+    displayName: Password
+    description: The password used when logging in to the Docker registry
+    example: s0m3p455w0rd
+
+outputTypes:
+  tag:
+    type: string
+    description: The Docker image tag used when performing the given operation

--- a/registry/docker-image/src/index.js
+++ b/registry/docker-image/src/index.js
@@ -1,0 +1,81 @@
+const {
+  checkDockerSetup,
+  buildImage,
+  login,
+  pushImage,
+  logout,
+  removeImage,
+  getToken,
+  deleteImage
+} = require('./utils')
+
+// "public" functions
+async function build(inputs, context) {
+  const { tag } = inputs
+
+  await checkDockerSetup()
+
+  context.log(`Building Docker image based on "${inputs.dockerfilePath}"...`)
+
+  await buildImage(inputs.dockerfilePath, inputs.tag, inputs.contextPath)
+
+  const outputs = { tag }
+  const state = { ...inputs }
+  delete state.username
+  delete state.password
+  context.saveState(state)
+
+  context.log(`Image successfully built with tag "${tag}"`)
+
+  return outputs
+}
+
+async function deploy(inputs, context) {
+  // build if we don't have state yet (haven't run `build` before)
+  if (Object.keys(context.state).length === 0) {
+    await build(inputs, context)
+  }
+
+  const { username, password, tag, registryUrl } = inputs
+
+  await checkDockerSetup()
+
+  context.log(`Pushing Docker image to registry "${registryUrl}"...`)
+
+  await login(username, password, registryUrl)
+  await pushImage(tag)
+  await logout(registryUrl)
+
+  const outputs = { tag }
+  const state = { ...inputs }
+  delete state.username
+  delete state.password
+  context.saveState(state)
+
+  context.log(`Image successfully pushed to registry "${registryUrl}"`)
+
+  return outputs
+}
+
+async function remove(inputs, context) {
+  const { username, password } = inputs
+  const { tag, registryUrl } = context.state
+
+  await checkDockerSetup()
+
+  context.log(`Removing Docker image "${tag}" locally...`)
+  await removeImage(tag)
+
+  context.log(`Removing Docker image "${tag}" from registry "${registryUrl}"...`)
+  const token = await getToken(username, password, registryUrl)
+  await deleteImage(token, tag, registryUrl)
+
+  context.saveState()
+  return {}
+}
+
+module.exports = {
+  build,
+  deploy,
+  remove
+}

--- a/registry/docker-image/src/index.test.js
+++ b/registry/docker-image/src/index.test.js
@@ -1,0 +1,131 @@
+const {
+  checkDockerSetup,
+  buildImage,
+  login,
+  pushImage,
+  logout,
+  removeImage,
+  getToken,
+  deleteImage
+} = require('./utils')
+const dockerComponent = require('./index')
+
+jest.mock('./utils/checkDockerSetup')
+jest.mock('./utils/buildImage')
+jest.mock('./utils/login')
+jest.mock('./utils/pushImage')
+jest.mock('./utils/logout')
+jest.mock('./utils/removeImage')
+jest.mock('./utils/getToken')
+jest.mock('./utils/deleteImage')
+
+checkDockerSetup.mockImplementation(() => Promise.resolve(true))
+buildImage.mockImplementation(() => Promise.resolve('https://my-registry:8080/jdoe/my-image'))
+login.mockImplementation(() => Promise.resolve(true))
+pushImage.mockImplementation(() => Promise.resolve('https://my-registry:8080/jdoe/my-image'))
+logout.mockImplementation(() => Promise.resolve(true))
+removeImage.mockImplementation(() => Promise.resolve('https://my-registry:8080/jdoe/my-image'))
+getToken.mockImplementation(() => 'jwt-auth-token')
+deleteImage.mockImplementation(() => Promise.resolve())
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('docker-image tests', () => {
+  let tag
+  let inputs
+  let context
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    tag = 'https://my-registry:8080/jdoe/my-image'
+    inputs = {
+      dockerfilePath: './Dockerfile',
+      contextPath: '.',
+      tag: 'https://my-registry:8080/jdoe/my-image',
+      registryUrl: 'https://my-registry:8080',
+      username: 'jdoe',
+      password: 's0m3p455w0rd'
+    }
+    context = {
+      state: {
+        ...inputs
+      },
+      log: jest.fn(),
+      saveState: jest.fn()
+    }
+  })
+
+  describe('when running "build"', () => {
+    it('should successfully build an image', async () => {
+      const outputs = await dockerComponent.build(inputs, context)
+
+      const expectedState = { ...inputs }
+      delete expectedState.username
+      delete expectedState.password
+
+      expect(outputs).toEqual({ tag })
+      expect(checkDockerSetup).toHaveBeenCalledTimes(1)
+      expect(buildImage).toBeCalledWith(inputs.dockerfilePath, inputs.tag, inputs.contextPath)
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toBeCalledWith(expectedState)
+    })
+  })
+
+  describe('when running "deploy"', () => {
+    it('should push the image to the Docker registry', async () => {
+      const outputs = await dockerComponent.deploy(inputs, context)
+
+      const expectedState = { ...inputs }
+      delete expectedState.username
+      delete expectedState.password
+
+      expect(outputs).toEqual({ tag })
+      expect(checkDockerSetup).toHaveBeenCalledTimes(1)
+      expect(login).toBeCalledWith(inputs.username, inputs.password, inputs.registryUrl)
+      expect(pushImage).toBeCalledWith(inputs.tag)
+      expect(logout).toBeCalledWith(inputs.registryUrl)
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toBeCalledWith(expectedState)
+    })
+
+    it('should build the image if it was not built beforehand', async () => {
+      // empty state --> image was not built
+      context.state = {}
+      const outputs = await dockerComponent.deploy(inputs, context)
+
+      const expectedState = { ...inputs }
+      delete expectedState.username
+      delete expectedState.password
+
+      expect(outputs).toEqual({ tag })
+      expect(checkDockerSetup).toHaveBeenCalledTimes(2)
+      expect(buildImage).toBeCalledWith(inputs.dockerfilePath, inputs.tag, inputs.contextPath)
+      expect(login).toBeCalledWith(inputs.username, inputs.password, inputs.registryUrl)
+      expect(pushImage).toBeCalledWith(inputs.tag)
+      expect(logout).toBeCalledWith(inputs.registryUrl)
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toBeCalledWith(expectedState)
+    })
+  })
+
+  describe('when running "remove"', () => {
+    it('should remove the image locally and from the Docker registry', async () => {
+      const outputs = await dockerComponent.remove(inputs, context)
+
+      expect(outputs).toEqual({})
+      expect(checkDockerSetup).toHaveBeenCalledTimes(1)
+      expect(removeImage).toBeCalledWith(context.state.tag)
+      expect(getToken).toBeCalledWith(inputs.username, inputs.password, context.state.registryUrl)
+      expect(deleteImage).toBeCalledWith(
+        'jwt-auth-token',
+        context.state.tag,
+        context.state.registryUrl
+      )
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/registry/docker-image/src/utils/buildImage.js
+++ b/registry/docker-image/src/utils/buildImage.js
@@ -1,0 +1,9 @@
+const execa = require('execa')
+
+async function buildImage(dockerfilePath, tag, contextPath) {
+  await execa('docker', ['build', '--file', dockerfilePath, '--tag', tag, contextPath])
+
+  return tag
+}
+
+module.exports = buildImage

--- a/registry/docker-image/src/utils/buildImage.test.js
+++ b/registry/docker-image/src/utils/buildImage.test.js
@@ -1,0 +1,34 @@
+const execa = require('execa')
+const buildImage = require('./buildImage')
+
+jest.mock('execa')
+
+execa.mockImplementation(() => Promise.resolve())
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#buildImage()', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  it('should build the image', async () => {
+    const dockerfilePath = './Dockerfile'
+    const tag = 'jdoe/my-project:latest'
+    const contextPath = '.'
+
+    const res = await buildImage(dockerfilePath, tag, contextPath)
+
+    expect(res).toEqual(tag)
+    expect(execa).toHaveBeenCalledWith('docker', [
+      'build',
+      '--file',
+      dockerfilePath,
+      '--tag',
+      tag,
+      contextPath
+    ])
+  })
+})

--- a/registry/docker-image/src/utils/checkDockerSetup.js
+++ b/registry/docker-image/src/utils/checkDockerSetup.js
@@ -1,0 +1,20 @@
+const isDockerInstalled = require('./isDockerInstalled')
+const isDockerRunning = require('./isDockerRunning')
+
+async function checkDockerSetup() {
+  if (!(await isDockerInstalled())) {
+    throw new Error(
+      'Docker not installed. Please install Docker on your machine (see: https://docker.com)...'
+    )
+  }
+
+  if (!(await isDockerRunning())) {
+    throw new Error(
+      'Docker not running. Please make sure to run the Docker deamon before continuing...'
+    )
+  }
+
+  return true
+}
+
+module.exports = checkDockerSetup

--- a/registry/docker-image/src/utils/checkDockerSetup.test.js
+++ b/registry/docker-image/src/utils/checkDockerSetup.test.js
@@ -1,0 +1,46 @@
+const checkDockerSetup = require('./checkDockerSetup')
+const isDockerInstalled = require('./isDockerInstalled')
+const isDockerRunning = require('./isDockerRunning')
+
+jest.mock('./isDockerInstalled')
+jest.mock('./isDockerRunning')
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#checkDockerSetup()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should throw if Docker is not installed', async () => {
+    isDockerInstalled.mockImplementation(() => false)
+    // NOTE: docker can't be running if it's not installed
+    isDockerRunning.mockImplementation(() => false)
+
+    await expect(checkDockerSetup()).rejects.toThrow('Docker not installed')
+    expect(isDockerInstalled).toHaveBeenCalledTimes(1)
+    expect(isDockerRunning).toHaveBeenCalledTimes(0)
+  })
+
+  it('should throw if Docker is not running', async () => {
+    isDockerInstalled.mockImplementation(() => true)
+    isDockerRunning.mockImplementation(() => false)
+
+    await expect(checkDockerSetup()).rejects.toThrow('Docker not running')
+    expect(isDockerInstalled).toHaveBeenCalledTimes(1)
+    expect(isDockerRunning).toHaveBeenCalledTimes(1)
+  })
+
+  it('should resolve with true if Docker is installed and running', async () => {
+    isDockerInstalled.mockImplementation(() => true)
+    isDockerRunning.mockImplementation(() => true)
+
+    const res = await checkDockerSetup()
+
+    expect(res).toEqual(true)
+    expect(isDockerInstalled).toHaveBeenCalledTimes(1)
+    expect(isDockerRunning).toHaveBeenCalledTimes(1)
+  })
+})

--- a/registry/docker-image/src/utils/constants.js
+++ b/registry/docker-image/src/utils/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+  DOCKER_HUB_URL: 'https://hub.docker.com'
+}

--- a/registry/docker-image/src/utils/deleteImage.js
+++ b/registry/docker-image/src/utils/deleteImage.js
@@ -1,0 +1,18 @@
+const fetch = require('node-fetch')
+
+async function deleteImage(token, tag, registryUrl) {
+  let [username, image] = tag.split('/').slice(-2) // eslint-disable-line
+  // remove appendix like ":latest"
+  image = image.split(':').shift()
+
+  const resource = [username, image].join('/')
+
+  return fetch(`${registryUrl}/v2/repositories/${resource}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `JWT ${token}`
+    }
+  })
+}
+
+module.exports = deleteImage

--- a/registry/docker-image/src/utils/deleteImage.test.js
+++ b/registry/docker-image/src/utils/deleteImage.test.js
@@ -1,0 +1,29 @@
+const fetch = require('node-fetch')
+const deleteImage = require('./deleteImage')
+
+jest.mock('node-fetch')
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#deleteImage()', () => {
+  const token = 'jwt-auth-token'
+  const registryUrl = 'https://my-registry:8080'
+  const tag = 'https://my-registry:8080/jdoe/my-image:latest'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should delete the image from the Docker registry', async () => {
+    await deleteImage(token, tag, registryUrl)
+
+    expect(fetch).toHaveBeenCalledWith('https://my-registry:8080/v2/repositories/jdoe/my-image', {
+      method: 'DELETE',
+      headers: {
+        Authorization: 'JWT jwt-auth-token'
+      }
+    })
+  })
+})

--- a/registry/docker-image/src/utils/getToken.js
+++ b/registry/docker-image/src/utils/getToken.js
@@ -1,0 +1,17 @@
+const fetch = require('node-fetch')
+
+async function getToken(username, password, registryUrl) {
+  const result = await fetch(`${registryUrl}/v2/users/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      username,
+      password
+    })
+  }).then((res) => res.json())
+  return result.token
+}
+
+module.exports = getToken

--- a/registry/docker-image/src/utils/getToken.test.js
+++ b/registry/docker-image/src/utils/getToken.test.js
@@ -1,0 +1,40 @@
+const fetch = require('node-fetch')
+const getToken = require('./getToken')
+
+jest.mock('node-fetch', () =>
+  jest.fn(() =>
+    Promise.resolve({
+      json: () => ({ token: 'jwt-auth-token' })
+    })
+  )
+)
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#getToken()', () => {
+  const username = 'jdoe'
+  const password = 's0m3p455w0rd'
+  const registryUrl = 'https://my-registry:8080'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should get a JWT token from the Docker registry', async () => {
+    const res = await getToken(username, password, registryUrl)
+
+    expect(res).toEqual('jwt-auth-token')
+    expect(fetch).toHaveBeenCalledWith('https://my-registry:8080/v2/users/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        username,
+        password
+      })
+    })
+  })
+})

--- a/registry/docker-image/src/utils/index.js
+++ b/registry/docker-image/src/utils/index.js
@@ -1,0 +1,23 @@
+const buildImage = require('./buildImage')
+const checkDockerSetup = require('./checkDockerSetup')
+const deleteImage = require('./deleteImage')
+const getToken = require('./getToken')
+const isDockerInstalled = require('./isDockerInstalled')
+const isDockerRunning = require('./isDockerRunning')
+const login = require('./login')
+const logout = require('./logout')
+const pushImage = require('./pushImage')
+const removeImage = require('./removeImage')
+
+module.exports = {
+  buildImage,
+  checkDockerSetup,
+  deleteImage,
+  getToken,
+  isDockerInstalled,
+  isDockerRunning,
+  login,
+  logout,
+  pushImage,
+  removeImage
+}

--- a/registry/docker-image/src/utils/isDockerInstalled.js
+++ b/registry/docker-image/src/utils/isDockerInstalled.js
@@ -1,0 +1,12 @@
+const which = require('which')
+const BbPromise = require('bluebird')
+
+async function isDockerInstalled() {
+  return BbPromise.fromCallback((callback) => {
+    which('docker', callback)
+  })
+    .then(() => true)
+    .catch(() => false)
+}
+
+module.exports = isDockerInstalled

--- a/registry/docker-image/src/utils/isDockerInstalled.test.js
+++ b/registry/docker-image/src/utils/isDockerInstalled.test.js
@@ -1,0 +1,31 @@
+const which = require('which')
+const isDockerInstalled = require('./isDockerInstalled')
+
+jest.mock('which')
+
+which.mockImplementationOnce((cmd, cb) => cb(null, 'path-to-bin'))
+which.mockImplementationOnce((cmd, cb) => cb(new Error('not found'), null))
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#isDockerInstalled()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should detect if Docker is installed', async () => {
+    const res = await isDockerInstalled()
+
+    expect(which).toHaveBeenCalledTimes(1)
+    expect(res).toEqual(true)
+  })
+
+  it('should return false if Docker is not installed', async () => {
+    const res = await isDockerInstalled()
+
+    expect(which).toHaveBeenCalledTimes(1)
+    expect(res).toEqual(false)
+  })
+})

--- a/registry/docker-image/src/utils/isDockerRunning.js
+++ b/registry/docker-image/src/utils/isDockerRunning.js
@@ -1,0 +1,9 @@
+const execa = require('execa')
+
+async function isDockerRunning() {
+  return execa('docker', ['version'])
+    .then(() => true)
+    .catch(() => false)
+}
+
+module.exports = isDockerRunning

--- a/registry/docker-image/src/utils/isDockerRunning.test.js
+++ b/registry/docker-image/src/utils/isDockerRunning.test.js
@@ -1,0 +1,31 @@
+const execa = require('execa')
+const isDockerRunning = require('./isDockerRunning')
+
+jest.mock('execa')
+
+execa.mockImplementationOnce(() => Promise.resolve())
+execa.mockImplementationOnce(() => Promise.reject())
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#isDockerRunning()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should detect if Docker is running', async () => {
+    const res = await isDockerRunning()
+
+    expect(execa).toHaveBeenCalledWith('docker', ['version'])
+    expect(res).toEqual(true)
+  })
+
+  it('should return false if Docker is not running', async () => {
+    const res = await isDockerRunning()
+
+    expect(execa).toHaveBeenCalledWith('docker', ['version'])
+    expect(res).toEqual(false)
+  })
+})

--- a/registry/docker-image/src/utils/login.js
+++ b/registry/docker-image/src/utils/login.js
@@ -1,0 +1,14 @@
+const execa = require('execa')
+const { DOCKER_HUB_URL } = require('./constants')
+
+async function login(username, password, registryUrl) {
+  if (registryUrl === DOCKER_HUB_URL) registryUrl = null
+  // filter out null values in args
+  const args = ['login', '--username', username, '--password', password, registryUrl].filter(
+    (arg) => arg
+  )
+  await execa('docker', args)
+  return true
+}
+
+module.exports = login

--- a/registry/docker-image/src/utils/login.test.js
+++ b/registry/docker-image/src/utils/login.test.js
@@ -1,0 +1,50 @@
+const execa = require('execa')
+const login = require('./login')
+
+jest.mock('execa')
+
+execa.mockImplementation(() => Promise.resolve())
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#login()', () => {
+  const username = 'jdoe'
+  const password = 's0m3p455w0rd'
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  it('should login to the Docker registry ', async () => {
+    const registryUrl = 'https://my-registry:8080'
+
+    const res = await login(username, password, registryUrl)
+
+    expect(res).toEqual(true)
+    expect(execa).toHaveBeenCalledWith('docker', [
+      'login',
+      '--username',
+      username,
+      '--password',
+      password,
+      registryUrl
+    ])
+  })
+
+  it('should not use the registryUrl as a CLI argument if the public Docker registry is used', async () => {
+    const registryUrl = 'https://hub.docker.com'
+
+    const res = await login(username, password, registryUrl)
+
+    expect(res).toEqual(true)
+    expect(execa).toHaveBeenCalledWith('docker', [
+      'login',
+      '--username',
+      username,
+      '--password',
+      password
+    ])
+  })
+})

--- a/registry/docker-image/src/utils/logout.js
+++ b/registry/docker-image/src/utils/logout.js
@@ -1,0 +1,12 @@
+const execa = require('execa')
+const { DOCKER_HUB_URL } = require('./constants')
+
+async function logout(registryUrl) {
+  if (registryUrl === DOCKER_HUB_URL) registryUrl = null
+  // filter out null values in args
+  const args = ['logout', registryUrl].filter((arg) => arg)
+  await execa('docker', args)
+  return true
+}
+
+module.exports = logout

--- a/registry/docker-image/src/utils/logout.test.js
+++ b/registry/docker-image/src/utils/logout.test.js
@@ -1,0 +1,34 @@
+const execa = require('execa')
+const logout = require('./logout')
+
+jest.mock('execa')
+
+execa.mockImplementation(() => Promise.resolve())
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#logout()', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  it('should logout of the Docker registry ', async () => {
+    const registryUrl = 'https://my-registry:8080'
+
+    const res = await logout(registryUrl)
+
+    expect(res).toEqual(true)
+    expect(execa).toHaveBeenCalledWith('docker', ['logout', registryUrl])
+  })
+
+  it('should not use the registryUrl as a CLI argument if the public Docker registry is used', async () => {
+    const registryUrl = 'https://hub.docker.com'
+
+    const res = await logout(registryUrl)
+
+    expect(res).toEqual(true)
+    expect(execa).toHaveBeenCalledWith('docker', ['logout'])
+  })
+})

--- a/registry/docker-image/src/utils/pushImage.js
+++ b/registry/docker-image/src/utils/pushImage.js
@@ -1,0 +1,8 @@
+const execa = require('execa')
+
+async function pushImage(tag) {
+  await execa('docker', ['push', tag])
+  return tag
+}
+
+module.exports = pushImage

--- a/registry/docker-image/src/utils/pushImage.test.js
+++ b/registry/docker-image/src/utils/pushImage.test.js
@@ -1,0 +1,25 @@
+const execa = require('execa')
+const pushImage = require('./pushImage')
+
+jest.mock('execa')
+
+execa.mockImplementation(() => Promise.resolve())
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#pushImage()', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  it('should push the image to the Docker registry', async () => {
+    const tag = 'https://my-registry:8080/jdoe/my-image'
+
+    const res = await pushImage(tag)
+
+    expect(res).toEqual(tag)
+    expect(execa).toHaveBeenCalledWith('docker', ['push', tag])
+  })
+})

--- a/registry/docker-image/src/utils/removeImage.js
+++ b/registry/docker-image/src/utils/removeImage.js
@@ -1,0 +1,8 @@
+const execa = require('execa')
+
+async function removeImage(tag) {
+  await execa('docker', ['rmi', '--force', true, tag])
+  return tag
+}
+
+module.exports = removeImage

--- a/registry/docker-image/src/utils/removeImage.test.js
+++ b/registry/docker-image/src/utils/removeImage.test.js
@@ -1,0 +1,25 @@
+const execa = require('execa')
+const removeImage = require('./removeImage')
+
+jest.mock('execa')
+
+execa.mockImplementation(() => Promise.resolve())
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('#removeImage()', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+
+  it('should remove the image locally', async () => {
+    const tag = 'jdoe/my-project:latest'
+
+    const res = await removeImage(tag)
+
+    expect(res).toEqual(tag)
+    expect(execa).toHaveBeenCalledWith('docker', ['rmi', '--force', true, tag])
+  })
+})


### PR DESCRIPTION
Implements a Docker image component which makes it possible to build and publish Docker images.

The following config can be used to test the `build` / `deploy` and `remove` commands:

```yml
# serverless.yml

type: docker-image-test

components:
  docker:
    type: docker-image
    inputs:
      dockerfilePath: ${self.path}/Dockerfile
      contextPath: ${self.path}
      tag: jdoe/my-image:latest
      registryUrl: https://my-registry.com # leave this empty if the image should be pushed to the public Docker registry
      username: jdoe
      password: s0m3p455w0rd
```

```
# Dockerfile

FROM hello-world
```

You can run `components build` / `components deploy` to build / push the Docker image. Once built and pushed you can remove the Docker image via `components remove`.