### PR TITLE
Add Event Gateway Event Type component

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Also please do join the _Components_ channel on our public [Serverless-Contrib S
     * [s3-sync](./registry/s3-sync)
     * [s3-uploader](./registry/s3-uploader)
     * [s3-website-config](./registry/s3-website-config)
+    * [serverless-eventgateway-event-type](./registry/serverless-eventgateway-event-type)
     * [static-website](./registry/static-website)
     * [twilio-application](./registry/twilio-application)
     * [twilio-phone-number](./registry/twilio-phone-number)

--- a/registry/serverless-eventgateway-event-type/README.md
+++ b/registry/serverless-eventgateway-event-type/README.md
@@ -1,0 +1,48 @@
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_HEADER) -->
+# Serverless Eventgateway Event Type
+
+Manages Event Gateway Event Types
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (TOC) -->
+- [Input Types](#input-types)
+- [Output Types](#output-types)
+- [Example](#example)
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_INPUT_TYPES) -->
+## Input Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **space**| `string` | The Event Gateway space which should be used
+| **authorizerId**| `string` | The authorizer function id
+| **url**| `string`<br/>*required* | The Event Gateway URL
+| **accessKey**| `string`<br/>*required* | The access key used to authenticate with the hosted Event Gateway
+| **name**| `string`<br/>*required* | The event type name
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_OUTPUT_TYPES) -->
+## Output Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **name**| `string` | The event type name
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_EXAMPLES) -->
+## Example
+```yml
+type: my-application
+components:
+  myServerlessEventgatewayEventType:
+    type: serverless-eventgateway-event-type
+    inputs:
+      space: acme-marketing-space
+      authorizerId: authorizerFunction
+      url: 'http://localhost'
+      accessKey: s0m34c355k3y
+      name: user.created
+
+```
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/registry/serverless-eventgateway-event-type/package-lock.json
+++ b/registry/serverless-eventgateway-event-type/package-lock.json
@@ -1,0 +1,85 @@
+{
+  "name": "@serverless-components/serverless-eventgateway-event-type",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@serverless/event-gateway-sdk": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@serverless/event-gateway-sdk/-/event-gateway-sdk-0.10.2.tgz",
+      "integrity": "sha512-CgbeAqXUWoDnNW152tTY6VkMeTpL0jcl87SApflIdUV8dnSsmiBuEB9e/gqjhXW/RsD0orYr0j3yxe/nRxaZ3w==",
+      "requires": {
+        "isomorphic-fetch": "^2.2.1",
+        "url-parse": "^1.1.9"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "querystringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "url-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    }
+  }
+}

--- a/registry/serverless-eventgateway-event-type/package.json
+++ b/registry/serverless-eventgateway-event-type/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@serverless-components/serverless-eventgateway-event-type",
+  "version": "0.2.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "@serverless/event-gateway-sdk": "^0.10.2"
+  }
+}

--- a/registry/serverless-eventgateway-event-type/serverless.yml
+++ b/registry/serverless-eventgateway-event-type/serverless.yml
@@ -1,0 +1,44 @@
+type: serverless-eventgateway-event-type
+version: 0.2.0
+core: 0.2.x
+
+description: "Manages Event Gateway Event Types"
+license: Apache-2.0
+author: "Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
+repository: "github:serverless/components"
+
+inputTypes:
+  url:
+    type: string
+    required: true
+    displayName: URL
+    description: The Event Gateway URL
+    example: http://localhost
+  space:
+    type: string
+    default: default
+    displayName: Space
+    description: The Event Gateway space which should be used
+    example: acme-marketing-space
+  accessKey:
+    type: string
+    required: true
+    displayName: Access Key
+    description: The access key used to authenticate with the hosted Event Gateway
+    example: s0m34c355k3y
+  name:
+    type: string
+    required: true
+    displayName: Type
+    description: The event type name
+    example: user.created
+  authorizerId:
+    type: string
+    displayName: Authorizer ID
+    description: The authorizer function id
+    example: authorizerFunction
+
+outputTypes:
+  name:
+    type: string
+    description: The event type name

--- a/registry/serverless-eventgateway-event-type/src/index.js
+++ b/registry/serverless-eventgateway-event-type/src/index.js
@@ -1,0 +1,38 @@
+const { createEventType, updateEventType, deleteEventType } = require('./utils')
+
+// "public" functions
+async function deploy(inputs, context) {
+  const { name, url } = inputs
+
+  let eventTypeObj
+  if (!Object.keys(context.state).length) {
+    context.log(`Registering event type "${name}" at Event Gateway "${url}"...`)
+    eventTypeObj = await createEventType(inputs)
+  } else {
+    context.log(`Updating event type "${name}" at Event Gateway "${url}"...`)
+    eventTypeObj = await updateEventType(inputs)
+  }
+
+  const outputs = { name }
+  const state = { ...eventTypeObj, url }
+
+  context.saveState(state)
+
+  return outputs
+}
+
+async function remove(inputs, context) {
+  const { name, url } = context.state
+
+  context.log(`Removing event type "${name}" from Event Gateway "${url}"...`)
+
+  await deleteEventType({ ...context.state, accessKey: inputs.accessKey })
+
+  context.saveState()
+  return {}
+}
+
+module.exports = {
+  deploy,
+  remove
+}

--- a/registry/serverless-eventgateway-event-type/src/index.test.js
+++ b/registry/serverless-eventgateway-event-type/src/index.test.js
@@ -1,0 +1,95 @@
+const { createEventType, updateEventType, deleteEventType } = require('./utils')
+const egEventTypeComponent = require('./index')
+
+jest.mock('./utils/createEventType')
+jest.mock('./utils/updateEventType')
+jest.mock('./utils/deleteEventType')
+
+createEventType.mockImplementation(() =>
+  Promise.resolve({
+    space: 'my-space',
+    name: 'my.event',
+    authorizerId: 'authFunction',
+    metadata: {}
+  })
+)
+updateEventType.mockImplementation(() =>
+  Promise.resolve({
+    space: 'my-space',
+    name: 'my.event',
+    authorizerId: 'updatedAuthFunction',
+    metadata: {}
+  })
+)
+deleteEventType.mockImplementation(() => Promise.resolve(true))
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('serverless-eventgateway-event-type tests', () => {
+  let inputs
+  let context
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      name: 'my.event',
+      authorizerId: 'authFunction'
+    }
+    context = {
+      state: {
+        ...inputs
+      },
+      log: jest.fn(),
+      saveState: jest.fn()
+    }
+  })
+
+  describe('when running "deploy"', () => {
+    it('should create a new event type at the Event Gateway', async () => {
+      // empty state --> event type is not yet created
+      context.state = {}
+
+      const outputs = await egEventTypeComponent.deploy(inputs, context)
+
+      const expectedState = { ...inputs, metadata: {} }
+      delete expectedState.accessKey
+
+      expect(outputs).toEqual({ name: 'my.event' })
+      expect(createEventType).toBeCalledWith(inputs)
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toBeCalledWith(expectedState)
+    })
+
+    it('should update an existing event type at the Event Gateway', async () => {
+      // changing the authorizerId
+      inputs.authorizerId = 'updatedAuthFunction'
+
+      const outputs = await egEventTypeComponent.deploy(inputs, context)
+
+      const expectedState = { ...context.state, metadata: {}, authorizerId: inputs.authorizerId }
+      delete expectedState.accessKey
+
+      expect(outputs).toEqual({ name: 'my.event' })
+      expect(updateEventType).toBeCalledWith(inputs)
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toBeCalledWith(expectedState)
+    })
+  })
+
+  describe('when running "remove"', () => {
+    it('should remove the event type from the Event Gateway', async () => {
+      const outputs = await egEventTypeComponent.remove(inputs, context)
+
+      expect(outputs).toEqual({})
+      expect(deleteEventType).toBeCalledWith({ ...context.state, accessKey: inputs.accessKey })
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/registry/serverless-eventgateway-event-type/src/utils/createEventType.js
+++ b/registry/serverless-eventgateway-event-type/src/utils/createEventType.js
@@ -1,0 +1,10 @@
+const SDK = require('@serverless/event-gateway-sdk')
+
+async function createEventType(inputs) {
+  const { url, space, accessKey, name, authorizerId } = inputs
+  const eg = new SDK({ url, space, accessKey })
+
+  return eg.createEventType({ name, authorizerId })
+}
+
+module.exports = createEventType

--- a/registry/serverless-eventgateway-event-type/src/utils/createEventType.test.js
+++ b/registry/serverless-eventgateway-event-type/src/utils/createEventType.test.js
@@ -1,0 +1,37 @@
+const createEventType = require('./createEventType')
+
+const mockCreateEventType = jest.fn().mockResolvedValue({
+  space: 'my-space',
+  name: 'my.event',
+  authorizerId: 'authFunction',
+  metadata: {}
+})
+
+jest.mock('@serverless/event-gateway-sdk', () =>
+  jest.fn().mockImplementation(() => ({
+    createEventType: mockCreateEventType
+  }))
+)
+
+describe('#createEventType()', () => {
+  it('should create the given event type at the Event Gateway', async () => {
+    const inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      name: 'my.event',
+      authorizerId: 'authFunction'
+    }
+
+    const res = await createEventType(inputs)
+
+    const { name, authorizerId } = inputs
+    expect(mockCreateEventType).toBeCalledWith({ name, authorizerId })
+    expect(res).toEqual({
+      space: 'my-space',
+      name: 'my.event',
+      authorizerId: 'authFunction',
+      metadata: {}
+    })
+  })
+})

--- a/registry/serverless-eventgateway-event-type/src/utils/deleteEventType.js
+++ b/registry/serverless-eventgateway-event-type/src/utils/deleteEventType.js
@@ -1,0 +1,11 @@
+const SDK = require('@serverless/event-gateway-sdk')
+
+async function deleteEventType(inputs) {
+  const { url, space, accessKey, name } = inputs
+  const eg = new SDK({ url, space, accessKey })
+
+  await eg.deleteEventType({ name })
+  return true
+}
+
+module.exports = deleteEventType

--- a/registry/serverless-eventgateway-event-type/src/utils/deleteEventType.test.js
+++ b/registry/serverless-eventgateway-event-type/src/utils/deleteEventType.test.js
@@ -1,0 +1,26 @@
+const deleteEventType = require('./deleteEventType')
+
+const mockDeleteEventType = jest.fn()
+
+jest.mock('@serverless/event-gateway-sdk', () =>
+  jest.fn().mockImplementation(() => ({
+    deleteEventType: mockDeleteEventType
+  }))
+)
+
+describe('#deleteFunction()', () => {
+  it('should delete the event type from the Event Gateway', async () => {
+    const inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      name: 'my.event'
+    }
+
+    const res = await deleteEventType(inputs)
+
+    const { name } = inputs
+    expect(mockDeleteEventType).toBeCalledWith({ name })
+    expect(res).toEqual(true)
+  })
+})

--- a/registry/serverless-eventgateway-event-type/src/utils/index.js
+++ b/registry/serverless-eventgateway-event-type/src/utils/index.js
@@ -1,0 +1,9 @@
+const createEventType = require('./createEventType')
+const updateEventType = require('./updateEventType')
+const deleteEventType = require('./deleteEventType')
+
+module.exports = {
+  createEventType,
+  updateEventType,
+  deleteEventType
+}

--- a/registry/serverless-eventgateway-event-type/src/utils/updateEventType.js
+++ b/registry/serverless-eventgateway-event-type/src/utils/updateEventType.js
@@ -1,0 +1,10 @@
+const SDK = require('@serverless/event-gateway-sdk')
+
+async function updateEventType(inputs) {
+  const { url, space, accessKey, name, authorizerId } = inputs
+  const eg = new SDK({ url, space, accessKey })
+
+  return eg.updateEventType({ name, authorizerId })
+}
+
+module.exports = updateEventType

--- a/registry/serverless-eventgateway-event-type/src/utils/updateEventType.test.js
+++ b/registry/serverless-eventgateway-event-type/src/utils/updateEventType.test.js
@@ -1,0 +1,37 @@
+const updateEventType = require('./updateEventType')
+
+const mockUpdateEventType = jest.fn().mockResolvedValue({
+  space: 'my-space',
+  name: 'my.event',
+  authorizerId: 'authFunction',
+  metadata: {}
+})
+
+jest.mock('@serverless/event-gateway-sdk', () =>
+  jest.fn().mockImplementation(() => ({
+    updateEventType: mockUpdateEventType
+  }))
+)
+
+describe('#updateEventType()', () => {
+  it('should update an existing event type at the Event Gateway', async () => {
+    const inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      name: 'my.event',
+      authorizerId: 'authFunction'
+    }
+
+    const res = await updateEventType(inputs)
+
+    const { name, authorizerId } = inputs
+    expect(mockUpdateEventType).toBeCalledWith({ name, authorizerId })
+    expect(res).toEqual({
+      space: 'my-space',
+      name: 'my.event',
+      authorizerId: 'authFunction',
+      metadata: {}
+    })
+  })
+})


### PR DESCRIPTION
This adds the `serverless-eventgateway-event-type` component to the registry.

Basic usage looks like this:

```yml
# serverless.yml

type: eg-event-type-test

components:
  eventGatewayEventType:
    type: serverless-eventgateway-event-type
    inputs:
      space: acme-marketing-space
      accessKey: s0m34c355k3y
      url: 'http://localhost'
      name: user.created
```