### PR TITLE
Fix AwsSnsTopic check for changes

### DIFF
--- a/registry/AwsSnsTopic/src/index.js
+++ b/registry/AwsSnsTopic/src/index.js
@@ -163,10 +163,10 @@ const AwsSnsTopic = (SuperClass) =>
 
       this.provider = resolvable(() => or(inputs.provider, context.get('provider')))
       this.topicName = resolvable(() => or(inputs.topicName, `sns-${this.instanceId}`))
+      this.deliveryStatusAttributes = resolvable(() => or(inputs.deliveryStatusAttributes, []))
       this.displayName = inputs.displayName
       this.policy = inputs.policy
       this.deliveryPolicy = inputs.deliveryPolicy
-      this.deliveryStatusAttributes = inputs.deliveryStatusAttributes
     }
 
     shouldDeploy(prevInstance) {

--- a/registry/AwsSnsTopic/src/index.test.js
+++ b/registry/AwsSnsTopic/src/index.test.js
@@ -180,6 +180,26 @@ describe('AwsSnsTopic', () => {
     expect(res).toBe(undefined)
   })
 
+  it('shouldDeploy should return "undefined" if nothing changed and only required inputs are provided', async () => {
+    const inputs = {
+      topicName: 'myTopic',
+      provider
+    }
+    let oldComponent = await context.construct(AwsSnsTopic, inputs)
+    oldComponent = await context.defineComponent(oldComponent)
+    oldComponent = resolveComponentEvaluables(oldComponent)
+    await oldComponent.deploy(null, context)
+
+    const prevComponent = await deserialize(serialize(oldComponent, context), context)
+
+    let newComponent = await context.construct(AwsSnsTopic, inputs)
+    newComponent = await context.defineComponent(newComponent)
+    newComponent = resolveComponentEvaluables(newComponent)
+
+    const res = newComponent.shouldDeploy(prevComponent)
+    expect(res).toBe(undefined)
+  })
+
   it('shouldDeploy should return "replace" if "topic" changed', async () => {
     const inputs = {
       topicName: 'myTopic',


### PR DESCRIPTION
Fixes a bug where SNS topics are constantly re-deployed if if they haven't changed.

Added a regression test to ensure that this bug won't happen again in the near future.

From a DM with @raeesbhatti:

> The issue is that since we're using stuff like `{ foo = [] }` in function arguments we're setting defaults when values are not provided. This was the case for `deliveryStatusAttributes`. If it's not set via `inputs` it's `undefined`. However it's re-assigned to `[]` in the other functions it runs through. This causes `prevInstance.inputs.deliveryStatusAttributes` to have the value `[]` whereas inputs has `undefined`. This in turn causes the check if the inputs changed to return true every time, hence causing a re-deploy.

/cc @shortjared @mthenw 