### PR TITLE
Add Event Gateway CORS component

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Also please do join the _Components_ channel on our public [Serverless-Contrib S
     * [s3-sync](./registry/s3-sync)
     * [s3-uploader](./registry/s3-uploader)
     * [s3-website-config](./registry/s3-website-config)
+    * [serverless-eventgateway-cors](./registry/serverless-eventgateway-cors)
     * [serverless-eventgateway-event-type](./registry/serverless-eventgateway-event-type)
     * [serverless-eventgateway-function](./registry/serverless-eventgateway-function)
     * [static-website](./registry/static-website)

--- a/registry/serverless-eventgateway-cors/README.md
+++ b/registry/serverless-eventgateway-cors/README.md
@@ -1,0 +1,62 @@
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_HEADER) -->
+# Serverless Eventgateway Cors
+
+Manages Event Gateway CORS configurations
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (TOC) -->
+- [Input Types](#input-types)
+- [Output Types](#output-types)
+- [Example](#example)
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_INPUT_TYPES) -->
+## Input Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **space**| `string` | The Event Gateway space which should be used
+| **allowedOrigins**| `array` | The allowed origins for the CORS configuration
+| **allowedMethods**| `array` | The allowed methods for the CORS connfiguration
+| **allowedHeaders**| `array` | The allowed headers for the CORS configuration
+| **allowCredentials**| `boolean` | Whether credentials are allowed for the CORS configuration
+| **url**| `string`<br/>*required* | The Event Gateway URL
+| **accessKey**| `string`<br/>*required* | The access key used to authenticate with the hosted Event Gateway
+| **method**| `string`<br/>*required* | The method CORS configuration should be applied to
+| **path**| `string`<br/>*required* | The path CORS configuration should be applied to
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_OUTPUT_TYPES) -->
+## Output Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **corsId**| `string` | The CORS configuration id
+| **method**| `string` | The method CORS configuration is applied to
+| **path**| `string` | The path CORS configuration is applied to
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_EXAMPLES) -->
+## Example
+```yml
+type: my-application
+components:
+  myServerlessEventgatewayCors:
+    type: serverless-eventgateway-cors
+    inputs:
+      space: acme-marketing-space
+      allowedOrigins:
+        - 'http://*.domain.com'
+      allowedMethods:
+        - POST
+        - GET
+      allowedHeaders:
+        - Origin
+        - Accept
+      url: 'http://localhost'
+      accessKey: s0m34c355k3y
+      method: POST
+      path: /acme
+
+```
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/registry/serverless-eventgateway-cors/package-lock.json
+++ b/registry/serverless-eventgateway-cors/package-lock.json
@@ -1,0 +1,85 @@
+{
+  "name": "@serverless-components/serverless-eventgateway-cors",
+  "version": "0.2.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@serverless/event-gateway-sdk": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@serverless/event-gateway-sdk/-/event-gateway-sdk-0.10.2.tgz",
+      "integrity": "sha512-CgbeAqXUWoDnNW152tTY6VkMeTpL0jcl87SApflIdUV8dnSsmiBuEB9e/gqjhXW/RsD0orYr0j3yxe/nRxaZ3w==",
+      "requires": {
+        "isomorphic-fetch": "^2.2.1",
+        "url-parse": "^1.1.9"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "querystringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+      "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "url-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+      "requires": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    }
+  }
+}

--- a/registry/serverless-eventgateway-cors/package.json
+++ b/registry/serverless-eventgateway-cors/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@serverless-components/serverless-eventgateway-cors",
+  "version": "0.2.0",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "@serverless/event-gateway-sdk": "^0.10.2"
+  }
+}

--- a/registry/serverless-eventgateway-cors/serverless.yml
+++ b/registry/serverless-eventgateway-cors/serverless.yml
@@ -1,0 +1,71 @@
+type: serverless-eventgateway-cors
+version: 0.2.0
+core: 0.2.x
+
+description: "Manages Event Gateway CORS configurations"
+license: Apache-2.0
+author: "Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
+repository: "github:serverless/components"
+
+inputTypes:
+  url:
+    type: string
+    required: true
+    displayName: URL
+    description: The Event Gateway URL
+    example: http://localhost
+  space:
+    type: string
+    default: default
+    displayName: Space
+    description: The Event Gateway space which should be used
+    example: acme-marketing-space
+  accessKey:
+    type: string
+    required: true
+    displayName: Access Key
+    description: The access key used to authenticate with the hosted Event Gateway
+    example: s0m34c355k3y
+  method:
+    type: string
+    required: true
+    displayName: Method
+    description: The method CORS configuration should be applied to
+    example: POST
+  path:
+    type: string
+    required: true
+    displayName: Path
+    description: The path CORS configuration should be applied to
+    example: /acme
+  allowedOrigins:
+    type: array
+    displayName: Allowed Origins
+    description: The allowed origins for the CORS configuration
+    example: ['http://*.domain.com']
+  allowedMethods:
+    type: array
+    displayName: Allowed Methods
+    description: The allowed methods for the CORS connfiguration
+    example: ['POST', 'GET']
+  allowedHeaders:
+    type: array
+    displayName: Allowed Headers
+    description: The allowed headers for the CORS configuration
+    example: ['Origin', 'Accept']
+  allowCredentials:
+    type: boolean
+    displayName: Allowed Credentials
+    description: Whether credentials are allowed for the CORS configuration
+    example: false
+
+outputTypes:
+  corsId:
+    type: string
+    description: The CORS configuration id
+  method:
+    type: string
+    description: The method CORS configuration is applied to
+  path:
+    type: string
+    description: The path CORS configuration is applied to

--- a/registry/serverless-eventgateway-cors/src/index.js
+++ b/registry/serverless-eventgateway-cors/src/index.js
@@ -1,0 +1,38 @@
+const { createCors, updateCors, deleteCors } = require('./utils')
+
+// "public" functions
+async function deploy(inputs, context) {
+  const { method, path, url } = inputs
+
+  let corsObj
+  if (!Object.keys(context.state).length) {
+    context.log(`Configuring CORS for "${method} ${path}" at Event Gateway "${url}"...`)
+    corsObj = await createCors(inputs)
+  } else {
+    context.log(`Updating CORS configuration for "${method} ${path}" at Event Gateway "${url}"...`)
+    corsObj = await updateCors({ ...context.state, accessKey: inputs.accessKey })
+  }
+
+  const outputs = { method, path, corsId: corsObj.corsId }
+  const state = { ...corsObj, url }
+
+  context.saveState(state)
+
+  return outputs
+}
+
+async function remove(inputs, context) {
+  const { method, path, url } = context.state
+
+  context.log(`Removing CORS configuration for "${method} ${path}" from Event Gateway "${url}"...`)
+
+  await deleteCors({ ...context.state, accessKey: inputs.accessKey })
+
+  context.saveState()
+  return {}
+}
+
+module.exports = {
+  deploy,
+  remove
+}

--- a/registry/serverless-eventgateway-cors/src/index.test.js
+++ b/registry/serverless-eventgateway-cors/src/index.test.js
@@ -1,0 +1,109 @@
+const { createCors, updateCors, deleteCors } = require('./utils')
+const egCorsComponent = require('./index')
+
+jest.mock('./utils/createCors')
+jest.mock('./utils/updateCors')
+jest.mock('./utils/deleteCors')
+
+createCors.mockImplementation(() =>
+  Promise.resolve({
+    space: 'my-space',
+    corsId: 'randomCorsId',
+    method: 'POST',
+    path: '/my-path',
+    allowedOrigins: ['*'],
+    allowedMethods: ['POST', 'GET'],
+    allowedHeaders: ['Origin', 'Accept'],
+    allowCredentials: false,
+    metadata: {}
+  })
+)
+updateCors.mockImplementation(() =>
+  Promise.resolve({
+    space: 'my-space',
+    corsId: 'randomCorsId',
+    method: 'POST',
+    path: '/my-path',
+    allowedOrigins: ['*', 'http://example.com'],
+    allowedMethods: ['POST', 'GET'],
+    allowedHeaders: ['Origin', 'Accept'],
+    allowCredentials: false,
+    metadata: {}
+  })
+)
+deleteCors.mockImplementation(() => Promise.resolve(true))
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('serverless-eventgateway-cors tests', () => {
+  let inputs
+  let context
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      method: 'POST',
+      path: '/my-path',
+      allowedOrigins: ['*'],
+      allowedMethods: ['POST', 'GET'],
+      allowedHeaders: ['Origin', 'Accept'],
+      allowCredentials: false
+    }
+    context = {
+      state: {
+        ...inputs
+      },
+      log: jest.fn(),
+      saveState: jest.fn()
+    }
+  })
+
+  describe('when running "deploy"', () => {
+    it('should create a new CORS configuration at the Event Gateway', async () => {
+      // empty state --> CORS config is not yet created
+      context.state = {}
+
+      const outputs = await egCorsComponent.deploy(inputs, context)
+
+      const expectedState = { ...inputs, metadata: {}, corsId: 'randomCorsId' }
+      delete expectedState.accessKey
+
+      expect(outputs).toEqual({ method: 'POST', path: '/my-path', corsId: 'randomCorsId' })
+      expect(createCors).toBeCalledWith(inputs)
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toBeCalledWith(expectedState)
+    })
+
+    it('should update an existing CORS configuration at the Event Gateway', async () => {
+      // changing the allowedOrigins array
+      inputs.allowedOrigins.push('http://example.com')
+
+      const outputs = await egCorsComponent.deploy(inputs, context)
+
+      const expectedState = { ...context.state, metadata: {}, corsId: 'randomCorsId' }
+      delete expectedState.accessKey
+
+      expect(outputs).toEqual({ method: 'POST', path: '/my-path', corsId: 'randomCorsId' })
+      expect(updateCors).toBeCalledWith({ ...context.state, accessKey: inputs.accessKey })
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toBeCalledWith(expectedState)
+    })
+  })
+
+  describe('when running "remove"', () => {
+    it('should remove the CORS configuration from the Event Gateway', async () => {
+      const outputs = await egCorsComponent.remove(inputs, context)
+
+      expect(outputs).toEqual({})
+      expect(deleteCors).toBeCalledWith({ ...context.state, accessKey: inputs.accessKey })
+      expect(context.log).toHaveBeenCalled()
+      expect(context.saveState).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/registry/serverless-eventgateway-cors/src/utils/createCors.js
+++ b/registry/serverless-eventgateway-cors/src/utils/createCors.js
@@ -1,0 +1,27 @@
+const SDK = require('@serverless/event-gateway-sdk')
+
+async function createCors(inputs) {
+  const {
+    url,
+    space,
+    accessKey,
+    method,
+    path,
+    allowedOrigins,
+    allowedMethods,
+    allowedHeaders,
+    allowCredentials
+  } = inputs
+  const eg = new SDK({ url, space, accessKey })
+
+  return eg.createCORS({
+    method,
+    path,
+    allowedOrigins,
+    allowedMethods,
+    allowedHeaders,
+    allowCredentials
+  })
+}
+
+module.exports = createCors

--- a/registry/serverless-eventgateway-cors/src/utils/createCors.test.js
+++ b/registry/serverless-eventgateway-cors/src/utils/createCors.test.js
@@ -1,0 +1,65 @@
+const createCors = require('./createCors')
+
+const mockCreateCors = jest.fn().mockResolvedValue({
+  space: 'my-space',
+  corsId: 'randomCorsId',
+  method: 'POST',
+  path: '/my-path',
+  allowedOrigins: ['*'],
+  allowedMethods: ['POST', 'GET'],
+  allowedHeaders: ['Origin', 'Accept'],
+  allowCredentials: false,
+  metadata: {}
+})
+
+jest.mock('@serverless/event-gateway-sdk', () =>
+  jest.fn().mockImplementation(() => ({
+    createCORS: mockCreateCors
+  }))
+)
+
+describe('#createCors()', () => {
+  it('should create the given CORS configuration at the Event Gateway', async () => {
+    const inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      method: 'POST',
+      path: '/my-path',
+      allowedOrigins: ['*'],
+      allowedMethods: ['POST', 'GET'],
+      allowedHeaders: ['Origin', 'Accept'],
+      allowCredentials: false
+    }
+
+    const res = await createCors(inputs)
+
+    const {
+      method,
+      path,
+      allowedOrigins,
+      allowedMethods,
+      allowedHeaders,
+      allowCredentials
+    } = inputs
+    expect(mockCreateCors).toBeCalledWith({
+      method,
+      path,
+      allowedOrigins,
+      allowedMethods,
+      allowedHeaders,
+      allowCredentials
+    })
+    expect(res).toEqual({
+      space: 'my-space',
+      corsId: 'randomCorsId',
+      method: 'POST',
+      path: '/my-path',
+      allowedOrigins: ['*'],
+      allowedMethods: ['POST', 'GET'],
+      allowedHeaders: ['Origin', 'Accept'],
+      allowCredentials: false,
+      metadata: {}
+    })
+  })
+})

--- a/registry/serverless-eventgateway-cors/src/utils/deleteCors.js
+++ b/registry/serverless-eventgateway-cors/src/utils/deleteCors.js
@@ -1,0 +1,11 @@
+const SDK = require('@serverless/event-gateway-sdk')
+
+async function deleteCors(inputs) {
+  const { url, space, accessKey, corsId } = inputs
+  const eg = new SDK({ url, space, accessKey })
+
+  await eg.deleteCORS({ corsId })
+  return true
+}
+
+module.exports = deleteCors

--- a/registry/serverless-eventgateway-cors/src/utils/deleteCors.test.js
+++ b/registry/serverless-eventgateway-cors/src/utils/deleteCors.test.js
@@ -1,0 +1,26 @@
+const deleteCors = require('./deleteCors')
+
+const mockDeleteCors = jest.fn()
+
+jest.mock('@serverless/event-gateway-sdk', () =>
+  jest.fn().mockImplementation(() => ({
+    deleteCORS: mockDeleteCors
+  }))
+)
+
+describe('#deleteCors()', () => {
+  it('should delete the CORS configuration from the Event Gateway', async () => {
+    const inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      corsId: 'randomCorsId'
+    }
+
+    const res = await deleteCors(inputs)
+
+    const { corsId } = inputs
+    expect(mockDeleteCors).toBeCalledWith({ corsId })
+    expect(res).toEqual(true)
+  })
+})

--- a/registry/serverless-eventgateway-cors/src/utils/index.js
+++ b/registry/serverless-eventgateway-cors/src/utils/index.js
@@ -1,0 +1,9 @@
+const createCors = require('./createCors')
+const updateCors = require('./updateCors')
+const deleteCors = require('./deleteCors')
+
+module.exports = {
+  createCors,
+  updateCors,
+  deleteCors
+}

--- a/registry/serverless-eventgateway-cors/src/utils/updateCors.js
+++ b/registry/serverless-eventgateway-cors/src/utils/updateCors.js
@@ -1,0 +1,29 @@
+const SDK = require('@serverless/event-gateway-sdk')
+
+async function updateCors(inputs) {
+  const {
+    url,
+    space,
+    accessKey,
+    corsId,
+    method,
+    path,
+    allowedOrigins,
+    allowedMethods,
+    allowedHeaders,
+    allowCredentials
+  } = inputs
+  const eg = new SDK({ url, space, accessKey })
+
+  return eg.updateCORS({
+    corsId,
+    method,
+    path,
+    allowedOrigins,
+    allowedMethods,
+    allowedHeaders,
+    allowCredentials
+  })
+}
+
+module.exports = updateCors

--- a/registry/serverless-eventgateway-cors/src/utils/updateCors.test.js
+++ b/registry/serverless-eventgateway-cors/src/utils/updateCors.test.js
@@ -1,0 +1,68 @@
+const updateCors = require('./updateCors')
+
+const mockUpdateCors = jest.fn().mockResolvedValue({
+  space: 'my-space',
+  corsId: 'randomCorsId',
+  method: 'POST',
+  path: '/my-path',
+  allowedOrigins: ['*'],
+  allowedMethods: ['POST', 'GET'],
+  allowedHeaders: ['Origin', 'Accept'],
+  allowCredentials: false,
+  metadata: {}
+})
+
+jest.mock('@serverless/event-gateway-sdk', () =>
+  jest.fn().mockImplementation(() => ({
+    updateCORS: mockUpdateCors
+  }))
+)
+
+describe('#updateCors()', () => {
+  it('should update an existing CORS configuration at the Event Gateway', async () => {
+    const inputs = {
+      url: 'http://localhost',
+      space: 'my-space',
+      accessKey: 's0m34cc355k3y',
+      corsId: 'randomCorsId',
+      method: 'POST',
+      path: '/my-path',
+      allowedOrigins: ['*'],
+      allowedMethods: ['POST', 'GET'],
+      allowedHeaders: ['Origin', 'Accept'],
+      allowCredentials: false
+    }
+
+    const res = await updateCors(inputs)
+
+    const {
+      corsId,
+      method,
+      path,
+      allowedOrigins,
+      allowedMethods,
+      allowedHeaders,
+      allowCredentials
+    } = inputs
+    expect(mockUpdateCors).toBeCalledWith({
+      corsId,
+      method,
+      path,
+      allowedOrigins,
+      allowedMethods,
+      allowedHeaders,
+      allowCredentials
+    })
+    expect(res).toEqual({
+      space: 'my-space',
+      corsId: 'randomCorsId',
+      method: 'POST',
+      path: '/my-path',
+      allowedOrigins: ['*'],
+      allowedMethods: ['POST', 'GET'],
+      allowedHeaders: ['Origin', 'Accept'],
+      allowCredentials: false,
+      metadata: {}
+    })
+  })
+})


### PR DESCRIPTION
This adds the `serverless-eventgateway-cors` component to the registry.

Basic usage looks like this:

```yml
# serverless.yml

type: eg-cors-test

components:
  eventGatewayCors:
    type: serverless-eventgateway-cors
    inputs:
      space: acme-marketing-space
      accessKey: s0m34c355k3y
      url: 'http://localhost'
      path: /my-path
      method: POST
      allowedOrigins:
        - 'http://*.domain.com'
      allowedMethods:
        - POST
        - GET
      allowedHeaders:
        - Origin
        - Accept
      allowCredentials: false
```