### PR TITLE
Don't require credentials in AwsProvider

### DIFF
--- a/registry/AwsProvider/README.md
+++ b/registry/AwsProvider/README.md
@@ -1,0 +1,35 @@
+# AwsProvider
+
+The `AwsProvider` configures Provider details for Amazon Web Services. It has the following
+options:
+ * `credentials` - an Optional parameter containing access key id and secret access key OR a
+   security token and session token. If both are omitted, credentials will be loaded from
+   `~/.aws/credentials`
+ * `region` - the AWS region to use. Optional, defaults to `us-east-1`
+
+## Examples
+### Using access key & secret and `us-west-2`:
+```yaml
+type: AwsProvider
+  inputs:
+    credentials:
+      accessKeyId: AAAAA
+      secretAccessKey: BBBBBB
+    region: us-west-2
+```
+
+### Using temporary sessions for MFA
+```yaml
+type: AwsProvider
+  inputs:
+    credentials:
+      accessKeyId: AAAAA
+      secretAccessKey: BBBBBB
+      securityToken: CCCCCCCC
+      sessionToken: DDDDDDDD
+```
+
+### Using `~/.aws/credentials` and default region
+```yaml
+type: AwsProvider
+```

--- a/registry/AwsProvider/serverless.yml
+++ b/registry/AwsProvider/serverless.yml
@@ -9,7 +9,7 @@ region: ${inputs.region}
 inputTypes:
   credentials:
     type: object
-    require: true
+    require: false
   region:
     type: string
     require: false


### PR DESCRIPTION
## What has been implemented?
Allows you to omit the credentials in an `AwsProvider` instance, instead allowing `aws-sdk` to pull the creds from `~/.aws/credentials`.

As trivial as this change looks, it works because when credentials aren't defined in the `aws-sdk` config object, it reads the creds from disk

## Steps to verify

* delete the credentials section in sls-web-apps's `AwsProvider` section https://github.com/serverless/serverless-web-application/blob/master/serverless.yml#L35
* deploy sls-web-app