### PR TITLE
Add Event Gateway Function component

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Also please do join the _Components_ channel on our public [Serverless-Contrib S
     * [s3-sync](./registry/s3-sync)
     * [s3-uploader](./registry/s3-uploader)
     * [s3-website-config](./registry/s3-website-config)
+    * [serverless-eventgateway-function](./registry/serverless-eventgateway-function)
     * [static-website](./registry/static-website)
     * [twilio-application](./registry/twilio-application)
     * [twilio-phone-number](./registry/twilio-phone-number)

--- a/registry/serverless-eventgateway-function/README.md
+++ b/registry/serverless-eventgateway-function/README.md
@@ -1,0 +1,52 @@
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_HEADER) -->
+# Serverless Eventgateway Function
+
+Manages Event Gateway function registrations
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (TOC) -->
+- [Input Types](#input-types)
+- [Output Types](#output-types)
+- [Example](#example)
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_INPUT_TYPES) -->
+## Input Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **space**| `string` | The Event Gateway space which should be used
+| **url**| `string`<br/>*required* | The Event Gateway URL
+| **accessKey**| `string`<br/>*required* | The access key used to authenticate with the hosted Event Gateway
+| **functionId**| `string`<br/>*required* | The function id which is used to register the function
+| **functionType**| `string`<br/>*required* | The function type
+| **provider**| `object`<br/>*required* | Function related provider specification
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_OUTPUT_TYPES) -->
+## Output Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **functionId**| `string` | The function id which is used to register the function
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_EXAMPLES) -->
+## Example
+```yml
+type: my-application
+components:
+  myServerlessEventgatewayFunction:
+    type: serverless-eventgateway-function
+    inputs:
+      space: acme-marketing-space
+      url: 'http://localhost'
+      accessKey: s0m34c355k3y
+      functionId: sendEmail
+      functionType: awslambda
+      provider:
+        arn: 'arn:aws:lambda:us-east-1:12345:function:example'
+        region: us-east-1
+
+```
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/registry/serverless-eventgateway-function/package-lock.json
+++ b/registry/serverless-eventgateway-function/package-lock.json
@@ -1,0 +1,85 @@
+{
+  "name": "@serverless-components/serverless-eventgateway-function",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@serverless/event-gateway-sdk": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@serverless/event-gateway-sdk/-/event-gateway-sdk-0.10.2.tgz",
+      "integrity": "sha512-CgbeAqXUWoDnNW152tTY6VkMeTpL0jcl87SApflIdUV8dnSsmiBuEB9e/gqjhXW/RsD0orYr0j3yxe/nRxaZ3w==",
+      "requires": {
+        "isomorphic-fetch": "^2.2.1",
+        "url-parse": "^1.1.9"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "querystringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "url-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    }
+  }
+}

--- a/registry/serverless-eventgateway-function/package.json
+++ b/registry/serverless-eventgateway-function/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@serverless-components/serverless-eventgateway-function",
+  "version": "0.2.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "@serverless/event-gateway-sdk": "^0.10.2"
+  }
+}

--- a/registry/serverless-eventgateway-function/serverless.yml
+++ b/registry/serverless-eventgateway-function/serverless.yml
@@ -1,0 +1,53 @@
+type: serverless-eventgateway-function
+version: 0.2.0
+core: 0.2.x
+
+description: "Manages Event Gateway function registrations"
+license: Apache-2.0
+author: "Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
+repository: "github:serverless/components"
+
+inputTypes:
+  url:
+    type: string
+    required: true
+    displayName: URL
+    description: The Event Gateway URL
+    example: http://localhost
+  space:
+    type: string
+    default: default
+    displayName: Space
+    description: The Event Gateway space which should be used
+    example: acme-marketing-space
+  accessKey:
+    type: string
+    required: true
+    displayName: Access Key
+    description: The access key used to authenticate with the hosted Event Gateway
+    example: s0m34c355k3y
+  functionId:
+    type: string
+    required: true
+    displayName: Function ID
+    description: The function id which is used to register the function
+    example: sendEmail
+  # NOTE: we might want to switch back to `type` once the raml-validate package is fixed
+  # see: https://github.com/mulesoft-labs/node-raml-validate/pull/7
+  functionType:
+    type: string
+    required: true
+    displayName: Function type
+    description: The function type
+    example: awslambda
+  provider:
+    type: object
+    required: true
+    displayName: Provider
+    description: Function related provider specification
+    example: { arn: 'arn:aws:lambda:us-east-1:12345:function:example', region: 'us-east-1' }
+
+outputTypes:
+  functionId:
+    type: string
+    description: The function id which is used to register the function

--- a/registry/serverless-eventgateway-function/src/index.js
+++ b/registry/serverless-eventgateway-function/src/index.js
@@ -1,0 +1,42 @@
+const { createFunction, updateFunction, deleteFunction } = require('./utils')
+
+// "public" functions
+async function deploy(inputs, context) {
+  const { functionId, functionType, url } = inputs
+
+  let funcObj
+  if (!Object.keys(context.state).length) {
+    context.log(`Registering function "${functionId}" at Event Gateway "${url}"...`)
+    funcObj = await createFunction(inputs)
+  } else {
+    context.log(
+      `Updating function registration for function "${functionId}" at Event Gateway "${url}"...`
+    )
+    funcObj = await updateFunction(inputs)
+  }
+
+  const outputs = { functionId }
+  const state = { ...funcObj, functionType, url }
+
+  context.saveState(state)
+
+  return outputs
+}
+
+async function remove(inputs, context) {
+  const { functionId, url } = context.state
+
+  context.log(
+    `Removing function registration for function  "${functionId}" from Event Gateway "${url}"...`
+  )
+
+  await deleteFunction({ ...context.state, accessKey: inputs.accessKey })
+
+  context.saveState()
+  return {}
+}
+
+module.exports = {
+  deploy,
+  remove
+}

--- a/registry/serverless-eventgateway-function/src/index.test.js
+++ b/registry/serverless-eventgateway-function/src/index.test.js
@@ -1,0 +1,102 @@
+const { createFunction, updateFunction, deleteFunction } = require('./utils')
+const egFunctionComponent = require('./index')
+
+jest.mock('./utils/createFunction')
+jest.mock('./utils/updateFunction')
+jest.mock('./utils/deleteFunction')
+
+createFunction.mockImplementation(() =>
+  Promise.resolve({
+    space: 'my-space',
+    functionId: 'myFunction',
+    provider: {
+      arn: 'arn:aws:lambda:us-east-1:12345:function:my-function',
+      region: 'us-east-1'
+    },
+    metadata: {}
+  })
+)
+updateFunction.mockImplementation(() =>
+  Promise.resolve({
+    space: 'my-space',
+    functionId: 'myFunction',
+    provider: {
+      arn: 'arn:aws:lambda:us-east-1:12345:function:my-function',
+      region: 'eu-central-1'
+    },
+    metadata: {}
+  })
+)
+deleteFunction.mockImplementation(() => Promise.resolve(true))
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('serverless-eventgateway-function tests', () => {
+  let inputs
+  let context
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      functionId: 'myFunction',
+      functionType: 'awslambda',
+      provider: { arn: 'arn:aws:lambda:us-east-1:12345:function:my-function', region: 'us-east-1' }
+    }
+    context = {
+      state: {
+        ...inputs
+      },
+      log: jest.fn(),
+      saveState: jest.fn()
+    }
+  })
+
+  describe('when running "deploy"', () => {
+    it('should create a new function registration at the Event Gateway', async () => {
+      // empty state --> function is not yet registered
+      context.state = {}
+
+      const outputs = await egFunctionComponent.deploy(inputs, context)
+
+      const expectedState = { ...inputs, metadata: {} }
+      delete expectedState.accessKey
+
+      expect(outputs).toEqual({ functionId: 'myFunction' })
+      expect(createFunction).toBeCalledWith(inputs)
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toBeCalledWith(expectedState)
+    })
+
+    it('should update an existing function registration at the Event Gateway', async () => {
+      // changing some function provider values
+      inputs.provider.region = 'eu-central-1'
+
+      const outputs = await egFunctionComponent.deploy(inputs, context)
+
+      const expectedState = { ...context.state, metadata: {} }
+      delete expectedState.accessKey
+
+      expect(outputs).toEqual({ functionId: 'myFunction' })
+      expect(updateFunction).toBeCalledWith(inputs)
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toBeCalledWith(expectedState)
+    })
+  })
+
+  describe('when running "remove"', () => {
+    it('should remove the function registration from the Event Gateway', async () => {
+      const outputs = await egFunctionComponent.remove(inputs, context)
+
+      expect(outputs).toEqual({})
+      expect(deleteFunction).toBeCalledWith({ ...context.state, accessKey: inputs.accessKey })
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/registry/serverless-eventgateway-function/src/utils/createFunction.js
+++ b/registry/serverless-eventgateway-function/src/utils/createFunction.js
@@ -1,0 +1,10 @@
+const SDK = require('@serverless/event-gateway-sdk')
+
+async function createFunction(inputs) {
+  const { url, space, accessKey, functionId, functionType, provider } = inputs
+  const eg = new SDK({ url, space, accessKey })
+
+  return eg.createFunction({ functionId, type: functionType, provider })
+}
+
+module.exports = createFunction

--- a/registry/serverless-eventgateway-function/src/utils/createFunction.test.js
+++ b/registry/serverless-eventgateway-function/src/utils/createFunction.test.js
@@ -1,0 +1,44 @@
+const createFunction = require('./createFunction')
+
+const mockCreateFunction = jest.fn().mockResolvedValue({
+  space: 'my-space',
+  functionId: 'myFunction',
+  provider: {
+    arn: 'arn:aws:lambda:us-east-1:12345:function:my-function',
+    region: 'us-east-1'
+  },
+  metadata: {}
+})
+
+jest.mock('@serverless/event-gateway-sdk', () =>
+  jest.fn().mockImplementation(() => ({
+    createFunction: mockCreateFunction
+  }))
+)
+
+describe('#createFunction()', () => {
+  it('should register a function at the Event Gateway', async () => {
+    const inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      functionId: 'myFunction',
+      functionType: 'awslambda',
+      provider: { arn: 'arn:aws:lambda:us-east-1:12345:function:my-function', region: 'us-east-1' }
+    }
+
+    const res = await createFunction(inputs)
+
+    const { functionId, functionType, provider } = inputs
+    expect(mockCreateFunction).toBeCalledWith({ functionId, type: functionType, provider })
+    expect(res).toEqual({
+      space: 'my-space',
+      functionId: 'myFunction',
+      provider: {
+        arn: 'arn:aws:lambda:us-east-1:12345:function:my-function',
+        region: 'us-east-1'
+      },
+      metadata: {}
+    })
+  })
+})

--- a/registry/serverless-eventgateway-function/src/utils/deleteFunction.js
+++ b/registry/serverless-eventgateway-function/src/utils/deleteFunction.js
@@ -1,0 +1,11 @@
+const SDK = require('@serverless/event-gateway-sdk')
+
+async function deleteFunction(inputs) {
+  const { url, space, accessKey, functionId } = inputs
+  const eg = new SDK({ url, space, accessKey })
+
+  await eg.deleteFunction({ functionId })
+  return true
+}
+
+module.exports = deleteFunction

--- a/registry/serverless-eventgateway-function/src/utils/deleteFunction.test.js
+++ b/registry/serverless-eventgateway-function/src/utils/deleteFunction.test.js
@@ -1,0 +1,28 @@
+const deleteFunction = require('./deleteFunction')
+
+const mockDeleteFunction = jest.fn()
+
+jest.mock('@serverless/event-gateway-sdk', () =>
+  jest.fn().mockImplementation(() => ({
+    deleteFunction: mockDeleteFunction
+  }))
+)
+
+describe('#deleteFunction()', () => {
+  it('should delete a function registration from the Event Gateway', async () => {
+    const inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      functionId: 'myFunction',
+      functionType: 'awslambda',
+      provider: { arn: 'arn:aws:lambda:us-east-1:12345:function:my-function', region: 'us-east-1' }
+    }
+
+    const res = await deleteFunction(inputs)
+
+    const { functionId } = inputs
+    expect(mockDeleteFunction).toBeCalledWith({ functionId })
+    expect(res).toEqual(true)
+  })
+})

--- a/registry/serverless-eventgateway-function/src/utils/index.js
+++ b/registry/serverless-eventgateway-function/src/utils/index.js
@@ -1,0 +1,9 @@
+const createFunction = require('./createFunction')
+const updateFunction = require('./updateFunction')
+const deleteFunction = require('./deleteFunction')
+
+module.exports = {
+  createFunction,
+  updateFunction,
+  deleteFunction
+}

--- a/registry/serverless-eventgateway-function/src/utils/updateFunction.js
+++ b/registry/serverless-eventgateway-function/src/utils/updateFunction.js
@@ -1,0 +1,10 @@
+const SDK = require('@serverless/event-gateway-sdk')
+
+async function updateFunction(inputs) {
+  const { url, space, accessKey, functionId, functionType, provider } = inputs
+  const eg = new SDK({ url, space, accessKey })
+
+  return eg.updateFunction({ functionId, type: functionType, provider })
+}
+
+module.exports = updateFunction

--- a/registry/serverless-eventgateway-function/src/utils/updateFunction.test.js
+++ b/registry/serverless-eventgateway-function/src/utils/updateFunction.test.js
@@ -1,0 +1,44 @@
+const updateFunction = require('./updateFunction')
+
+const mockUpdateFunction = jest.fn().mockResolvedValue({
+  space: 'my-space',
+  functionId: 'myFunction',
+  provider: {
+    arn: 'arn:aws:lambda:us-east-1:12345:function:my-function',
+    region: 'us-east-1'
+  },
+  metadata: {}
+})
+
+jest.mock('@serverless/event-gateway-sdk', () =>
+  jest.fn().mockImplementation(() => ({
+    updateFunction: mockUpdateFunction
+  }))
+)
+
+describe('#updateFunction()', () => {
+  it('should update the function registered at the Event Gateway', async () => {
+    const inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      functionId: 'myFunction',
+      functionType: 'awslambda',
+      provider: { arn: 'arn:aws:lambda:us-east-1:12345:function:my-function', region: 'us-east-1' }
+    }
+
+    const res = await updateFunction(inputs)
+
+    const { functionId, functionType, provider } = inputs
+    expect(mockUpdateFunction).toBeCalledWith({ functionId, type: functionType, provider })
+    expect(res).toEqual({
+      space: 'my-space',
+      functionId: 'myFunction',
+      provider: {
+        arn: 'arn:aws:lambda:us-east-1:12345:function:my-function',
+        region: 'us-east-1'
+      },
+      metadata: {}
+    })
+  })
+})


### PR DESCRIPTION
This adds the `serverless-eventgateway-function` component to the registry.

Basic usage looks like this:

```yml
# serverless.yml

type: eg-function-test

components:
  eventGatewayFunction:
    type: serverless-eventgateway-function
    inputs:
      space: acme-marketing-space
      accessKey: s0m34c355k3y
      url: http://localhost
      functionId: sendEmail
      functionType: awslambda
      provider:
        arn: arn:aws:lambda:us-east-1:12345:function:example
        region: us-east-1
```