### PR TITLE
Add remove idempotency for AWS components

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -1,45 +1,97 @@
 const mocks = {
   // S3
   createBucketMock: jest.fn().mockReturnValue('bucket-abc'),
-  deleteBucketMock: jest.fn(),
+  deleteBucketMock: jest.fn().mockImplementation((params) => {
+    if (params.Bucket === 'already-removed-bucket') {
+      const error = new Error()
+      error.code = 'NoSuchBucket'
+      return Promise.reject(error)
+    }
+    return Promise.resolve()
+  }),
   listObjectsMock: jest.fn().mockImplementation((params) => {
-    if (params.Bucket === 'some-already-removed-bucket') {
-      return Promise.reject(new Error('The specified bucket does not exist'))
+    if (params.Bucket === 'already-removed-bucket') {
+      const error = new Error()
+      error.code = 'NoSuchBucket'
+      return Promise.reject(error)
     }
     return Promise.resolve({ Contents: [{ Key: 'abc' }] })
   }),
   listObjectsV2Mock: jest.fn().mockImplementation((params) => {
-    if (params.Bucket === 'some-already-removed-bucket') {
-      return Promise.reject(new Error('The specified bucket does not exist'))
+    if (params.Bucket === 'already-removed-bucket') {
+      const error = new Error()
+      error.code = 'NoSuchBucket'
+      return Promise.reject(error)
     }
     return Promise.resolve({ Contents: [{ Key: 'abc' }] })
   }),
-  deleteObjectMock: jest.fn(),
-  deleteObjectsMock: jest.fn(),
+  deleteObjectMock: jest.fn().mockImplementation((params) => {
+    if (params.Bucket === 'already-removed-bucket') {
+      const error = new Error()
+      error.code = 'NoSuchBucket'
+      return Promise.reject(error)
+    }
+    return Promise.resolve()
+  }),
+  deleteObjectsMock: jest.fn().mockImplementation((params) => {
+    if (params.Bucket === 'already-removed-bucket') {
+      const error = new Error()
+      error.code = 'NoSuchBucket'
+      return Promise.reject(error)
+    }
+    return Promise.resolve()
+  }),
   putBucketWebsiteMock: jest.fn(),
   putBucketPolicyMock: jest.fn(),
   putBucketCorsMock: jest.fn(),
   uploadMock: jest.fn(),
-  putRule: jest.fn().mockReturnValue({ RuleArn: 'abc:zxc' }),
-  putTargets: jest.fn(),
-  removeTargets: jest.fn(),
-  deleteRule: jest.fn(),
   addPermission: jest.fn(({ FunctionName }) => ({
     Statement: {
       Resrouce: FunctionName,
       Sid: 'sub:def'
     }
   })),
+
+  // CloudWatchEvents
+  putRule: jest.fn().mockReturnValue({ RuleArn: 'abc:zxc' }),
+  putTargets: jest.fn(),
+  removeTargets: jest.fn().mockImplementation((params) => {
+    if (params.Rule === 'already-removed-rule') {
+      const error = new Error()
+      error.code = 'ResourceNotFoundException'
+      return Promise.reject(error)
+    }
+    return Promise.resolve()
+  }),
+  deleteRule: jest.fn().mockImplementation((params) => {
+    if (params.Name === 'already-removed-rule') {
+      const error = new Error()
+      error.code = 'InternalException'
+      return Promise.reject(error)
+    }
+    return Promise.resolve()
+  }),
+
   // Lambda
   createFunctionMock: jest.fn().mockReturnValue({ FunctionArn: 'abc:zxc' }),
   updateFunctionCodeMock: jest.fn().mockReturnValue({ FunctionArn: 'abc:zxc' }),
   updateFunctionConfigurationMock: jest.fn().mockReturnValue({ FunctionArn: 'abc:zxc' }),
-  deleteFunctionMock: jest.fn(),
+  deleteFunctionMock: jest.fn().mockImplementation((params) => {
+    if (params.FunctionName === 'already-removed-function') {
+      const error = new Error()
+      error.code = 'ResourceNotFoundException'
+      return Promise.reject(error)
+    }
+    return Promise.resolve()
+  }),
+
   // IAM
   createRoleMock: jest.fn().mockReturnValue({ Role: { Arn: 'arn:aws:iam::XXXXX:role/test-role' } }),
   deleteRoleMock: jest.fn().mockImplementation((params) => {
-    if (params.RoleName === 'some-already-removed-role') {
-      return Promise.reject(new Error('Role not found'))
+    if (params.RoleName === 'already-removed-role') {
+      const error = new Error()
+      error.code = 'NoSuchEntity'
+      return Promise.reject(error)
     }
     return Promise.resolve({ Role: { Arn: null } })
   }),
@@ -47,7 +99,14 @@ const mocks = {
   detachRolePolicyMock: jest.fn(),
   updateAssumeRolePolicyMock: jest.fn(),
   createPolicyMock: jest.fn().mockReturnValue({ Policy: { Arn: 'abc:xyz' } }),
-  deletePolicyMock: jest.fn(),
+  deletePolicyMock: jest.fn().mockImplementation((params) => {
+    if (params.PolicyArn === 'already-removed-policy') {
+      const error = new Error()
+      error.code = 'NoSuchEntity'
+      return Promise.reject(error)
+    }
+    return Promise.resolve()
+  }),
   listEntitiesForPolicyMock: jest.fn().mockReturnValue({
     PolicyGroups: ['group'],
     PolicyRoles: ['role'],
@@ -58,12 +117,26 @@ const mocks = {
 
   // SNS
   createTopicMock: jest.fn().mockReturnValue({ TopicArn: 'abc:zxc' }),
-  deleteTopicMock: jest.fn(),
+  deleteTopicMock: jest.fn().mockImplementation((params) => {
+    if (params.TopicArn === 'already-removed-topic') {
+      const error = new Error()
+      error.code = 'NotFound'
+      return Promise.reject(error)
+    }
+    return Promise.resolve()
+  }),
   setTopicAttributesMock: jest.fn(),
   subscribeMock: jest.fn().mockReturnValue({
     SubscriptionArn: 'arn:aws:sns:region:XXXXX:test-subscription:r4nd0m'
   }),
-  unsubscribeMock: jest.fn(),
+  unsubscribeMock: jest.fn().mockImplementation((params) => {
+    if (params.SubscriptionArn === 'already-removed-subscription') {
+      const error = new Error()
+      error.code = 'NotFound'
+      return Promise.reject(error)
+    }
+    return Promise.resolve()
+  }),
 
   // APIGateway
   importRestApi: jest.fn().mockReturnValue({ id: 'my-new-id' }),

--- a/registry/AwsEventsRule/src/index.js
+++ b/registry/AwsEventsRule/src/index.js
@@ -72,13 +72,25 @@ const AwsEventsRule = (SuperClass) =>
         Ids: [this.lambda.functionName]
       }
 
-      await cloudWatchEvents.removeTargets(removeTargetsParams).promise()
+      try {
+        await cloudWatchEvents.removeTargets(removeTargetsParams).promise()
+      } catch (error) {
+        if (error.code !== 'ResourceNotFoundException') {
+          throw error
+        }
+      }
 
       const deleteRuleParams = {
         Name: this.lambda.functionName
       }
 
-      await cloudWatchEvents.deleteRule(deleteRuleParams).promise()
+      try {
+        await cloudWatchEvents.deleteRule(deleteRuleParams).promise()
+      } catch (error) {
+        if (error.code !== 'InternalException') {
+          throw error
+        }
+      }
     }
   }
 

--- a/registry/AwsIamPolicy/src/index.js
+++ b/registry/AwsIamPolicy/src/index.js
@@ -83,9 +83,9 @@ const AwsIamPolicy = (SuperClass) =>
         context.log(`Removing Policy: ${this.policyName}`)
         await deletePolicy(IAM, this.arn, context)
         context.log(`Policy '${this.policyName}' removed.`)
-      } catch (e) {
-        if (!e.message.includes('does not exist or is not attachable')) {
-          throw new Error(e)
+      } catch (error) {
+        if (error.code !== 'NoSuchEntity') {
+          throw error
         }
       }
     }

--- a/registry/AwsIamRole/src/index.js
+++ b/registry/AwsIamRole/src/index.js
@@ -155,9 +155,9 @@ const AwsIamRole = async (SuperClass, superContext) => {
       try {
         context.log(`Removing Role: ${this.roleName}`)
         this.arn = await deleteRole(IAM, this)
-      } catch (e) {
-        if (!e.message.includes('Role not found')) {
-          throw e
+      } catch (error) {
+        if (error.code !== 'NoSuchEntity') {
+          throw error
         }
       }
     }

--- a/registry/AwsLambdaFunction/src/index.js
+++ b/registry/AwsLambdaFunction/src/index.js
@@ -212,8 +212,8 @@ const AwsLambdaFunction = async (SuperClass, superContext) => {
       try {
         await deleteLambda(Lambda, functionName)
       } catch (error) {
-        if (!error.message.includes('Function not found')) {
-          throw new Error(error)
+        if (error.code !== 'ResourceNotFoundException') {
+          throw error
         }
       }
     }

--- a/registry/AwsS3Bucket/src/utils/deleteBucket.js
+++ b/registry/AwsS3Bucket/src/utils/deleteBucket.js
@@ -26,7 +26,7 @@ const deleteBucket = async ({ bucketName, provider }) => {
 
     return s3.deleteBucket({ Bucket: bucketName }).promise()
   } catch (error) {
-    if (!error.message.includes('The specified bucket does not exist')) {
+    if (error.code !== 'NoSuchBucket') {
       throw error
     }
   }

--- a/registry/AwsS3Website/src/index.test.js
+++ b/registry/AwsS3Website/src/index.test.js
@@ -73,6 +73,26 @@ describe('AwsS3Website', () => {
     expect(AWS.mocks.deleteObjectMock).toHaveBeenCalled()
   })
 
+  it('should remove the bucket even if it does not exist anymore', async () => {
+    let oldAwsS3Website = await context.construct(AwsS3Website, {
+      provider,
+      bucket: 'already-removed-bucket',
+      projectDir: path.resolve('./registry'),
+      assets: path.resolve('./registry'),
+      envFileLocation: path.resolve('./src/index.js')
+    })
+    oldAwsS3Website = await context.defineComponent(oldAwsS3Website)
+    oldAwsS3Website = resolveComponentEvaluables(oldAwsS3Website)
+    await oldAwsS3Website.deploy(null, context)
+
+    const prevAwsS3Website = await deserialize(serialize(oldAwsS3Website, context), context)
+    await prevAwsS3Website.remove(context)
+
+    expect(AWS.mocks.listObjectsMock).toBeCalledWith({ Bucket: 'already-removed-bucket' })
+    expect(AWS.mocks.deleteObjectMock).not.toHaveBeenCalled()
+    expect(AWS.mocks.deleteBucketMock).not.toHaveBeenCalled()
+  })
+
   it('shouldDeploy should return undefined if no changes', async () => {
     let oldAwsS3Website = await context.construct(AwsS3Website, {
       provider,

--- a/registry/AwsSnsSubscription/src/index.js
+++ b/registry/AwsSnsSubscription/src/index.js
@@ -112,7 +112,14 @@ const AwsSnsSubscription = (SuperClass) =>
     }
 
     async remove(context) {
-      return getProtocol(this.protocol).remove(this, context)
+      try {
+        const res = await getProtocol(this.protocol).remove(this, context)
+        return res
+      } catch (error) {
+        if (error.code !== 'NotFound') {
+          throw error.message
+        }
+      }
     }
 
     async info() {

--- a/registry/AwsSnsTopic/src/index.js
+++ b/registry/AwsSnsTopic/src/index.js
@@ -229,11 +229,17 @@ const AwsSnsTopic = (SuperClass) =>
       const AWS = provider.getSdk()
       const sns = new AWS.SNS()
       context.log(`Removing SNS topic: '${this.topicName}'`)
-      await sns
-        .deleteTopic({
-          TopicArn: this.topicArn
-        })
-        .promise()
+      try {
+        await sns
+          .deleteTopic({
+            TopicArn: this.topicArn
+          })
+          .promise()
+      } catch (error) {
+        if (error.code !== 'NotFound') {
+          throw error
+        }
+      }
       context.log(`SNS topic '${this.topicName}' removed.`)
     }
 


### PR DESCRIPTION
This PRs adds idempotency guarantees on removals for AWS components.

The implementation is based on the error codes AWS provides. This way we're not checking error-messages anymore which might be changed in the future. Unit tests were added to ensure the functionality.

**Note 1:** Right now the `AwsApiGateway` component was not updates since the API docs and its error codes are unavailable ATM --> https://docs.aws.amazon.com/goto/WebAPI/apigateway-2015-07-09/DeleteRestApi

**Note 2:** I've implemented this against the AWS SDK docs and checked the error structure (how to access the `code`) via `AwsIamRole` manually. Assume that not all components were tested manually and that the code I've picked from the docs might be wrong (updating this is a no-brainer though).

AWS components updated:

- [ ] `AwsApiGateway`
- [x] `AwsDynamoDB` (this was done in https://github.com/serverless/components/pull/341)
- [x] `AwsEventsRule`
- [x] `AwsIamPolicy`
- [x] `AwsIamRole`
- [x] `AwsLambdaFunction`
- [x] `AwsS3Bucket`
- [x] `AwsS3Website`
- [x] `AwsSnsSubscription`
- [x] `AwsSnsTopic`

/cc @brianneisler 