### PR TITLE
Inline IamRole Policies & better default creation for lambdas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
         - secure: Fzuq8z/p3+vb3DdsQJEPS9SAyGMUZ3hpgFSMUIglSVldgnHBKZ9GARjJvRLsyeBfnDJ1KL3MyMd5xbUK9glk4VyA54xrsuUX4Guuk9U0cueCEgfe2TMC50LTrJIUHREBal9hktyK5m9U5Kof4QeMRzcUN9VuscP2WS0Qt2TJMXbpsrcp++oD6kfZlyrvhQMAcv9ghgtBGeDBG90nJiE6eey5G1PkNECIY1t3raFgZdZnDs0FFLURZI91JvRgUxoN/rm1nRoBIE4yUHnx2ovXfqBps24LnSQVxDU73NJ39mGZhvDjJ3+KdlZwwwsADRhqP2ghUP0SZlEnHH8kcANA6O25ge+M6dGlsQ5uVqGKcuLFH7SoVgeQUWKb2XOdJZcWI/lby/TjWCtAG9AXdlX/42VKT0SR/QfjfG/acuFwFTQdwRx6AnquW+IQ8P5aKWd2re9SGi6FWi33eods0WnDQXN49BabRt8CeXzhF8X7wj1ccTeflsAeRgC1JOiRfKbDCbHzOPe9iLP+ivo8loXbQE0xhc3K2cYvUWHr4Cilkk2LLR/GhWWRwl+yvC/WWGtjGy66ponnYscGcCWEuJSCErfu56Z97r2JuDrKCVoTzcc//5lpkSl06wvlsvzz1Lr8kf6DKekmJbmDLZ394FfSMurZldc+ARHjYoi8TInvUkU=
 install:
 - npm install
+- node --version | grep v6 && npm run prepare || true
 - npm install -g codecov
 - pushd examples/restapi/code && npm install && popd
 script:

--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -151,7 +151,14 @@ const mocks = {
       return Promise.reject(error)
     }
     return Promise.resolve()
-  })
+  }),
+
+  // STS
+  getCallerIdentity: jest.fn().mockReturnValue(
+    Promise.resolve({
+      Account: 'account-id'
+    })
+  )
 }
 
 const APIGateway = function() {
@@ -304,6 +311,14 @@ const SNS = function() {
   }
 }
 
+const STS = function() {
+  return {
+    getCallerIdentity: (obj) => ({
+      promise: () => mocks.getCallerIdentity(obj)
+    })
+  }
+}
+
 export default {
   mocks,
   config: {
@@ -314,5 +329,6 @@ export default {
   IAM,
   Lambda,
   S3,
-  SNS
+  SNS,
+  STS
 }

--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -96,7 +96,9 @@ const mocks = {
     return Promise.resolve({ Role: { Arn: null } })
   }),
   attachRolePolicyMock: jest.fn(),
+  putRolePolicyMock: jest.fn(),
   detachRolePolicyMock: jest.fn(),
+  deleteRolePolicyMock: jest.fn(),
   updateAssumeRolePolicyMock: jest.fn(),
   createPolicyMock: jest.fn().mockReturnValue({ Policy: { Arn: 'abc:xyz' } }),
   deletePolicyMock: jest.fn().mockImplementation((params) => {
@@ -197,8 +199,14 @@ const IAM = function() {
     attachRolePolicy: (obj) => ({
       promise: () => mocks.attachRolePolicyMock(obj)
     }),
+    putRolePolicy: (obj) => ({
+      promise: () => mocks.putRolePolicyMock(obj)
+    }),
     detachRolePolicy: (obj) => ({
       promise: () => mocks.detachRolePolicyMock(obj)
+    }),
+    deleteRolePolicy: (obj) => ({
+      promise: () => mocks.deleteRolePolicyMock(obj)
     }),
     updateAssumeRolePolicy: (obj) => ({
       promise: () => mocks.updateAssumeRolePolicyMock(obj)

--- a/registry/AwsIamRole/serverless.yml
+++ b/registry/AwsIamRole/serverless.yml
@@ -27,4 +27,4 @@ inputTypes:
   policy:
     type: object
     displayName: IAM Role Policy
-    description: The policy that grants an entity permission to assume the role
+    description: A managed IAM policy or an inline policy document

--- a/registry/AwsIamRole/serverless.yml
+++ b/registry/AwsIamRole/serverless.yml
@@ -26,5 +26,6 @@ inputTypes:
     example: lambda.amazonaws.com
   policy:
     type: object
+    returied: true
     displayName: IAM Role Policy
     description: A managed IAM policy or an inline policy document

--- a/registry/AwsIamRole/src/index.js
+++ b/registry/AwsIamRole/src/index.js
@@ -122,11 +122,8 @@ const AwsIamRole = async (SuperClass, superContext) => {
         )
       }
 
-      // HACK BRN: Temporary workaround until we add property type/default support
-      const defaultPolicy = {}
       this.provider = inputs.provider
       this.service = inputs.service
-      this.policy = resolvable(() => or(inputs.policy, defaultPolicy))
       this.roleName = resolvable(() => or(inputs.roleName, `role-${this.instanceId}`))
     }
 

--- a/registry/AwsIamRole/src/index.js
+++ b/registry/AwsIamRole/src/index.js
@@ -1,19 +1,47 @@
-import { get, equals, is, resolve, sleep, or, resolvable, not, pick, keys } from '@serverless/utils'
+import {
+  get,
+  equals,
+  is,
+  isEmpty,
+  has,
+  resolve,
+  sleep,
+  or,
+  resolvable,
+  not,
+  pick,
+  keys
+} from '@serverless/utils'
 
-const attachRolePolicy = async (IAM, { roleName, policy }) => {
-  await IAM.attachRolePolicy({
-    RoleName: roleName,
-    PolicyArn: policy.arn
-  }).promise()
+const addRolePolicy = async (IAM, { roleName, policy }) => {
+  if (has('arn', policy)) {
+    await IAM.attachRolePolicy({
+      RoleName: roleName,
+      PolicyArn: policy.arn
+    }).promise()
+  } else if (!isEmpty(policy)) {
+    await IAM.putRolePolicy({
+      RoleName: roleName,
+      PolicyName: `${roleName}-policy`,
+      PolicyDocument: JSON.stringify(policy)
+    }).promise()
+  }
 
   return sleep(15000)
 }
 
-const detachRolePolicy = async (IAM, { roleName, policy }) => {
-  await IAM.detachRolePolicy({
-    RoleName: roleName,
-    PolicyArn: policy.arn
-  }).promise()
+const removeRolePolicy = async (IAM, { roleName, policy }) => {
+  if (has('arn', policy)) {
+    await IAM.detachRolePolicy({
+      RoleName: roleName,
+      PolicyArn: policy.arn
+    }).promise()
+  } else if (!isEmpty(policy)) {
+    await IAM.deleteRolePolicy({
+      RoleName: roleName,
+      PolicyName: `${roleName}-policy`
+    }).promise()
+  }
 }
 
 const createRole = async (IAM, { roleName, service, policy }) => {
@@ -33,7 +61,7 @@ const createRole = async (IAM, { roleName, service, policy }) => {
     AssumeRolePolicyDocument: JSON.stringify(assumeRolePolicyDocument)
   }).promise()
 
-  await attachRolePolicy(IAM, {
+  await addRolePolicy(IAM, {
     roleName,
     policy
   })
@@ -43,7 +71,7 @@ const createRole = async (IAM, { roleName, service, policy }) => {
 
 const deleteRole = async (IAM, { roleName, policy }) => {
   try {
-    await detachRolePolicy(IAM, {
+    await removeRolePolicy(IAM, {
       roleName,
       policy
     })
@@ -95,9 +123,7 @@ const AwsIamRole = async (SuperClass, superContext) => {
       }
 
       // HACK BRN: Temporary workaround until we add property type/default support
-      const defaultPolicy = {
-        arn: 'arn:aws:iam::aws:policy/AdministratorAccess'
-      }
+      const defaultPolicy = {}
       this.provider = inputs.provider
       this.service = inputs.service
       this.policy = resolvable(() => or(inputs.policy, defaultPolicy))
@@ -151,8 +177,8 @@ const AwsIamRole = async (SuperClass, superContext) => {
           await updateAssumeRolePolicy(IAM, this)
         }
         if (!equals(prevInstance.policy, this.policy)) {
-          await detachRolePolicy(IAM, prevInstance)
-          await attachRolePolicy(IAM, { roleName: this.roleName, policy: this.policy })
+          await removeRolePolicy(IAM, prevInstance)
+          await addRolePolicy(IAM, { roleName: this.roleName, policy: this.policy })
         }
       }
     }

--- a/registry/AwsIamRole/src/index.test.js
+++ b/registry/AwsIamRole/src/index.test.js
@@ -73,7 +73,10 @@ describe('AwsIamRole', () => {
     const inputs = {
       roleName: 'abc',
       service: 'lambda.amazonaws.com',
-      provider
+      provider,
+      policy: {
+        arn: 'arn:aws:iam::aws:policy/AdministratorAccess'
+      }
     }
 
     let awsIamRole = await context.construct(AwsIamRole, inputs)
@@ -110,6 +113,56 @@ describe('AwsIamRole', () => {
     expect(sleep).toBeCalledWith(15000)
   })
 
+  it('should attach inline policy if specified', async () => {
+    const inputs = {
+      roleName: 'abc',
+      service: 'lambda.amazonaws.com',
+      provider,
+      policy: {
+        Version: '2012-10-17',
+        Statement: {
+          Action: ['*'],
+          Resource: ['*'],
+          Effect: 'Allow'
+        }
+      }
+    }
+
+    let awsIamRole = await context.construct(AwsIamRole, inputs)
+    awsIamRole = await context.defineComponent(awsIamRole)
+    awsIamRole = resolveComponentEvaluables(awsIamRole)
+
+    await awsIamRole.deploy(undefined, context)
+
+    const createRoleParams = {
+      RoleName: inputs.roleName,
+      Path: '/',
+      AssumeRolePolicyDocument: JSON.stringify({
+        Version: '2012-10-17',
+        Statement: {
+          Effect: 'Allow',
+          Principal: {
+            Service: inputs.service
+          },
+          Action: 'sts:AssumeRole'
+        }
+      })
+    }
+
+    const putRolePolicyParams = {
+      RoleName: inputs.roleName,
+      PolicyName: `${inputs.roleName}-policy`,
+      PolicyDocument: JSON.stringify(inputs.policy)
+    }
+
+    expect(AWS.mocks.createRoleMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.createRoleMock).toBeCalledWith(createRoleParams)
+    expect(AWS.mocks.putRolePolicyMock).toHaveBeenCalledTimes(1)
+    expect(AWS.mocks.putRolePolicyMock).toBeCalledWith(putRolePolicyParams)
+    expect(awsIamRole.arn).toEqual('arn:aws:iam::XXXXX:role/test-role')
+    expect(sleep).toBeCalledWith(15000)
+  })
+
   it('should update if role name has changed', async () => {
     let oldAwsIamRole = await context.construct(AwsIamRole, {
       roleName: 'old-role-name',
@@ -141,7 +194,10 @@ describe('AwsIamRole', () => {
     const inputs = {
       roleName: 'abc',
       service: 'apig.amazonaws.com',
-      provider
+      provider,
+      policy: {
+        arn: 'arn:aws:iam::aws:policy/AdministratorAccess'
+      }
     }
 
     let awsIamRole = await context.construct(AwsIamRole, inputs)
@@ -180,7 +236,10 @@ describe('AwsIamRole', () => {
     const inputs = {
       roleName: 'abc',
       service: 'lambda.amazonaws.com',
-      provider
+      provider,
+      policy: {
+        arn: 'arn:aws:iam::aws:policy/AdministratorAccess'
+      }
     }
 
     let awsIamRole = await context.construct(AwsIamRole, inputs)

--- a/registry/AwsIamRole/src/index.test.js
+++ b/registry/AwsIamRole/src/index.test.js
@@ -9,6 +9,8 @@ import {
   serialize
 } from '../../../src/utils'
 
+jest.setTimeout(10000)
+
 let context
 let provider
 let AwsIamRole

--- a/registry/AwsLambdaFunction/src/index.js
+++ b/registry/AwsLambdaFunction/src/index.js
@@ -147,7 +147,9 @@ const AwsLambdaFunction = async (SuperClass, superContext) => {
       if (!role) {
         const provider = resolve(this.provider)
         const region = resolve(provider.region)
-        const { accountId } = { accountId: '*' } // await provider.getAccountInfo()
+        const AWS = provider.getSdk()
+        const STS = new AWS.STS()
+        const { Account } = await STS.getCallerIdentity().promise()
         role = await context.construct(
           AwsIamRole,
           {
@@ -160,16 +162,14 @@ const AwsLambdaFunction = async (SuperClass, superContext) => {
                 {
                   Action: ['logs:CreateLogStream'],
                   Resource: [
-                    `arn:aws:logs:${region}:${accountId}:log-group:/aws/lambda/${
-                      this.functionName
-                    }:*`
+                    `arn:aws:logs:${region}:${Account}:log-group:/aws/lambda/${this.functionName}:*`
                   ],
                   Effect: 'Allow'
                 },
                 {
                   Action: ['logs:PutLogEvents'],
                   Resource: [
-                    `arn:aws:logs:${region}:${accountId}:log-group:/aws/lambda/${
+                    `arn:aws:logs:${region}:${Account}:log-group:/aws/lambda/${
                       this.functionName
                     }:*:*`
                   ],

--- a/registry/AwsLambdaFunction/src/index.js
+++ b/registry/AwsLambdaFunction/src/index.js
@@ -157,14 +157,14 @@ const AwsLambdaFunction = async (SuperClass, superContext) => {
                 {
                   Action: ['logs:CreateLogStream'],
                   Resource: [
-                    `arn:aws:logs:us-east-1:*:log-group:/aws/lambda/${this.functionName}:*`
+                    `arn:aws:logs:${this.provider.region}:*:log-group:/aws/lambda/${this.functionName}:*`
                   ],
                   Effect: 'Allow'
                 },
                 {
                   Action: ['logs:PutLogEvents'],
                   Resource: [
-                    `arn:aws:logs:us-east-1:*:log-group:/aws/lambda/${this.functionName}:*:*`
+                    `arn:aws:logs:${this.provider.region}:*:log-group:/aws/lambda/${this.functionName}:*:*`
                   ],
                   Effect: 'Allow'
                 }

--- a/registry/AwsLambdaFunction/src/index.js
+++ b/registry/AwsLambdaFunction/src/index.js
@@ -150,7 +150,26 @@ const AwsLambdaFunction = async (SuperClass, superContext) => {
           {
             roleName: `${resolve(this.functionName)}-execution-role`,
             service: 'lambda.amazonaws.com',
-            provider: this.provider
+            provider: this.provider,
+            policy: {
+              Version: '2012-10-17',
+              Statement: [
+                {
+                  Action: ['logs:CreateLogStream'],
+                  Resource: [
+                    `arn:aws:logs:us-east-1:*:log-group:/aws/lambda/${this.functionName}:*`
+                  ],
+                  Effect: 'Allow'
+                },
+                {
+                  Action: ['logs:PutLogEvents'],
+                  Resource: [
+                    `arn:aws:logs:us-east-1:*:log-group:/aws/lambda/${this.functionName}:*:*`
+                  ],
+                  Effect: 'Allow'
+                }
+              ]
+            }
           },
           context
         )

--- a/registry/AwsLambdaFunction/src/index.js
+++ b/registry/AwsLambdaFunction/src/index.js
@@ -145,6 +145,9 @@ const AwsLambdaFunction = async (SuperClass, superContext) => {
     async define(context) {
       let role = resolve(this.role)
       if (!role) {
+        const provider = resolve(this.provider)
+        const region = resolve(provider.region)
+        const { accountId } = { accountId: '*' } // await provider.getAccountInfo()
         role = await context.construct(
           AwsIamRole,
           {
@@ -157,14 +160,18 @@ const AwsLambdaFunction = async (SuperClass, superContext) => {
                 {
                   Action: ['logs:CreateLogStream'],
                   Resource: [
-                    `arn:aws:logs:${this.provider.region}:*:log-group:/aws/lambda/${this.functionName}:*`
+                    `arn:aws:logs:${region}:${accountId}:log-group:/aws/lambda/${
+                      this.functionName
+                    }:*`
                   ],
                   Effect: 'Allow'
                 },
                 {
                   Action: ['logs:PutLogEvents'],
                   Resource: [
-                    `arn:aws:logs:${this.provider.region}:*:log-group:/aws/lambda/${this.functionName}:*:*`
+                    `arn:aws:logs:${region}:${accountId}:log-group:/aws/lambda/${
+                      this.functionName
+                    }:*:*`
                   ],
                   Effect: 'Allow'
                 }

--- a/registry/AwsLambdaFunction/src/index.test.js
+++ b/registry/AwsLambdaFunction/src/index.test.js
@@ -6,7 +6,7 @@ import { readFileSync } from 'fs'
 import { deserialize, resolveComponentEvaluables, serialize } from '../../../src/utils'
 import { createTestContext } from '../../../test'
 
-jest.setTimeout(10000)
+jest.setTimeout(30000)
 
 jest.mock('@serverless/utils', () => ({
   ...require.requireActual('@serverless/utils'),

--- a/registry/AwsLambdaFunction/src/index.test.js
+++ b/registry/AwsLambdaFunction/src/index.test.js
@@ -864,14 +864,18 @@ describe('AwsLambdaFunction', () => {
         {
           Action: ['logs:CreateLogStream'],
           Resource: [
-            `arn:aws:logs:us-east-1:*:log-group:/aws/lambda/${awsLambdaFunction.functionName}:*`
+            `arn:aws:logs:us-east-1:account-id:log-group:/aws/lambda/${
+              awsLambdaFunction.functionName
+            }:*`
           ],
           Effect: 'Allow'
         },
         {
           Action: ['logs:PutLogEvents'],
           Resource: [
-            `arn:aws:logs:us-east-1:*:log-group:/aws/lambda/${awsLambdaFunction.functionName}:*:*`
+            `arn:aws:logs:us-east-1:account-id:log-group:/aws/lambda/${
+              awsLambdaFunction.functionName
+            }:*:*`
           ],
           Effect: 'Allow'
         }

--- a/registry/AwsLambdaFunction/src/index.test.js
+++ b/registry/AwsLambdaFunction/src/index.test.js
@@ -836,7 +836,7 @@ describe('AwsLambdaFunction', () => {
 
   it('should load AwsIamRole if role is not provided', async () => {
     let awsLambdaFunction = await context.construct(AwsLambdaFunction, {
-      provider,
+      provider: await context.construct(AwsProvider, { region: 'us-east-1' }),
       code: './code',
       functionName: 'hello',
       functionDescription: 'hello description',
@@ -858,5 +858,24 @@ describe('AwsLambdaFunction', () => {
     const children = await awsLambdaFunction.define(context)
     const role = resolveComponentEvaluables(children.role)
     expect(role.roleName).toBe(`${awsLambdaFunction.functionName}-execution-role`)
+    expect(role.policy).toEqual({
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: ['logs:CreateLogStream'],
+          Resource: [
+            `arn:aws:logs:us-east-1:*:log-group:/aws/lambda/${awsLambdaFunction.functionName}:*`
+          ],
+          Effect: 'Allow'
+        },
+        {
+          Action: ['logs:PutLogEvents'],
+          Resource: [
+            `arn:aws:logs:us-east-1:*:log-group:/aws/lambda/${awsLambdaFunction.functionName}:*:*`
+          ],
+          Effect: 'Allow'
+        }
+      ]
+    })
   })
 })

--- a/registry/AwsProvider/src/index.js
+++ b/registry/AwsProvider/src/index.js
@@ -1,9 +1,10 @@
+import { resolve } from '@serverless/utils'
 import AWS from 'aws-sdk'
 
 const AwsProvider = {
   getSdk() {
     // TODO BRN: This won't work for multi provider/region
-    AWS.config.update({ region: this.region, credentials: this.credentials })
+    AWS.config.update({ region: resolve(this.region), credentials: resolve(this.credentials) })
     return AWS
   },
   getCredentials() {


### PR DESCRIPTION
## What has been implemented?

* AwsIamRole now supports being given an inline policy in addition to one with an ARN
* AwsIamRole no longer defaults to attaching the admin policy
* AwsLambdaCompute now specifies the minimum inline role that a lambda needs
  * doesn't currently set account Id in the ARN, not sure if that's available in this context?

## Steps to verify

* run `components deploy` in a service using AwsLambdaCompute without roles specified
* in the AWS console check that the roles created have an inline policy granting perms to create & write to a the right cloudwatch log group and not have the managed AdministratorAccess policy attached.

## Todos:

* [x] Write tests
* [x] Write / update documentation
* [x] Run Prettier
