### PR TITLE
Aws VPC routes, route tables, and route table association

### DIFF
--- a/registry/aws-vpc-route-table-association/README.md
+++ b/registry/aws-vpc-route-table-association/README.md
@@ -1,0 +1,38 @@
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_HEADER) -->
+# AWS Vpc Route Table Association
+
+Provision AWS VPC Route Table Association with Serverless Components
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (TOC) -->
+- [Input Types](#input-types)
+- [Output Types](#output-types)
+- [Example](#example)
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_INPUT_TYPES) -->
+## Input Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **routeTableId**| `string`<br/>*required* | AWS VPC route table id
+| **subnetId**| `string`<br/>*required* | AWS subnet id
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_OUTPUT_TYPES) -->
+## Output Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **associationId**| `string` | Route table association id
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_EXAMPLES) -->
+## Example
+```yml
+type: my-application
+components:
+  myAwsVpcRouteTableAssociation:
+    type: aws-vpc-route-table-association
+    inputs:
+      routeTableId: rtb-abbaabba
+      subnetId: rtb-abbaabba
+
+```
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/registry/aws-vpc-route-table-association/README.md
+++ b/registry/aws-vpc-route-table-association/README.md
@@ -32,7 +32,7 @@ components:
     type: aws-vpc-route-table-association
     inputs:
       routeTableId: rtb-abbaabba
-      subnetId: rtb-abbaabba
+      subnetId: subnet-abbaabba
 
 ```
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/registry/aws-vpc-route-table-association/package.json
+++ b/registry/aws-vpc-route-table-association/package.json
@@ -2,8 +2,12 @@
   "name": "@serverless-components/aws-vpc-route-table-association",
   "version": "0.2.0",
   "private": true,
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.224.1",
+    "ramda": "^0.25.0"
   }
 }

--- a/registry/aws-vpc-route-table-association/package.json
+++ b/registry/aws-vpc-route-table-association/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@serverless-components/aws-vpc-route-table-association",
+  "version": "0.2.0",
+  "private": true,
+  "main": "src/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/registry/aws-vpc-route-table-association/serverless.yml
+++ b/registry/aws-vpc-route-table-association/serverless.yml
@@ -1,0 +1,28 @@
+---
+type: aws-vpc-route-table-association
+version: 0.2.0
+core: 0.2.x
+
+description: "Provision AWS VPC Route Table Association with Serverless Components"
+license: Apache-2.0
+author: "Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
+repository: "github:serverless/components"
+
+inputTypes:
+  routeTableId:
+    type: string
+    displayName: AWS VPC route table id
+    description: AWS VPC route table id
+    example: rtb-abbaabba
+    required: true
+  subnetId:
+    type: string
+    displayName: AWS subnet id
+    description: AWS subnet id
+    example: subnet-abbaabba
+    required: true
+
+outputTypes:
+  associationId:
+    type: string
+    description: Route table association id

--- a/registry/aws-vpc-route-table-association/src/index.js
+++ b/registry/aws-vpc-route-table-association/src/index.js
@@ -1,0 +1,64 @@
+const AWS = require('aws-sdk')
+const { isEmpty } = require('ramda')
+
+const ec2 = new AWS.EC2({
+  region: process.env.AWS_DEFAULT_REGION || 'us-east-1'
+})
+
+const deploy = async (inputs, context) => {
+  const { state } = context
+  if (
+    !isEmpty(state) &&
+    inputs.subnetId === state.subnetId &&
+    inputs.routeTableId === state.routeTableId
+  ) {
+    return { associationId: state.associationId }
+  }
+
+  // @todo remove after type-system branch merge
+  if (!isEmpty(state) && inputs.subnetId !== state.subnetId) {
+    context.log(`Updating the VPC Route Table Association "${state.associationId}"`)
+    await remove(inputs, context)
+  } else {
+    context.log('Creating a VPC Route Table Association')
+  }
+
+  const { AssociationId: associationId } = await ec2
+    .associateRouteTable({
+      SubnetId: inputs.subnetId,
+      RouteTableId: inputs.routeTableId
+    })
+    .promise()
+
+  context.saveState({
+    associationId,
+    subnetId: inputs.subnetId,
+    routeTableId: inputs.routeTableId
+  })
+
+  return { associationId }
+}
+
+const remove = async (inputs, context) => {
+  const { state } = context
+  context.log(`Removing the route table association "${state.associationId}"`)
+  await ec2
+    .disassociateRouteTable({
+      AssociationId: state.associationId
+    })
+    .promise()
+  context.log(`Route table "${state.associationId}" removed`)
+  context.saveState({})
+  return {}
+}
+
+const replacement = (inputs, context) => {
+  const { state } = context
+  return !isEmpty(state) && inputs.vpcId !== state.vpcId
+}
+
+module.exports = {
+  deploy,
+  remove,
+  replacement
+}

--- a/registry/aws-vpc-route-table-association/src/index.js
+++ b/registry/aws-vpc-route-table-association/src/index.js
@@ -42,23 +42,23 @@ const deploy = async (inputs, context) => {
 const remove = async (inputs, context) => {
   const { state } = context
   context.log(`Removing the route table association "${state.associationId}"`)
-  await ec2
-    .disassociateRouteTable({
-      AssociationId: state.associationId
-    })
-    .promise()
+  try {
+    await ec2
+      .disassociateRouteTable({
+        AssociationId: state.associationId
+      })
+      .promise()
+  } catch (error) {
+    if (error.code !== 'InvalidAssociationID.NotFound') {
+      throw error
+    }
+  }
   context.log(`Route table "${state.associationId}" removed`)
   context.saveState({})
   return {}
 }
 
-const replacement = (inputs, context) => {
-  const { state } = context
-  return !isEmpty(state) && inputs.vpcId !== state.vpcId
-}
-
 module.exports = {
   deploy,
-  remove,
-  replacement
+  remove
 }

--- a/registry/aws-vpc-route-table-association/src/index.test.js
+++ b/registry/aws-vpc-route-table-association/src/index.test.js
@@ -3,9 +3,9 @@ const awsVpcRouteTableAssociationComponent = require('./index')
 
 jest.mock('aws-sdk', () => {
   const mocks = {
-    associateRouteTableMock: jest.fn(() => ({
+    associateRouteTableMock: jest.fn().mockResolvedValue({
       AssociationId: 'rtbassoc-abbaabba'
-    })),
+    }),
     disassociateRouteTableMock: jest.fn(({ AssociationId }) => {
       if (AssociationId === 'rtbassoc-not-abba') {
         const error = new Error()

--- a/registry/aws-vpc-route-table-association/src/index.test.js
+++ b/registry/aws-vpc-route-table-association/src/index.test.js
@@ -1,14 +1,182 @@
-// aws-vpc-route-table-association
-const myComponent = require('./index')
+const AWS = require('aws-sdk')
+const awsVpcRouteTableAssociationComponent = require('./index')
 
-describe('aws-vpc-route-table-association Unit Tests', () => {
-  it('should have tests', async () => {
+jest.mock('aws-sdk', () => {
+  const mocks = {
+    associateRouteTableMock: jest.fn(() => ({
+      AssociationId: 'rtbassoc-abbaabba'
+    })),
+    disassociateRouteTableMock: jest.fn(({ AssociationId }) => {
+      if (AssociationId === 'rtbassoc-not-abba') {
+        const error = new Error()
+        error.code = 'InvalidAssociationID.NotFound'
+        throw error
+      } else if (AssociationId === 'rtbassoc-error') {
+        throw new Error('Something went wrong')
+      }
+      return {}
+    })
+  }
+
+  const EC2 = {
+    associateRouteTable: (obj) => ({
+      promise: () => mocks.associateRouteTableMock(obj)
+    }),
+    disassociateRouteTable: (obj) => ({
+      promise: () => mocks.disassociateRouteTableMock(obj)
+    })
+  }
+  return {
+    mocks,
+    EC2: jest.fn().mockImplementation(() => EC2)
+  }
+})
+
+afterEach(() => {
+  Object.keys(AWS.mocks).forEach((mock) => AWS.mocks[mock].mockClear())
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('AWS VPC Route Table Association Unit Tests', () => {
+  it('should create a new route table association', async () => {
     const contextMock = {
       state: {},
       log: () => {},
       saveState: jest.fn()
     }
-    await myComponent.deploy({}, contextMock)
-    expect(false).toBe(true)
+
+    const inputs = {
+      subnetId: 'subnet-abbaabba',
+      routeTableId: 'rtb-abbaabba'
+    }
+
+    const result = await awsVpcRouteTableAssociationComponent.deploy(inputs, contextMock)
+    expect(result).toEqual({ associationId: 'rtbassoc-abbaabba' })
+    expect(AWS.mocks.associateRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.disassociateRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+  })
+
+  it('should update the route table association', async () => {
+    const contextMock = {
+      state: {
+        subnetId: 'subnet-baababba',
+        routeTableId: 'rtb-baababba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      subnetId: 'subnet-abbaabba',
+      routeTableId: 'rtb-abbaabba'
+    }
+
+    const result = await awsVpcRouteTableAssociationComponent.deploy(inputs, contextMock)
+    expect(result).toEqual({ associationId: 'rtbassoc-abbaabba' })
+    expect(AWS.mocks.associateRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.disassociateRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(2)
+  })
+
+  it('should ignore deploy if nothing is change', async () => {
+    const contextMock = {
+      state: {
+        subnetId: 'subnet-abbaabba',
+        routeTableId: 'rtb-abbaabba',
+        associationId: 'rtbassoc-abbaabba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      subnetId: 'subnet-abbaabba',
+      routeTableId: 'rtb-abbaabba'
+    }
+
+    const result = await awsVpcRouteTableAssociationComponent.deploy(inputs, contextMock)
+    expect(result).toEqual({ associationId: 'rtbassoc-abbaabba' })
+    expect(AWS.mocks.associateRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.disassociateRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(0)
+  })
+
+  it('should remote the route table', async () => {
+    const contextMock = {
+      state: {
+        subnetId: 'subnet-abbaabba',
+        routeTableId: 'rtb-abbaabba',
+        associationId: 'rtbassoc-abbaabba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      subnetId: 'subnet-abbaabba',
+      routeTableId: 'rtb-abbaabba'
+    }
+
+    const result = await awsVpcRouteTableAssociationComponent.remove(inputs, contextMock)
+    expect(result).toEqual({})
+    expect(AWS.mocks.associateRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.disassociateRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+  })
+
+  it('should omit not found error on remove', async () => {
+    const contextMock = {
+      state: {
+        subnetId: 'subnet-abbaabba',
+        routeTableId: 'rtb-abbaabba',
+        associationId: 'rtbassoc-not-abba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      subnetId: 'subnet-abbaabba',
+      routeTableId: 'rtb-abbaabba'
+    }
+
+    const result = await awsVpcRouteTableAssociationComponent.remove(inputs, contextMock)
+    expect(result).toEqual({})
+    expect(AWS.mocks.associateRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.disassociateRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+  })
+
+  it('should throw error on unexpected error', async () => {
+    const contextMock = {
+      state: {
+        subnetId: 'subnet-abbaabba',
+        routeTableId: 'rtb-abbaabba',
+        associationId: 'rtbassoc-error'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      subnetId: 'subnet-abbaabba',
+      routeTableId: 'rtb-abbaabba'
+    }
+
+    let result
+    try {
+      result = await awsVpcRouteTableAssociationComponent.remove(inputs, contextMock)
+    } catch (error) {
+      expect(error.message).toBe('Something went wrong')
+    }
+
+    expect(result).toBeUndefined()
+    expect(AWS.mocks.associateRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.disassociateRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(0)
   })
 })

--- a/registry/aws-vpc-route-table-association/src/index.test.js
+++ b/registry/aws-vpc-route-table-association/src/index.test.js
@@ -1,0 +1,14 @@
+// aws-vpc-route-table-association
+const myComponent = require('./index')
+
+describe('aws-vpc-route-table-association Unit Tests', () => {
+  it('should have tests', async () => {
+    const contextMock = {
+      state: {},
+      log: () => {},
+      saveState: jest.fn()
+    }
+    await myComponent.deploy({}, contextMock)
+    expect(false).toBe(true)
+  })
+})

--- a/registry/aws-vpc-route-table/README.md
+++ b/registry/aws-vpc-route-table/README.md
@@ -1,0 +1,36 @@
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_HEADER) -->
+# AWS Vpc Route Table
+
+Provision AWS VPC Route Table with Serverless Components
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (TOC) -->
+- [Input Types](#input-types)
+- [Output Types](#output-types)
+- [Example](#example)
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_INPUT_TYPES) -->
+## Input Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **vpcId**| `string`<br/>*required* | The id of the VPC
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_OUTPUT_TYPES) -->
+## Output Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **routeTableId**| `string` | The route table id
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_EXAMPLES) -->
+## Example
+```yml
+type: my-application
+components:
+  myAwsVpcRouteTable:
+    type: aws-vpc-route-table
+    inputs:
+      vpcId: vpc-abbaabba
+
+```
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/registry/aws-vpc-route-table/package.json
+++ b/registry/aws-vpc-route-table/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@serverless-components/aws-vpc-route-table",
+  "version": "0.2.0",
+  "private": true,
+  "main": "src/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.224.1",
+    "ramda": "^0.25.0"
+  }
+}

--- a/registry/aws-vpc-route-table/package.json
+++ b/registry/aws-vpc-route-table/package.json
@@ -2,7 +2,7 @@
   "name": "@serverless-components/aws-vpc-route-table",
   "version": "0.2.0",
   "private": true,
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/registry/aws-vpc-route-table/serverless.yml
+++ b/registry/aws-vpc-route-table/serverless.yml
@@ -1,0 +1,22 @@
+---
+type: aws-vpc-route-table
+version: 0.2.0
+core: 0.2.x
+
+description: "Provision AWS VPC Route Table with Serverless Components"
+license: Apache-2.0
+author: "Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
+repository: "github:serverless/components"
+
+inputTypes:
+  vpcId:
+    type: string
+    displayName: The id of the VPC
+    description: The id of the VPC
+    example: vpc-abbaabba
+    required: true
+
+outputTypes:
+  routeTableId:
+    type: string
+    description: The route table id

--- a/registry/aws-vpc-route-table/src/index.js
+++ b/registry/aws-vpc-route-table/src/index.js
@@ -40,8 +40,8 @@ const remove = async (inputs, context) => {
       RouteTableId: state.routeTableId
     })
     .promise()
-  context.saveState({})
   context.log(`Route table "${state.routeTableId}" removed`)
+  context.saveState({})
   return {}
 }
 

--- a/registry/aws-vpc-route-table/src/index.js
+++ b/registry/aws-vpc-route-table/src/index.js
@@ -35,11 +35,17 @@ const deploy = async (inputs, context) => {
 const remove = async (inputs, context) => {
   const { state } = context
   context.log(`Removing the route table "${state.routeTableId}"`)
-  await ec2
-    .deleteRouteTable({
-      RouteTableId: state.routeTableId
-    })
-    .promise()
+  try {
+    await ec2
+      .deleteRouteTable({
+        RouteTableId: state.routeTableId
+      })
+      .promise()
+  } catch (error) {
+    if (error.code !== 'InvalidRouteTableID.NotFound') {
+      throw error
+    }
+  }
   context.log(`Route table "${state.routeTableId}" removed`)
   context.saveState({})
   return {}

--- a/registry/aws-vpc-route-table/src/index.js
+++ b/registry/aws-vpc-route-table/src/index.js
@@ -1,0 +1,51 @@
+const AWS = require('aws-sdk')
+const { isEmpty } = require('ramda')
+
+const ec2 = new AWS.EC2({
+  region: process.env.AWS_DEFAULT_REGION || 'us-east-1'
+})
+
+const deploy = async (inputs, context) => {
+  const { state } = context
+  if (!isEmpty(state) && inputs.vpcId === state.vpcId) {
+    return { routeTableId: state.routeTableId }
+  }
+
+  if (!isEmpty(state) && inputs.vpcId !== state.vpcId) {
+    context.log(`Updating the VPC Route Table "${state.routeTableId}"`)
+    await remove(inputs, context)
+  } else {
+    context.log('Creating a VPC Route Table')
+  }
+
+  const { RouteTable: routeTable } = await ec2
+    .createRouteTable({
+      VpcId: inputs.vpcId
+    })
+    .promise()
+
+  context.saveState({
+    vpcId: inputs.vpcId,
+    routeTableId: routeTable.RouteTableId
+  })
+  context.log(`Route table "${routeTable.RouteTableId}" created`)
+  return { routeTableId: routeTable.RouteTableId }
+}
+
+const remove = async (inputs, context) => {
+  const { state } = context
+  context.log(`Removing the route table "${state.routeTableId}"`)
+  await ec2
+    .deleteRouteTable({
+      RouteTableId: state.routeTableId
+    })
+    .promise()
+  context.saveState({})
+  context.log(`Route table "${state.routeTableId}" removed`)
+  return {}
+}
+
+module.exports = {
+  deploy,
+  remove
+}

--- a/registry/aws-vpc-route-table/src/index.test.js
+++ b/registry/aws-vpc-route-table/src/index.test.js
@@ -3,11 +3,11 @@ const awsVpcRouteTableComponent = require('./index')
 
 jest.mock('aws-sdk', () => {
   const mocks = {
-    createRouteTableMock: jest.fn(() => ({
+    createRouteTableMock: jest.fn().mockResolvedValue({
       RouteTable: {
         RouteTableId: 'rtb-abbaabba'
       }
-    })),
+    }),
     deleteRouteTableMock: jest.fn(({ RouteTableId }) => {
       if (RouteTableId === 'rtb-not-abba') {
         const error = new Error()

--- a/registry/aws-vpc-route-table/src/index.test.js
+++ b/registry/aws-vpc-route-table/src/index.test.js
@@ -1,0 +1,14 @@
+// aws-vpc-route-table
+const myComponent = require('./index')
+
+describe('aws-vpc-route-table Unit Tests', () => {
+  it('should have tests', async () => {
+    const contextMock = {
+      state: {},
+      log: () => {},
+      saveState: jest.fn()
+    }
+    await myComponent.deploy({}, contextMock)
+    expect(false).toBe(true)
+  })
+})

--- a/registry/aws-vpc-route-table/src/index.test.js
+++ b/registry/aws-vpc-route-table/src/index.test.js
@@ -1,14 +1,174 @@
-// aws-vpc-route-table
-const myComponent = require('./index')
+const AWS = require('aws-sdk')
+const awsVpcRouteTableComponent = require('./index')
 
-describe('aws-vpc-route-table Unit Tests', () => {
-  it('should have tests', async () => {
+jest.mock('aws-sdk', () => {
+  const mocks = {
+    createRouteTableMock: jest.fn(() => ({
+      RouteTable: {
+        RouteTableId: 'rtb-abbaabba'
+      }
+    })),
+    deleteRouteTableMock: jest.fn(({ RouteTableId }) => {
+      if (RouteTableId === 'rtb-not-abba') {
+        const error = new Error()
+        error.code = 'InvalidRouteTableID.NotFound'
+        throw error
+      } else if (RouteTableId === 'rtb-error') {
+        throw new Error('Something went wrong')
+      }
+      return {}
+    })
+  }
+
+  const EC2 = {
+    createRouteTable: (obj) => ({
+      promise: () => mocks.createRouteTableMock(obj)
+    }),
+    deleteRouteTable: (obj) => ({
+      promise: () => mocks.deleteRouteTableMock(obj)
+    })
+  }
+  return {
+    mocks,
+    EC2: jest.fn().mockImplementation(() => EC2)
+  }
+})
+
+afterEach(() => {
+  Object.keys(AWS.mocks).forEach((mock) => AWS.mocks[mock].mockClear())
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('AWS VPC Route Table Unit Tests', () => {
+  it('should create a new route table', async () => {
     const contextMock = {
       state: {},
       log: () => {},
       saveState: jest.fn()
     }
-    await myComponent.deploy({}, contextMock)
-    expect(false).toBe(true)
+
+    const inputs = {
+      vpcId: 'vpc-abbaabba'
+    }
+
+    const result = await awsVpcRouteTableComponent.deploy(inputs, contextMock)
+    expect(result).toEqual({ routeTableId: 'rtb-abbaabba' })
+    expect(AWS.mocks.createRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.deleteRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+  })
+
+  it('should update the route table', async () => {
+    const contextMock = {
+      state: {
+        vpcId: 'vpc-baababba',
+        routeTableId: 'rtb-baababba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      vpcId: 'vpc-abbaabba'
+    }
+
+    const result = await awsVpcRouteTableComponent.deploy(inputs, contextMock)
+    expect(result).toEqual({ routeTableId: 'rtb-abbaabba' })
+    expect(AWS.mocks.createRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.deleteRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(2)
+  })
+
+  it('should ignore if vpc is not changed', async () => {
+    const contextMock = {
+      state: {
+        vpcId: 'vpc-abbaabba',
+        routeTableId: 'rtb-abbaabba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      vpcId: 'vpc-abbaabba'
+    }
+
+    const result = await awsVpcRouteTableComponent.deploy(inputs, contextMock)
+    expect(result).toEqual({ routeTableId: 'rtb-abbaabba' })
+    expect(AWS.mocks.createRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.deleteRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(0)
+  })
+
+  it('should remote the route table', async () => {
+    const contextMock = {
+      state: {
+        vpcId: 'vpc-abbaabba',
+        routeTableId: 'rtb-abbaabba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      vpcId: 'vpc-abbaabba'
+    }
+
+    const result = await awsVpcRouteTableComponent.remove(inputs, contextMock)
+    expect(result).toEqual({})
+    expect(AWS.mocks.createRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.deleteRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+  })
+
+  it('should omit not found error on remove', async () => {
+    const contextMock = {
+      state: {
+        vpcId: 'vpc-abbaabba',
+        routeTableId: 'rtb-not-abba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      vpcId: 'vpc-abbaabba'
+    }
+
+    const result = await awsVpcRouteTableComponent.remove(inputs, contextMock)
+    expect(result).toEqual({})
+    expect(AWS.mocks.createRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.deleteRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+  })
+
+  it('should throw error on unexpected error', async () => {
+    const contextMock = {
+      state: {
+        vpcId: 'vpc-abbaabba',
+        routeTableId: 'rtb-error'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      vpcId: 'vpc-abbaabba'
+    }
+
+    let result
+    try {
+      result = await awsVpcRouteTableComponent.remove(inputs, contextMock)
+    } catch (error) {
+      expect(error.message).toBe('Something went wrong')
+    }
+
+    expect(result).toBeUndefined()
+    expect(AWS.mocks.createRouteTableMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.deleteRouteTableMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(0)
   })
 })

--- a/registry/aws-vpc-route/README.md
+++ b/registry/aws-vpc-route/README.md
@@ -1,0 +1,52 @@
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_HEADER) -->
+# AWS Vpc Route
+
+My component description
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (TOC) -->
+- [Input Types](#input-types)
+- [Output Types](#output-types)
+- [Example](#example)
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_INPUT_TYPES) -->
+## Input Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **destinationCidrBlock**| `string` | Destination Ipv4 Cidr Block
+| **destinationIpv6CidrBlock**| `string` | Destination Ipv6 Cidr Block
+| **egressOnlyInternetGatewayId**| `string` | Egress Only Internet Gateway Id
+| **gatewayId**| `string` | Gateway Id
+| **instanceId**| `string` | Instance Id
+| **natGatewayId**| `string` | Nat Gateway Id
+| **networkInterfaceId**| `string` | NetworkInterface Id
+| **routeTableId**| `string` | RouteTable Id
+| **vpcPeeringConnectionId**| `string` | Vpc Peering Connection Id
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_OUTPUT_TYPES) -->
+## Output Types
+| Name | Type | Description |
+|:------ |:-----|:-----------------|
+| **myOutput**| `string` | my output string
+
+<!-- AUTO-GENERATED-CONTENT:END -->
+<!-- AUTO-GENERATED-CONTENT:START (COMPONENT_EXAMPLES) -->
+## Example
+```yml
+type: my-application
+components:
+  myAwsVpcRoute:
+    type: aws-vpc-route
+    inputs:
+      destinationCidrBlock: 10.0.0.0/16
+      destinationIpv6CidrBlock: '2600:1f18:24c2:b200::/64'
+      egressOnlyInternetGatewayId: '123'
+      gatewayId: '123'
+      instanceId: '123'
+      natGatewayId: '123'
+      networkInterfaceId: '123'
+      routeTableId: '123'
+      vpcPeeringConnectionId: '123'
+
+```
+<!-- AUTO-GENERATED-CONTENT:END -->

--- a/registry/aws-vpc-route/README.md
+++ b/registry/aws-vpc-route/README.md
@@ -1,7 +1,7 @@
 <!-- AUTO-GENERATED-CONTENT:START (COMPONENT_HEADER) -->
 # AWS Vpc Route
 
-My component description
+Provision AWS VPC Route with Serverless Components
 <!-- AUTO-GENERATED-CONTENT:END -->
 <!-- AUTO-GENERATED-CONTENT:START (TOC) -->
 - [Input Types](#input-types)
@@ -40,13 +40,13 @@ components:
     inputs:
       destinationCidrBlock: 10.0.0.0/16
       destinationIpv6CidrBlock: '2600:1f18:24c2:b200::/64'
-      egressOnlyInternetGatewayId: '123'
-      gatewayId: '123'
-      instanceId: '123'
-      natGatewayId: '123'
-      networkInterfaceId: '123'
-      routeTableId: '123'
-      vpcPeeringConnectionId: '123'
+      egressOnlyInternetGatewayId: eigw-abbaabba
+      gatewayId: igw-abbaabba
+      instanceId: i-abbaabba
+      natGatewayId: nat-abbaabba
+      networkInterfaceId: eni-abbaabba
+      routeTableId: rtb-abbaabba
+      vpcPeeringConnectionId: pcx-abbaabba
 
 ```
 <!-- AUTO-GENERATED-CONTENT:END -->

--- a/registry/aws-vpc-route/package.json
+++ b/registry/aws-vpc-route/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@serverless-components/aws-vpc-route",
+  "version": "0.2.0",
+  "private": true,
+  "main": "src/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.224.1",
+    "ramda": "^0.25.0"
+  }
+}

--- a/registry/aws-vpc-route/package.json
+++ b/registry/aws-vpc-route/package.json
@@ -2,7 +2,7 @@
   "name": "@serverless-components/aws-vpc-route",
   "version": "0.2.0",
   "private": true,
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/registry/aws-vpc-route/serverless.yml
+++ b/registry/aws-vpc-route/serverless.yml
@@ -1,0 +1,64 @@
+---
+type: aws-vpc-route
+version: 0.2.0
+core: 0.2.x
+
+description: "My component description"
+license: Apache-2.0
+author: "Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
+repository: "github:serverless/components"
+
+inputTypes:
+  destinationCidrBlock:
+    type: string
+    displayName: Destination Ipv4 Cidr Block
+    description: Destination Ipv4 Cidr Block
+    example: 10.0.0.0/16
+    # replacement
+  destinationIpv6CidrBlock:
+    type: string
+    displayName: Destination Ipv6 Cidr Block
+    description: Destination Ipv6 Cidr Block
+    example: "2600:1f18:24c2:b200::/64"
+    # replacement
+  egressOnlyInternetGatewayId:
+    type: string
+    displayName: Egress Only Internet Gateway Id
+    description: Egress Only Internet Gateway Id
+    example: "123"
+  gatewayId:
+    type: string
+    displayName: Gateway Id
+    description: Gateway Id
+    example: "123"
+  instanceId:
+    type: string
+    displayName: Instance Id
+    description: Instance Id
+    example: "123"
+  natGatewayId:
+    type: string
+    displayName: Nat Gateway Id
+    description: Nat Gateway Id
+    example: "123"
+  networkInterfaceId:
+    type: string
+    displayName: NetworkInterface Id
+    description: NetworkInterface Id
+    example: "123"
+  routeTableId:
+    type: string
+    displayName: RouteTable Id
+    description: RouteTable Id
+    example: "123"
+    # replacement
+  vpcPeeringConnectionId:
+    type: string
+    displayName: Vpc Peering Connection Id
+    description: Vpc Peering Connection Id
+    example: "123"
+
+outputTypes:
+  myOutput:
+    type: string
+    description: my output string

--- a/registry/aws-vpc-route/serverless.yml
+++ b/registry/aws-vpc-route/serverless.yml
@@ -1,12 +1,11 @@
----
 type: aws-vpc-route
 version: 0.2.0
 core: 0.2.x
 
-description: "My component description"
+description: "Provision AWS VPC Route with Serverless Components"
 license: Apache-2.0
-author: "Serverless, Inc. <hello@serverless.com> (https://serverless.com)"
-repository: "github:serverless/components"
+author: 'Serverless, Inc. <hello@serverless.com> (https://serverless.com)'
+repository: 'github:serverless/components'
 
 inputTypes:
   destinationCidrBlock:
@@ -19,44 +18,44 @@ inputTypes:
     type: string
     displayName: Destination Ipv6 Cidr Block
     description: Destination Ipv6 Cidr Block
-    example: "2600:1f18:24c2:b200::/64"
+    example: '2600:1f18:24c2:b200::/64'
     # replacement
   egressOnlyInternetGatewayId:
     type: string
     displayName: Egress Only Internet Gateway Id
     description: Egress Only Internet Gateway Id
-    example: "123"
+    example: 'eigw-abbaabba'
   gatewayId:
     type: string
     displayName: Gateway Id
     description: Gateway Id
-    example: "123"
+    example: 'igw-abbaabba'
   instanceId:
     type: string
     displayName: Instance Id
     description: Instance Id
-    example: "123"
+    example: 'i-abbaabba'
   natGatewayId:
     type: string
     displayName: Nat Gateway Id
     description: Nat Gateway Id
-    example: "123"
+    example: 'nat-abbaabba'
   networkInterfaceId:
     type: string
     displayName: NetworkInterface Id
     description: NetworkInterface Id
-    example: "123"
+    example: 'eni-abbaabba'
   routeTableId:
     type: string
     displayName: RouteTable Id
     description: RouteTable Id
-    example: "123"
+    example: 'rtb-abbaabba'
     # replacement
   vpcPeeringConnectionId:
     type: string
     displayName: Vpc Peering Connection Id
     description: Vpc Peering Connection Id
-    example: "123"
+    example: 'pcx-abbaabba'
 
 outputTypes:
   myOutput:

--- a/registry/aws-vpc-route/src/index.js
+++ b/registry/aws-vpc-route/src/index.js
@@ -1,0 +1,70 @@
+const AWS = require('aws-sdk')
+const { isEmpty, pick, equals } = require('ramda')
+
+const ec2 = new AWS.EC2({
+  region: process.env.AWS_DEFAULT_REGION || 'us-east-1'
+})
+
+// const capitalize = (string) => `${head(string).toUpperCase()}${slice(1, Infinity, string)}`
+
+const compareStateAndInputs = (state, inputs, keys) => {
+  const inputsPick = pick(keys, inputs)
+  const statePick = pick(keys, state)
+  return equals(statePick, inputsPick)
+}
+
+const deploy = async (inputs, context) => {
+  const { state } = context
+  if (!isEmpty(state) && equals(state, inputs)) {
+    return {}
+  }
+
+  if (
+    !isEmpty(state) &&
+    !compareStateAndInputs(state, inputs, [
+      'routeTableId',
+      'destinationIpv6CidrBlock',
+      'destinationCidrBlock'
+    ])
+  ) {
+    context.log('changes in the route requires replacement')
+    await remove(inputs, context)
+  }
+
+  context.log(`create a route for the route table "${inputs.routeTableId}"`)
+  await ec2
+    .createRoute({
+      DestinationCidrBlock: inputs.destinationCidrBlock,
+      GatewayId: inputs.gatewayId,
+      RouteTableId: inputs.routeTableId
+    })
+    .promise()
+  context.log(`the route for the route table "${inputs.routeTableId}" created`)
+  context.saveState(inputs)
+  return {}
+}
+
+const remove = async (inputs, context) => {
+  const { state } = context
+  context.log(`removing the route from the route table "${state.routeTableId}"`)
+  try {
+    await ec2
+      .deleteRoute({
+        RouteTableId: state.routeTableId,
+        DestinationCidrBlock: state.destinationCidrBlock,
+        DestinationIpv6CidrBlock: state.DdstinationIpv6CidrBlock
+      })
+      .promise()
+  } catch (error) {
+    // console.log(error)
+    throw error
+  }
+  context.log(`the route removed from the route table "${state.routeTableId}"`)
+  context.saveState({})
+  return {}
+}
+
+module.exports = {
+  deploy,
+  remove
+}

--- a/registry/aws-vpc-route/src/index.test.js
+++ b/registry/aws-vpc-route/src/index.test.js
@@ -1,14 +1,186 @@
-// aws-vpc-route
-const myComponent = require('./index')
+const AWS = require('aws-sdk')
+const awsVpcRouteComponent = require('./index')
 
-describe('aws-vpc-route Unit Tests', () => {
-  it('should have tests', async () => {
+jest.mock('aws-sdk', () => {
+  const mocks = {
+    createRouteMock: jest.fn().mockResolvedValue({}),
+    deleteRouteMock: jest.fn(({ DestinationCidrBlock }) => {
+      if (DestinationCidrBlock === '1.0.0.0/0') {
+        const error = new Error()
+        error.code = 'InvalidRoute.NotFound'
+        throw error
+      } else if (DestinationCidrBlock === '2.0.0.0/0') {
+        throw new Error('Something went wrong')
+      }
+      return {}
+    })
+  }
+
+  const EC2 = {
+    createRoute: (obj) => ({
+      promise: () => mocks.createRouteMock(obj)
+    }),
+    deleteRoute: (obj) => ({
+      promise: () => mocks.deleteRouteMock(obj)
+    })
+  }
+  return {
+    mocks,
+    EC2: jest.fn().mockImplementation(() => EC2)
+  }
+})
+
+afterEach(() => {
+  Object.keys(AWS.mocks).forEach((mock) => AWS.mocks[mock].mockClear())
+})
+
+afterAll(() => {
+  jest.restoreAllMocks()
+})
+
+describe('AWS VPC Route Unit Tests', () => {
+  it('should create a new route', async () => {
     const contextMock = {
       state: {},
       log: () => {},
       saveState: jest.fn()
     }
-    await myComponent.deploy({}, contextMock)
-    expect(false).toBe(true)
+
+    const inputs = {
+      destinationCidrBlock: '0.0.0.0/0',
+      gatewayId: 'igw-abbaabba',
+      routeTableId: 'irtb-abbaabba'
+    }
+
+    const result = await awsVpcRouteComponent.deploy(inputs, contextMock)
+    expect(result).toEqual({})
+    expect(AWS.mocks.createRouteMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.deleteRouteMock).toHaveBeenCalledTimes(0)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+  })
+
+  it('should update the route', async () => {
+    const contextMock = {
+      state: {
+        destinationCidrBlock: '10.0.0.0/8',
+        gatewayId: 'igw-abbaabba',
+        routeTableId: 'irtb-abbaabba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      destinationCidrBlock: '0.0.0.0/0',
+      gatewayId: 'igw-abbaabba',
+      routeTableId: 'irtb-abbaabba'
+    }
+
+    const result = await awsVpcRouteComponent.deploy(inputs, contextMock)
+    expect(result).toEqual({})
+    expect(AWS.mocks.createRouteMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.deleteRouteMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(2)
+  })
+
+  it('should ignore deploy if nothing is change', async () => {
+    const contextMock = {
+      state: {
+        destinationCidrBlock: '0.0.0.0/0',
+        gatewayId: 'igw-abbaabba',
+        routeTableId: 'irtb-abbaabba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      destinationCidrBlock: '0.0.0.0/0',
+      gatewayId: 'igw-abbaabba',
+      routeTableId: 'irtb-abbaabba'
+    }
+
+    const result = await awsVpcRouteComponent.deploy(inputs, contextMock)
+    expect(result).toEqual({})
+    expect(AWS.mocks.createRouteMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.deleteRouteMock).toHaveBeenCalledTimes(0)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(0)
+  })
+
+  it('should remote the route', async () => {
+    const contextMock = {
+      state: {
+        subnetId: 'subnet-abbaabba',
+        routeTableId: 'rtb-abbaabba',
+        associationId: 'rtbassoc-abbaabba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      subnetId: 'subnet-abbaabba',
+      routeTableId: 'rtb-abbaabba'
+    }
+
+    const result = await awsVpcRouteComponent.remove(inputs, contextMock)
+    expect(result).toEqual({})
+    expect(AWS.mocks.createRouteMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.deleteRouteMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+  })
+
+  it('should omit not found error on remove', async () => {
+    const contextMock = {
+      state: {
+        destinationCidrBlock: '1.0.0.0/0',
+        gatewayId: 'igw-abbaabba',
+        routeTableId: 'irtb-abbaabba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      destinationCidrBlock: '0.0.0.0/0',
+      gatewayId: 'igw-abbaabba',
+      routeTableId: 'irtb-abbaabba'
+    }
+
+    const result = await awsVpcRouteComponent.remove(inputs, contextMock)
+    expect(result).toEqual({})
+    expect(AWS.mocks.createRouteMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.deleteRouteMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(1)
+  })
+
+  it('should throw error on unexpected error', async () => {
+    const contextMock = {
+      state: {
+        destinationCidrBlock: '2.0.0.0/0',
+        gatewayId: 'igw-abbaabba',
+        routeTableId: 'irtb-abbaabba'
+      },
+      log: () => {},
+      saveState: jest.fn()
+    }
+
+    const inputs = {
+      destinationCidrBlock: '0.0.0.0/0',
+      gatewayId: 'igw-abbaabba',
+      routeTableId: 'irtb-abbaabba'
+    }
+
+    let result
+    try {
+      result = await awsVpcRouteComponent.remove(inputs, contextMock)
+    } catch (error) {
+      expect(error.message).toBe('Something went wrong')
+    }
+
+    expect(result).toBeUndefined()
+    expect(AWS.mocks.createRouteMock).toHaveBeenCalledTimes(0)
+    expect(AWS.mocks.deleteRouteMock).toHaveBeenCalledTimes(1)
+    expect(contextMock.saveState).toHaveBeenCalledTimes(0)
   })
 })

--- a/registry/aws-vpc-route/src/index.test.js
+++ b/registry/aws-vpc-route/src/index.test.js
@@ -1,0 +1,14 @@
+// aws-vpc-route
+const myComponent = require('./index')
+
+describe('aws-vpc-route Unit Tests', () => {
+  it('should have tests', async () => {
+    const contextMock = {
+      state: {},
+      log: () => {},
+      saveState: jest.fn()
+    }
+    await myComponent.deploy({}, contextMock)
+    expect(false).toBe(true)
+  })
+})


### PR DESCRIPTION
## What has been implemented?

Closes #270
Closes #271
Closes #272

**This should wait for the type-system and replacement removal.**

## Steps to verify

```yaml
type: routes-service

components:
  myAwsVpcRouteTable:
    type: aws-vpc-route-table
    inputs:
      vpcId: vpc-myvpcid
  myAwsVpcRouteTableAssociation:
    type: aws-vpc-route-table-association
    inputs:
      routeTableId: ${myAwsVpcRouteTable.routeTableId}
      subnetId: subnet-abbaabba
  myAwsInternetgateway:
    type: aws-internetgateway
    inputs:
      vpcId: vpc-abbaabba
  myAwsVpcRoute:
    type: aws-vpc-route
    inputs:
      destinationCidrBlock: 0.0.0.0/0
      gatewayId: ${myAwsInternetgateway.internetGatewayId}
      routeTableId: ${myAwsVpcRouteTable.routeTableId}
```

## Todos:

* [x] Write tests
* [x] Write / update documentation
* [x] Run Prettier
