### PR TITLE
Silent component logging

### DIFF
--- a/src/utils/context/newContext.js
+++ b/src/utils/context/newContext.js
@@ -5,12 +5,11 @@ import defineComponentFromState from '../component/defineComponentFromState'
 import generateInstanceId from '../component/generateInstanceId'
 // import setKey from '../component/setKey'
 import { DEFAULT_PLUGINS } from '../constants'
+import { log, debug, warn, error, info } from '../logging'
 import createDeployment from '../deployment/createDeployment'
 import createRemovalDeployment from '../deployment/createRemovalDeployment'
 import loadDeployment from '../deployment/loadDeployment'
 import loadPreviousDeployment from '../deployment/loadPreviousDeployment'
-import debug from '../logging/debug'
-import log from '../logging/log'
 import loadPlugins from '../plugin/loadPlugins'
 import loadProject from '../project/loadProject'
 import deserialize from '../serialize/deserialize'
@@ -49,6 +48,15 @@ const newContext = (props) => {
   const overrides = context.overrides || {}
   const finalContext = {
     ...context,
+    log: (...args) => log(finalContext, ...args),
+    debug: (...args) => debug(finalContext, ...args),
+    console: {
+      log: (...args) => log(finalContext, ...args),
+      debug: (...args) => debug(finalContext, ...args),
+      warn: (...args) => warn(finalContext, ...args),
+      error: (...args) => error(finalContext, ...args),
+      info: (...args) => info(finalContext, ...args)
+    },
     construct: (type, inputs) => construct(type, inputs, finalContext),
     create,
     createDeployment: async () => {
@@ -110,7 +118,6 @@ const newContext = (props) => {
         instance
       })
     },
-    debug: (...args) => debug(finalContext, ...args),
     defineComponent: (component, state) => defineComponent(component, state, finalContext),
     defineComponentFromState: (component) => defineComponentFromState(component, finalContext),
     defType: (def) => defType(def, finalContext),
@@ -244,7 +251,6 @@ const newContext = (props) => {
       })
     },
     loadType: (...args) => loadType(...args, finalContext),
-    log: (...args) => log(finalContext, ...args),
     merge: (value) =>
       newContext({
         ...context,

--- a/src/utils/context/newContext.test.js
+++ b/src/utils/context/newContext.test.js
@@ -21,6 +21,13 @@ describe('#newContext()', () => {
     expect(context).toEqual({
       app: {},
       cache: {},
+      console: {
+        log: expect.any(Function),
+        debug: expect.any(Function),
+        info: expect.any(Function),
+        warn: expect.any(Function),
+        error: expect.any(Function)
+      },
       construct: expect.any(Function),
       create: expect.any(Function),
       createDeployment: expect.any(Function),

--- a/src/utils/dag/deployGraph.test.js
+++ b/src/utils/dag/deployGraph.test.js
@@ -15,6 +15,11 @@ describe('#deployGraph()', () => {
 
   beforeEach(async () => {
     context = await createTestContext()
+    // NOTE: we need to replace `log` with `debug` since this is what components get
+    context = {
+      ...context,
+      log: context.debug
+    }
   })
 
   it('calls deploy when shouldDeploy returns "deploy"', async () => {

--- a/src/utils/dag/execGraph.js
+++ b/src/utils/dag/execGraph.js
@@ -2,7 +2,12 @@ import { all, append, isEmpty, reduce } from '@serverless/utils'
 import cloneGraph from './cloneGraph'
 import detectCircularDeps from './detectCircularDeps'
 
-const execNode = (iteratee, node, context) => iteratee(node, context)
+const execNode = (iteratee, node, context) =>
+  iteratee(node, {
+    ...context,
+    // replace `log` with `debug` so that component logs are hidden by default
+    log: context.debug
+  })
 
 const execNodeIds = async (iteratee, nodeIds, graph, context) =>
   all(

--- a/src/utils/dag/execGraph.test.js
+++ b/src/utils/dag/execGraph.test.js
@@ -10,20 +10,25 @@ describe('#execGraph()', () => {
     graph.setNode('testB', testNodeB)
     graph.setEdge('testA', 'testB')
 
-    const testContext = {
-      debug: () => {},
-      log: () => {}
+    const context = {
+      log: () => {},
+      debug: () => {}
     }
     const executor = {
       iteratee: jest.fn(),
       next: jest.fn((grph) => grph.sinks())
     }
-    const result = execGraph(executor, graph, testContext)
+    const result = execGraph(executor, graph, context)
     expect(result).toBeInstanceOf(Promise)
 
     await result
 
-    expect(executor.iteratee).toHaveBeenNthCalledWith(1, testNodeB, testContext)
-    expect(executor.iteratee).toHaveBeenNthCalledWith(2, testNodeA, testContext)
+    const modifiedContext = {
+      log: context.debug,
+      debug: context.debug
+    }
+
+    expect(executor.iteratee).toHaveBeenNthCalledWith(1, testNodeB, modifiedContext)
+    expect(executor.iteratee).toHaveBeenNthCalledWith(2, testNodeA, modifiedContext)
   })
 })

--- a/src/utils/dag/removeGraph.test.js
+++ b/src/utils/dag/removeGraph.test.js
@@ -16,6 +16,11 @@ describe('#removeGraph()', () => {
 
   beforeEach(async () => {
     context = await createTestContext()
+    // NOTE: we need to replace `log` with `debug` since this is what components get
+    context = {
+      ...context,
+      log: context.debug
+    }
   })
 
   it('calls remove when shouldDeploy returns "remove"', async () => {

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -87,7 +87,10 @@ describe('index', () => {
     const mod = require('./logging')
     expect(mod).toEqual({
       debug: expect.any(Function),
-      log: expect.any(Function)
+      log: expect.any(Function),
+      info: expect.any(Function),
+      warn: expect.any(Function),
+      error: expect.any(Function)
     })
   })
 

--- a/src/utils/logging/error.js
+++ b/src/utils/logging/error.js
@@ -1,0 +1,8 @@
+const error = (context, ...args) => {
+  if (!process.env.CI) {
+    // eslint-disable-next-line no-console
+    console.log(...args)
+  }
+}
+
+export default error

--- a/src/utils/logging/error.test.js
+++ b/src/utils/logging/error.test.js
@@ -1,4 +1,4 @@
-import log from './log'
+import error from './error'
 
 jest.spyOn(global.console, 'log')
 
@@ -7,7 +7,7 @@ afterAll(() => {
   delete process.env.CI
 })
 
-describe('#log()', () => {
+describe('#error()', () => {
   const msg = 'Hello World!'
 
   beforeEach(() => {
@@ -16,13 +16,13 @@ describe('#log()', () => {
   })
 
   it('should log message using console.log (node 6 and <= 8.9 support)', () => {
-    log(undefined, msg)
+    error(undefined, msg)
     expect(global.console.log).toHaveBeenCalledWith(msg)
   })
 
   it('should not write message to log if CI env var is set', () => {
     process.env.CI = true
-    log(undefined, msg)
+    error(undefined, msg)
     expect(global.console.log).not.toHaveBeenCalled()
   })
 })

--- a/src/utils/logging/index.js
+++ b/src/utils/logging/index.js
@@ -1,2 +1,5 @@
 export { default as debug } from './debug'
+export { default as error } from './error'
+export { default as info } from './info'
 export { default as log } from './log'
+export { default as warn } from './warn'

--- a/src/utils/logging/info.js
+++ b/src/utils/logging/info.js
@@ -1,0 +1,8 @@
+const info = (context, ...args) => {
+  if (!process.env.CI) {
+    // eslint-disable-next-line no-console
+    console.log(...args)
+  }
+}
+
+export default info

--- a/src/utils/logging/info.test.js
+++ b/src/utils/logging/info.test.js
@@ -1,4 +1,4 @@
-import log from './log'
+import info from './info'
 
 jest.spyOn(global.console, 'log')
 
@@ -7,7 +7,7 @@ afterAll(() => {
   delete process.env.CI
 })
 
-describe('#log()', () => {
+describe('#info()', () => {
   const msg = 'Hello World!'
 
   beforeEach(() => {
@@ -16,13 +16,13 @@ describe('#log()', () => {
   })
 
   it('should log message using console.log (node 6 and <= 8.9 support)', () => {
-    log(undefined, msg)
+    info(undefined, msg)
     expect(global.console.log).toHaveBeenCalledWith(msg)
   })
 
   it('should not write message to log if CI env var is set', () => {
     process.env.CI = true
-    log(undefined, msg)
+    info(undefined, msg)
     expect(global.console.log).not.toHaveBeenCalled()
   })
 })

--- a/src/utils/logging/warn.js
+++ b/src/utils/logging/warn.js
@@ -1,0 +1,8 @@
+const warn = (context, ...args) => {
+  if (!process.env.CI) {
+    // eslint-disable-next-line no-console
+    console.log(...args)
+  }
+}
+
+export default warn

--- a/src/utils/logging/warn.test.js
+++ b/src/utils/logging/warn.test.js
@@ -1,4 +1,4 @@
-import log from './log'
+import warn from './warn'
 
 jest.spyOn(global.console, 'log')
 
@@ -7,7 +7,7 @@ afterAll(() => {
   delete process.env.CI
 })
 
-describe('#log()', () => {
+describe('#warn()', () => {
   const msg = 'Hello World!'
 
   beforeEach(() => {
@@ -16,13 +16,13 @@ describe('#log()', () => {
   })
 
   it('should log message using console.log (node 6 and <= 8.9 support)', () => {
-    log(undefined, msg)
+    warn(undefined, msg)
     expect(global.console.log).toHaveBeenCalledWith(msg)
   })
 
   it('should not write message to log if CI env var is set', () => {
     process.env.CI = true
-    log(undefined, msg)
+    warn(undefined, msg)
     expect(global.console.log).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
This PR adds the change that the `context.log` function is replaced with `context.debug` before it's passed into components.

With this change verbose component outputs are hidden by default and only visible if one runs the component command with the help of the `--debug` flag (such as `components deploy --debug`). All system logs are still shown by default.

Additionally other log level were implemented which are accessible via `context.console.*` (they follow the JavaScript `console.*` pattern). This means that e.g. component authors can use `context.console.error` to show an error or `context.console.log` to force a log message to be shown.

Here's an example which shows how this can be used as a component author:

```js
const NestedService = {
  shouldDeploy(prevInstance) {
    return 'deploy'
  },

  deploy(prevInstance, context) {
    context.log('Hello World!') // hidden by default (only visible when passing in the --debug flag)
    context.console.error('An error oruccred')
  }
}

module.exports = NestedService
```

/cc @brianneisler 