### PR TITLE
AwsIamRole name length validation

### DIFF
--- a/registry/AwsIamRole/serverless.yml
+++ b/registry/AwsIamRole/serverless.yml
@@ -17,6 +17,7 @@ inputTypes:
     default: role-${self.instanceId}
     displayName: IAM role name
     description: The name of the role to create
+    maxLength: 64
   service:
     type: string
     required: true

--- a/registry/AwsIamRole/src/index.js
+++ b/registry/AwsIamRole/src/index.js
@@ -84,6 +84,16 @@ const AwsIamRole = async (SuperClass, superContext) => {
     async construct(inputs, context) {
       await super.construct(inputs, context)
 
+      // TODO: remove this validation once core supports full RAML spec
+      const roleNameMaxLength = this.inputTypes.roleName.maxLength
+      if (inputs.roleName && inputs.roleName.length > roleNameMaxLength) {
+        throw new Error(
+          `IAM role name "${inputs.roleName}" is ${
+            inputs.roleName.length
+          } characters long (max. allowed length is 64)`
+        )
+      }
+
       // HACK BRN: Temporary workaround until we add property type/default support
       const defaultPolicy = {
         arn: 'arn:aws:iam::aws:policy/AdministratorAccess'

--- a/registry/AwsIamRole/src/index.test.js
+++ b/registry/AwsIamRole/src/index.test.js
@@ -1,5 +1,6 @@
 import AWS from 'aws-sdk'
 import path from 'path'
+import crypto from 'crypto'
 import { sleep } from '@serverless/utils'
 import {
   createContext,
@@ -48,6 +49,24 @@ describe('AwsIamRole', () => {
 
     const AwsProvider = await context.loadType('AwsProvider')
     provider = await context.construct(AwsProvider, {})
+  })
+
+  it('should throw if role name is greater than 64 characters', async () => {
+    const roleName = crypto.randomBytes(33).toString('hex')
+
+    const inputs = {
+      roleName,
+      service: 'lambda.amazonaws.com',
+      provider
+    }
+
+    try {
+      const awsIamRole = await context.construct(AwsIamRole, inputs)
+      await context.defineComponent(awsIamRole)
+      resolveComponentEvaluables(awsIamRole)
+    } catch (error) {
+      expect(error.message).toMatch('allowed length is 64')
+    }
   })
 
   it('should create role if first deployment', async () => {


### PR DESCRIPTION
Adds a validation which checks for the length of tha `AwsIamRole` name property.

/cc @sebito91 