### PR TITLE
Aws elb component

### DIFF
--- a/registry/aws-elb/README.md
+++ b/registry/aws-elb/README.md
@@ -1,0 +1,37 @@
+# AWS ELB
+
+Provision AWS application and network loadbalancer with serverless components
+
+- Input Types
+- Output Types
+- Example
+
+## Input Types
+
+| Name	  |                   Type |                      Description |
+| ------ | ------ |------ |
+|name	|                     string| 	                     Name of the ELB |
+elbtype        |              string            |              Type of ELB application or network |
+subnets	       |   array of strings	       |     List of subnets for the ELB |
+securityGroups |        array of strings        |        List of security groups for the ELB |
+scheme         |            string             |            Scheme of the ELB internet-facing or internal |
+ipAddressType  |        string                  |        IpAddressType ipv4 or dualstack |
+subnetMappings |             Array of SubnetMapping objects|   SubnetMapping for the ELB. Must be specified for network type.|
+tags           |             Array of key value pairs. |        Tags to be attached with the ELB.|
+
+## Output Types
+
+|Name|	        Type |	Description|
+| ------ | ------ |------ |
+|loadBalancerArn |	string|	Amanzon resource name (ARN) of the ELB created.|
+
+## EXAMPLE
+```
+type: my-application
+components:
+  myELB:
+    type: aws-elb
+    inputs:
+      name: my-project-elb1
+      subnets: ["subnet-0b8da2094908e1b23","subnet-02579e43d5262dfeb"]
+      securityGroups: ["sg-06f16046d66441c1c"]

--- a/registry/aws-elb/README.md
+++ b/registry/aws-elb/README.md
@@ -32,6 +32,6 @@ components:
   myELB:
     type: aws-elb
     inputs:
-      name: my-project-elb1
+      name: my-project-elb
       subnets: ["subnet-0b8da2094908e1b23","subnet-02579e43d5262dfeb"]
       securityGroups: ["sg-06f16046d66441c1c"]

--- a/registry/aws-elb/package-lock.json
+++ b/registry/aws-elb/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "@serverless-components/aws-elb",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-sdk": {
+      "version": "2.315.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.315.0.tgz",
+      "integrity": "sha512-GqKve4H6DCpPG7zm5L5S5Is50AnRHbBei1kKFhUKj4KfB7lV/0OIVfjob2Jh4a6I4I1tqnTcdTXGlhBccS1f3w==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.1.0",
+        "xml2js": "0.4.19"
+      }
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
+      }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.1",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/registry/aws-elb/package.json
+++ b/registry/aws-elb/package.json
@@ -1,12 +1,12 @@
 {
-    "name": "@serverless-components/aws-elb",
-    "version": "0.2.0",
-    "private": true,
-    "main": "dist/index.js",
-    "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "dependencies": {
-      "aws-sdk": "^2.224.1"
-    }
+  "name": "@serverless-components/aws-elb",
+  "version": "0.2.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.224.1"
   }
+}

--- a/registry/aws-elb/package.json
+++ b/registry/aws-elb/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "@serverless-components/aws-elb",
+    "version": "0.2.0",
+    "private": true,
+    "main": "dist/index.js",
+    "scripts": {
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "dependencies": {
+      "aws-sdk": "^2.224.1"
+    }
+  }

--- a/registry/aws-elb/serverless.yml
+++ b/registry/aws-elb/serverless.yml
@@ -17,7 +17,7 @@ inputTypes:
   elbtype:
     type: string
     required: false
-    description: The type of load balancer. The default is application. network
+    description: The type of load balancer. The default is application. network is another option.
   subnets:
     type: array
     required: false
@@ -33,11 +33,11 @@ inputTypes:
   ipAddressType:
     type: string
     required: false
-    description: The type of IP addresses used by the subnets for load balancer. Valid values are ipv4 and dualstack. Internal load balancers                   must use ipv4.
+    description: The type of IP addresses used by the subnets for load balancer. Valid values are ipv4 and dualstack. Internal load balancers must use ipv4.
   subnetMappings:
     type: array
     required: false
-    description: The IDs of the public subnets. You can specify only one subnet per Availability Zone. Either subnets or subnet mappings must                  be specified .
+    description: The IDs of the public subnets. You can specify only one subnet per Availability Zone. Either subnets or subnet mappings must be specified.
   tags:
     type: array
     required: false

--- a/registry/aws-elb/serverless.yml
+++ b/registry/aws-elb/serverless.yml
@@ -1,0 +1,49 @@
+type: aws-elb
+version: 0.2.0
+core: 0.2.x
+
+description: "Provision AWS ELB with serverless components"
+license: Apache-2.0
+author: "Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
+repository: "github:serverless/components"
+
+inputTypes:
+  name:
+    type: string
+    required: true
+    displayName: ELB Name
+    description: The name of the ELB. Name must be in AWS region.
+    example: myelb
+  elbtype:
+    type: string
+    required: false
+    description: The type of load balancer. The default is application. network
+  subnets:
+    type: array
+    required: false
+    description: List of subnets for the ELB
+  securityGroups:
+    type: array
+    required: false
+    description: List of security groups to attach with the ELB.
+  scheme:
+    type: string
+    required: false
+    description: Type of loanbalancer. Valid values are internet-facing and internal.
+  ipAddressType:
+    type: string
+    required: false
+    description: The type of IP addresses used by the subnets for load balancer. Valid values are ipv4 and dualstack. Internal load balancers                   must use ipv4.
+  subnetMappings:
+    type: array
+    required: false
+    description: The IDs of the public subnets. You can specify only one subnet per Availability Zone. Either subnets or subnet mappings must                  be specified .
+  tags:
+    type: array
+    required: false
+    description: One or more tags to assign to the load balancer.
+
+outputTypes:
+  loadBalancerArn:
+    type: string
+    description: ARN of the ELB created

--- a/registry/aws-elb/src/index.js
+++ b/registry/aws-elb/src/index.js
@@ -1,0 +1,126 @@
+/* eslint-disable no-console */
+
+const AWS = require('aws-sdk')
+
+const ELBv2 = new AWS.ELBv2({ region: process.env.AWS_DEFAULT_REGION || 'us-east-1' })
+
+const setSecurityGroup = async (inputs,arn) => {
+      var params = {
+           LoadBalancerArn: arn,
+           SecurityGroups: inputs.securityGroups };
+      ELBv2.setSecurityGroups(params, function(err, data) {
+         if (err) console.log(err, err.stack);
+         else     console.log(data);
+      });
+}
+const setSubnets = async (inputs,arn) => {
+      var params = {
+           LoadBalancerArn: arn,
+           Subnets: inputs.subnets };
+      ELBv2.setSubnets(params, function(err, data) {
+         if (err) console.log(err, err.stack);
+         else     console.log(data);
+      });
+}
+
+const setIpAddressType = async (inputs,arn) => {
+      var params = {
+           LoadBalancerArn: arn,
+           IpAddressType: inputs.ipAddressType};
+      ELBv2.setIpAddressType(params, function(err, data) {
+         if (err) console.log(err, err.stack);
+         else     console.log(data);
+      });
+}
+const createELB = async (inputs) => {
+
+    var params = {
+     Name: inputs.name,
+     Subnets: inputs.subnets,
+     SecurityGroups: inputs.securityGroups,
+     IpAddressType: inputs.ipAddressType,
+     Scheme: inputs.scheme,
+     Type: inputs.elbtype,
+     SubnetMappings: inputs.subnetMappings,
+     Tags: inputs.tags
+     };
+    const elb = await ELBv2.createLoadBalancer(params, function(err, data) {
+    if (err)  console.log(err, err.stack);
+     else     return data;
+    }).promise();
+    return elb
+}
+const deploy = async (inputs, context) => {
+
+    const { state } = context
+    if (!state.name && inputs.name) {
+    context.log(`Creating ELb: '${inputs.name}'`)
+    const elb = await createELB(inputs)
+    context.saveState({ name: inputs.name,
+                    subnets: inputs.subnets,
+                    securityGroups: inputs.securityGroups,
+                    ipAddressType: elb.LoadBalancers[0]["IpAddressType"],
+                    scheme: elb.LoadBalancers[0]["Scheme"],
+                    elbtype: elb.LoadBalancers[0]["Type"],
+                    subnetMappings: inputs.subnetMappings,
+                    arn: elb.LoadBalancers[0]["LoadBalancerArn"]
+                    })
+     return { arn: state.arn }
+  }
+    if (state.name !== inputs.name || state.elbtype !== inputs.elbtype && inputs.elbtype || state.scheme !== inputs.scheme && inputs.scheme)
+   {
+      context.log("changing name or elbtype or scheme forces new resource")
+      await remove(inputs,context)
+      context.log(`Creating ELb: '${inputs.name}'`)
+      const elb = await createELB(inputs)
+      context.saveState({ name: inputs.name,
+                    subnets: inputs.subnets,
+                    securityGroups: inputs.securityGroups,
+                    ipAddressType: elb.LoadBalancers[0]["IpAddressType"],
+                    scheme: elb.LoadBalancers[0]["Scheme"],
+                    elbtype: elb.LoadBalancers[0]["Type"],
+                    subnetMappings: inputs.subnetMappings,
+                    arn: elb.LoadBalancers[0]["LoadBalancerArn"]
+                    })
+       return { arn: state.arn }
+   }
+   if (state.securityGroups !== inputs.securityGroups) {
+    await setSecurityGroup(inputs, state.arn)
+    context.log(`security group updated ELB: '${state.name}'`)
+    state.securityGroups = inputs.securityGroups
+   }
+ if (state.subnets !== inputs.subnets || state.subnetMappings !== inputs.subnetMappings) {
+    await setSubnets(inputs, state.arn)
+    state.subnets = inputs.subnets
+    context.log(`subnets updated ELB: '${state.name}'`)
+    state.subnetMappings = inputs.subnetMappings
+  }
+ if (state.ipAddressType !== inputs.ipAddressType && inputs.ipAddressType) {
+    await setIpAddressType(inputs, state.arn)
+    context.log(`ipAddressType updated ELB: '${state.name}'`)
+    state.ipAddressType = inputs.ipAddressType
+   }
+ return { arn: state.arn }
+}
+
+const deleteELB = async (arn) => {
+
+  var params = { LoadBalancerArn: arn };
+  ELBv2.deleteLoadBalancer(params, function(err, data) {
+     if (err) console.log(err, err.stack);
+    else      console.log(data);
+ });
+}
+
+const remove = async (inputs, context) => {
+
+ const { state } = context
+ context.log(`Deleting ELB: '${state.name}'`)
+ await deleteELB(state.arn)
+ context.saveState()
+ return {}
+}
+module.exports = {
+    deploy,
+    remove
+}  

--- a/registry/aws-elb/src/index.js
+++ b/registry/aws-elb/src/index.js
@@ -6,16 +6,16 @@ const ELBv2 = new AWS.ELBv2({ region: process.env.AWS_DEFAULT_REGION || 'us-east
 
 function compareArrays(array1, array2)  {
 
-    array1 = array1.slice();
-    array2 = array2.slice();
-  if (array1.length === array2.length) {
-      array1.sort();
-      array2.sort();                         
-      return array1.every(function(item, index) {
-          return item === array2[index];       
-      });                                      
-  }
-  return false;
+      array1 = array1.slice();
+      array2 = array2.slice();
+    if (array1.length === array2.length) {
+        array1.sort();
+        array2.sort();                         
+        return array1.every(function(item, index) {
+            return item === array2[index];       
+        });                                      
+    }
+    return false;
 
 }
 
@@ -23,28 +23,25 @@ const setSecurityGroup = async (inputs,arn) => {
       var params = {
            LoadBalancerArn: arn,
            SecurityGroups: inputs.securityGroups };
-      ELBv2.setSecurityGroups(params, function(err, data) {
+      ELBv2.setSecurityGroups(params, function(err) {
          if (err) console.log(err, err.stack);
-         else     console.log(data);
       });
 }
 const setSubnets = async (inputs,arn) => {
       var params = {
            LoadBalancerArn: arn,
            Subnets: inputs.subnets };
-      ELBv2.setSubnets(params, function(err, data) {
+      ELBv2.setSubnets(params, function(err) {
          if (err) console.log(err, err.stack);
-         else     console.log(data);
       });
 }
 
-const setIpAddressType = async (inputs,arn) => {
+const setIpAddressType = async (inputs, arn) => {
       var params = {
            LoadBalancerArn: arn,
            IpAddressType: inputs.ipAddressType};
-      ELBv2.setIpAddressType(params, function(err, data) {
+      ELBv2.setIpAddressType(params, function(err) {
          if (err) console.log(err, err.stack);
-         else     console.log(data);
       });
 }
 const createELB = async (inputs,context) => {
@@ -64,20 +61,20 @@ const createELB = async (inputs,context) => {
      else     return data;
     }).promise();
     context.saveState({ name: inputs.name,
-        subnets: inputs.subnets,
-        securityGroups: inputs.securityGroups,
-        ipAddressType: elb.LoadBalancers[0]["IpAddressType"],
-        scheme: elb.LoadBalancers[0]["Scheme"],
-        elbtype: elb.LoadBalancers[0]["Type"],
-        subnetMappings: inputs.subnetMappings,
-        arn: elb.LoadBalancers[0]["LoadBalancerArn"]
-        })
+                    subnets: inputs.subnets,
+                    securityGroups: inputs.securityGroups,
+                    ipAddressType: elb.LoadBalancers[0]["IpAddressType"],
+                    scheme: elb.LoadBalancers[0]["Scheme"],
+                    elbtype: elb.LoadBalancers[0]["Type"],
+                    subnetMappings: inputs.subnetMappings,
+                    arn: elb.LoadBalancers[0]["LoadBalancerArn"]
+                    })
 
     return context.state.arn
 }
 const deploy = async (inputs, context) => {
 
-    const { state } = context
+    const state  = context.state
     if (!state.name && inputs.name) {
     context.log(`Creating ELb: '${inputs.name}'`)
     const arn = await createELB(inputs,context)
@@ -91,12 +88,12 @@ const deploy = async (inputs, context) => {
       const arn = await createELB(inputs,context)
        return { arn: arn }
    }
-   if (!compareArrays(state.securityGroups,inputs.securityGroups)) {
+ if (!compareArrays(state.securityGroups,inputs.securityGroups)) {
     await setSecurityGroup(inputs, state.arn)
     context.log(`security group updated ELB: '${state.name}'`)
     state.securityGroups = inputs.securityGroups
    }
-   if (!compareArrays(state.subnets,inputs.subnets) || inputs.subnetMappings && !compareArrays(state.subnetMappings,inputs.subnetMappings)) {
+ if (inputs.subnets && !compareArrays(state.subnets,inputs.subnets) || inputs.subnetMappings && !compareArrays(state.subnetMappings,inputs.subnetMappings)) {
     await setSubnets(inputs, state.arn)
     state.subnets = inputs.subnets
     context.log(`subnets updated ELB: '${state.name}'`)
@@ -113,9 +110,8 @@ const deploy = async (inputs, context) => {
 const deleteELB = async (arn) => {
 
   var params = { LoadBalancerArn: arn };
-  ELBv2.deleteLoadBalancer(params, function(err, data) {
+  ELBv2.deleteLoadBalancer(params, function(err) {
      if (err) console.log(err, err.stack);
-    else      console.log(data);
  });
 }
 

--- a/registry/aws-elb/src/index.test.js
+++ b/registry/aws-elb/src/index.test.js
@@ -12,6 +12,8 @@ jest.mock('aws-sdk', () => {
                                    IpAddressType: 'ipv4'} ] }
                                )}),
     deleteLoadBalancerMock: jest.fn().mockReturnValue({}),
+    setSecurityGroupsMock: jest.fn().mockReturnValue({}),
+    setSubnetsMock: jest.fn().mockReturnValue({})
 }
 
   const ELBv2 = {
@@ -20,6 +22,12 @@ jest.mock('aws-sdk', () => {
     }),
     deleteLoadBalancer: (obj) => (
       mocks.deleteLoadBalancerMock(obj)
+    ),
+    setSecurityGroups: (obj) => (
+      mocks.setSecurityGroupsMock(obj)
+    ),
+    setSubnets: (obj) => (
+      mocks.setSubnetsMock(obj)
     )
 }
 
@@ -32,7 +40,8 @@ jest.mock('aws-sdk', () => {
 afterEach(() => {
   AWS.mocks.createLoadBalancerMock.mockClear()
   AWS.mocks.deleteLoadBalancerMock.mockClear()
-  
+  AWS.mocks.setSecurityGroupsMock.mockClear()
+  AWS.mocks.setSubnetsMock.mockClear()
 })
 
 afterAll(() => {
@@ -76,5 +85,59 @@ describe('aws-elb tests', () => {
     expect(AWS.mocks.deleteLoadBalancerMock).toHaveBeenCalledTimes(1)
     expect(contextMock.saveState).toHaveBeenCalledTimes(1)
     expect(outputs).toEqual({})
+  })
+  it('should update security group an existing ELB', async () => {
+    const contextMock = {
+      state: {
+        name: 'my-project-elb',
+         arn: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107',
+        subnets: ["subnet-0b8da2094908e1b23","subnet-01a46af43b2c5e16c"],
+        securityGroups: ["sg-03fa0c02886c183d4"]
+
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+    const inputs = {
+      name: 'my-project-elb',
+      arn: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107',
+     subnets: ["subnet-0b8da2094908e1b23","subnet-01a46af43b2c5e16c"],
+     securityGroups: ["sg-06f16046d66441c1c"]
+    }
+    const {arn} = await ELBComponent.deploy(inputs, contextMock)
+
+    expect(AWS.ELBv2).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.createLoadBalancerMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.deleteLoadBalancerMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.setSecurityGroupsMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(0)
+    expect(arn).toEqual('arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107')
+    expect(contextMock.state.securityGroups).toEqual(inputs.securityGroups)
+  })
+  it('should update subnets of an existing ELB', async () => {
+    const contextMock = {
+      state: {
+        name: 'my-project-elb',
+         arn: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107',
+        subnets: ["subnet-0b8da2094908e1b23","subnet-01a46af43b2c5e16c"],
+        securityGroups: ["sg-03fa0c02886c183d4"]
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+    const inputs = {
+      name: 'my-project-elb',
+      arn: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107',
+     subnets: ["subnet-0b8da2094908e1b23","subnet-02579e43d5262dfeb"],
+     securityGroups: ["sg-03fa0c02886c183d4"]
+    }
+    const {arn} = await ELBComponent.deploy(inputs, contextMock)
+    expect(AWS.ELBv2).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.createLoadBalancerMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.deleteLoadBalancerMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.setSubnetsMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(0)
+    expect(arn).toEqual('arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107')
+    expect(contextMock.state.subnets).toEqual(inputs.subnets)
   })
 })

--- a/registry/aws-elb/src/index.test.js
+++ b/registry/aws-elb/src/index.test.js
@@ -145,7 +145,7 @@ describe('aws-elb tests', () => {
     expect(arn).toEqual('arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107')
     expect(contextMock.state.subnets).toEqual(inputs.subnets)
   })
-  it('should update  of an existing ELB', async () => {
+  it('should update ipAddressType of an existing ELB', async () => {
     const contextMock = {
       state: {
         name: 'my-project-elb',

--- a/registry/aws-elb/src/index.test.js
+++ b/registry/aws-elb/src/index.test.js
@@ -186,7 +186,7 @@ describe('aws-elb tests', () => {
       name: 'my-project-elb1',
       subnets: ["subnet-0b8da2094908e1b23","subnet-02579e43d5262dfeb"],
     }
-    const {arn} = await ELBComponent.deploy(inputs, contextMock)
+    await ELBComponent.deploy(inputs, contextMock)
     expect(AWS.ELBv2).toHaveBeenCalledTimes(1)
     expect(AWS.mocks.createLoadBalancerMock).toHaveBeenCalledTimes(1)
     expect(AWS.mocks.deleteLoadBalancerMock).toHaveBeenCalledTimes(1)

--- a/registry/aws-elb/src/index.test.js
+++ b/registry/aws-elb/src/index.test.js
@@ -3,7 +3,7 @@ const ELBComponent = require('./index')
 
 jest.mock('aws-sdk', () => {
   const mocks = {
-    createLoadBalancerMock: jest.fn().mockImplementation((params) => {
+    createLoadBalancerMock: jest.fn().mockImplementation(() => {
       return Promise.resolve({ LoadBalancers:
                                [ { LoadBalancerArn: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107',
                                    LoadBalancerName: 'my-project-elb',

--- a/registry/aws-elb/src/index.test.js
+++ b/registry/aws-elb/src/index.test.js
@@ -1,0 +1,80 @@
+const AWS = require('aws-sdk')
+const ELBComponent = require('./index')
+
+jest.mock('aws-sdk', () => {
+  const mocks = {
+    createLoadBalancerMock: jest.fn().mockImplementation((params) => {
+      return Promise.resolve({ LoadBalancers:
+                               [ { LoadBalancerArn: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107',
+                                   LoadBalancerName: 'my-project-elb',
+                                   Scheme: 'internet-facing',
+                                   Type: 'application',
+                                   IpAddressType: 'ipv4'} ] }
+                               )}),
+    deleteLoadBalancerMock: jest.fn().mockReturnValue({}),
+}
+
+  const ELBv2 = {
+    createLoadBalancer: (obj) => ({
+      promise: () => mocks.createLoadBalancerMock(obj)
+    }),
+    deleteLoadBalancer: (obj) => (
+      mocks.deleteLoadBalancerMock(obj)
+    )
+}
+
+  return {
+    mocks,
+    ELBv2: jest.fn().mockImplementation(() => ELBv2)
+  }
+})
+
+afterEach(() => {
+  AWS.mocks.createLoadBalancerMock.mockClear()
+  AWS.mocks.deleteLoadBalancerMock.mockClear()
+  
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('aws-elb tests', () => {
+  it('should deploy an ELB component with no errors', async () => {
+    const contextMock = {
+      state: {},
+      archive: {},
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      name: 'my-project-elb',
+      subnets: ["subnet-0b8da2094908e1b23","subnet-01a46af43b2c5e16c"]
+    }
+
+    const {arn} = await ELBComponent.deploy(inputs, contextMock)
+
+    expect(AWS.ELBv2).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.createLoadBalancerMock).toHaveBeenCalledTimes(1)
+    expect(arn).toEqual('arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107')
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+  })
+  it('should remove an existing ELB', async () => {
+    const contextMock = {
+      state: {
+        name: 'my-project-elb',
+         arn: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-project-elb/b8aeaf4b672f5107'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+    const inputs = {}
+    const outputs = await ELBComponent.remove(inputs, contextMock)
+
+    expect(AWS.ELBv2).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.deleteLoadBalancerMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+    expect(outputs).toEqual({})
+  })
+})


### PR DESCRIPTION
## What has been implemented?
aws-elb component which allows creating an application as well as network load balancers.
Closes #276 

## Steps to verify
Use the example provided in README.md file, update the values of subnets and security groups.
components deploy - creates new ELB
components remove- deletes the ELB.
deploy can also be used to edit mutable ELB properties subnets, securityGroups, ipAddressType and subnetMappings.
Attempts to change im-mutable properties like scheme results in the creation of new ELB and deletion of existing one.

## Todos:

1.  Write tests cases.
