### PR TITLE
Create a new component script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:appveyor": "jest --testPathPattern=\"bin|examples|registry|src\" --colors --forceExit",
     "docs": "node ./scripts/doc-gen.js",
     "postinstall": "node ./scripts/postinstall.js",
-    "prepublishOnly": "node ./scripts/prepublish.js"
+    "prepublishOnly": "node ./scripts/prepublish.js",
+    "create:component": "node ./scripts/create-component.js"
   },
   "dependencies": {
     "@octokit/rest": "^14.0.5",

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -1,0 +1,78 @@
+/* eslint-disable no-console */
+const fs = require('fs-extra')
+const path = require('path')
+
+const { version } = require('../package.json')
+const name = process.argv[2]
+const directory = path.join(process.cwd(), 'registry', name)
+
+const packageJsonTemplate = {
+  name: `@serverless-components/${name}`,
+  version: version,
+  private: true,
+  main: 'dist/index.js',
+  scripts: {
+    test: 'echo "Error: no test specified" && exit 1'
+  }
+}
+
+const serverlessYmlTemplate = `---
+type: ${name}
+version: ${version}
+core: ${version
+  .split('.')
+  .slice(0, 2)
+  .join('.')}.x
+
+description: "My component description"
+license: Apache-2.0
+author: "Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
+repository: "github:serverless/components"
+
+inputTypes:
+  myInput:
+    type: string
+    displayName: My input
+    description: My input string
+    example: hello-world
+
+outputTypes:
+  myOutput:
+    type: string
+    description: my output string
+`
+
+const readMeTemplate = `<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_HEADER) -->
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (TOC) -->
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_INPUT_TYPES) -->
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_OUTPUT_TYPES) -->
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_EXAMPLES) -->
+<!-- AUTO-GENERATED-CONTENT:END -->
+`
+
+const run = async () => {
+  if (await fs.exists(directory)) {
+    throw new Error(`Component "${name}" already exists.`)
+  }
+  await fs.ensureDir(directory)
+  await fs.writeJson(path.join(directory, 'package.json'), packageJsonTemplate, {
+    encoding: 'utf8',
+    spaces: 2
+  })
+  await fs.writeFile(path.join(directory, 'serverless.yml'), serverlessYmlTemplate, {
+    encoding: 'utf8'
+  })
+  await fs.writeFile(path.join(directory, 'README.md'), readMeTemplate, {
+    encoding: 'utf8'
+  })
+}
+
+run().catch((error) => {
+  console.error('ERROR:', error.message)
+})
+
+/* eslint-enable no-console */

--- a/scripts/create-component.js
+++ b/scripts/create-component.js
@@ -54,21 +54,55 @@ const readMeTemplate = `<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_HEADER) -->
 <!-- AUTO-GENERATED-CONTENT:END -->
 `
 
+const indexTemplate = `// ${name}
+
+const deploy = async () => {
+  return {}
+}
+
+const remove = async () => {
+  return {}
+}
+
+module.exports = {
+  deploy,
+  remove
+}
+`
+
+const indexTestTemplate = `// ${name}
+
+describe('#${name}', () => {
+  it('should have tests', async () => {
+    expect(false).toBe(true)
+  })
+})
+`
+
 const run = async () => {
   if (await fs.exists(directory)) {
     throw new Error(`Component "${name}" already exists.`)
   }
   await fs.ensureDir(directory)
-  await fs.writeJson(path.join(directory, 'package.json'), packageJsonTemplate, {
-    encoding: 'utf8',
-    spaces: 2
-  })
-  await fs.writeFile(path.join(directory, 'serverless.yml'), serverlessYmlTemplate, {
-    encoding: 'utf8'
-  })
-  await fs.writeFile(path.join(directory, 'README.md'), readMeTemplate, {
-    encoding: 'utf8'
-  })
+  await fs.ensureDir(path.join(directory, 'src'))
+  await Promise.all([
+    fs.writeJson(path.join(directory, 'package.json'), packageJsonTemplate, {
+      encoding: 'utf8',
+      spaces: 2
+    }),
+    fs.writeFile(path.join(directory, 'serverless.yml'), serverlessYmlTemplate, {
+      encoding: 'utf8'
+    }),
+    fs.writeFile(path.join(directory, 'README.md'), readMeTemplate, {
+      encoding: 'utf8'
+    }),
+    fs.writeFile(path.join(directory, 'src', 'index.js'), indexTemplate, {
+      encoding: 'utf8'
+    }),
+    fs.writeFile(path.join(directory, 'src', 'index.test.js'), indexTestTemplate, {
+      encoding: 'utf8'
+    })
+  ])
 }
 
 run().catch((error) => {


### PR DESCRIPTION
## What has been implemented?

This PR adds script that creates an empty component boilerplate to the registry.

## Steps to verify

Run `npm run create:component my-component` and the script should create a new component to the registry directory with name `my-component`.

The new component directory should contain package.json, readme.md, serverless.yml, src/index.js, and src/index.test.js files.

## Todos:

* [ ] Write tests
* [ ] Write / update documentation
* [ ] Run Prettier
