### PR TITLE
Update slack link to a redirect through serverless.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ components:
 [![dependencies](https://img.shields.io/david/serverless/serverless-components.svg)](https://www.npmjs.com/package/serverless-components)
 [![license](https://img.shields.io/npm/l/serverless-components.svg)](https://www.npmjs.com/package/serverless-components)
 
-[Website](http://www.serverless.com) • [Slack](https://join.slack.com/t/serverless-contrib/shared_invite/enQtNDI4MjM3MTIwMTgzLTE3Y2RkOTY1YTY1MTE0ZjA0YTBhYjA2NzNiMGUwODNlYWFjNjE3YTE1OGFjZjFiNmE1NTgzM2NjYzc5ZTNhM2Q) • [Newsletter](http://eepurl.com/b8dv4P) • [Forum](http://forum.serverless.com) • [Meetups](http://serverlessmeetups.com) • [Twitter](https://twitter.com/goserverless) • [We're Hiring](https://serverless.com/company/jobs/)
+[Website](http://www.serverless.com) • [Slack](https://serverless.com/slack) • [Newsletter](http://eepurl.com/b8dv4P) • [Forum](http://forum.serverless.com) • [Meetups](http://serverlessmeetups.com) • [Twitter](https://twitter.com/goserverless) • [We're Hiring](https://serverless.com/company/jobs/)
 
 Also please do join the _Components_ channel on our public [Serverless-Contrib Slack](https://serverless-contrib.slack.com/messages/C9U3RA55M) to continue the conversation.
 


### PR DESCRIPTION
This redirect will make it easier to manage this link in the future.
