### PR TITLE
Graph operation status reporting

### DIFF
--- a/src/utils/dag/execGraph.js
+++ b/src/utils/dag/execGraph.js
@@ -1,13 +1,16 @@
 import { all, append, isEmpty, reduce } from '@serverless/utils'
 import cloneGraph from './cloneGraph'
 import detectCircularDeps from './detectCircularDeps'
+import logStatus from './logStatus'
 
-const execNode = (iteratee, node, context) =>
-  iteratee(node, {
+const execNode = (iteratee, node, context) => {
+  logStatus(iteratee, node, context)
+  return iteratee(node, {
     ...context,
     // replace `log` with `debug` so that component logs are hidden by default
     log: context.debug
   })
+}
 
 const execNodeIds = async (iteratee, nodeIds, graph, context) =>
   all(

--- a/src/utils/dag/index.js
+++ b/src/utils/dag/index.js
@@ -1,4 +1,5 @@
 export { default as buildGraph } from './buildGraph'
 export { default as deployGraph } from './deployGraph'
 export { default as detectCircularDeps } from './detectCircularDeps'
+export { default as logStatus } from './logStatus'
 export { default as removeGraph } from './removeGraph'

--- a/src/utils/dag/logStatus.js
+++ b/src/utils/dag/logStatus.js
@@ -1,0 +1,41 @@
+import { filter, mapObjIndexed, resolve, not, isEmpty } from '@serverless/utils'
+
+function getParameters(instance) {
+  if (instance.inputs && instance.inputTypes) {
+    const requiredParams = filter((inputType) => !!inputType.required, instance.inputTypes)
+    const paramsAsObject = mapObjIndexed(
+      (num, key) => resolve(instance.inputs[key]),
+      requiredParams
+    )
+    if (not(isEmpty(paramsAsObject))) {
+      return JSON.stringify(paramsAsObject, null, 2)
+        .replace(/[\{\}]/g, '')
+        .slice(0, -1)
+    }
+    return paramsAsObject
+  }
+}
+
+function logCurrentStatus(iteratee, node, context) {
+  const { prevInstance, nextInstance } = node
+
+  const componentName =
+    (nextInstance && nextInstance.constructor.name) ||
+    (prevInstance && prevInstance.constructor.name)
+
+  if (iteratee.name === 'deployNode') {
+    const params = getParameters(nextInstance)
+    context.log(
+      `Deploying "${componentName}" ${not(isEmpty(params)) ? `with parameters: ${params}` : ''}`
+    )
+  } else if (iteratee.name === 'removeNode') {
+    if (prevInstance) {
+      const params = getParameters(prevInstance)
+      context.log(
+        `Removing "${componentName}" ${not(isEmpty(params)) ? `with parameters: ${params}` : ''}`
+      )
+    }
+  }
+}
+
+export default logCurrentStatus

--- a/src/utils/dag/logStatus.test.js
+++ b/src/utils/dag/logStatus.test.js
@@ -1,0 +1,102 @@
+import logStatus from './logStatus'
+
+describe('#logStatus()', () => {
+  let iteratee
+  let mockLog
+  let context
+
+  beforeEach(() => {
+    iteratee = {}
+    mockLog = jest.fn()
+    context = {
+      log: mockLog
+    }
+  })
+
+  it('should log the current status when deploying', () => {
+    iteratee.name = 'deployNode'
+    const node = {
+      nextInstance: {
+        constructor: {
+          name: 'SomeService'
+        },
+        inputs: {
+          name: 'some-name'
+        },
+        inputTypes: {
+          name: {
+            type: 'string',
+            required: true
+          }
+        }
+      }
+    }
+    logStatus(iteratee, node, context)
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog.mock.calls[0][0]).toMatch(/Deploying.*with parameters.*/)
+  })
+
+  it('should log the current status when removing', () => {
+    iteratee.name = 'removeNode'
+    const node = {
+      prevInstance: {
+        constructor: {
+          name: 'SomeService'
+        },
+        inputs: {
+          name: 'some-name'
+        },
+        inputTypes: {
+          name: {
+            type: 'string',
+            required: true
+          }
+        }
+      }
+    }
+    logStatus(iteratee, node, context)
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog.mock.calls[0][0]).toMatch(/Removing.*with parameters.*/)
+  })
+
+  it('should be able to deal with node instances without inputs defined', () => {
+    iteratee.name = 'deployNode'
+    const node = {
+      nextInstance: {
+        constructor: {
+          name: 'SomeService'
+        }
+      },
+      prevInstance: {
+        constructor: {
+          name: 'SomeService'
+        }
+      }
+    }
+    logStatus(iteratee, node, context)
+
+    expect(mockLog).toHaveBeenCalledTimes(1)
+    expect(mockLog.mock.calls[0][0]).toEqual('Deploying "SomeService" ')
+  })
+
+  it('should not log any status if the operation is unknown', () => {
+    iteratee.name = 'UNKNOWN_OPERATION'
+    const node = {
+      nextInstance: {
+        constructor: {
+          name: 'SomeService'
+        }
+      },
+      prevInstance: {
+        constructor: {
+          name: 'SomeService'
+        }
+      }
+    }
+    logStatus(iteratee, node, context)
+
+    expect(mockLog).toHaveBeenCalledTimes(0)
+  })
+})


### PR DESCRIPTION
This adds the functionality to log what the core system is deploying / removing while walking through the graph.

Only inputs / paramsters which are `required` are shown so that user can determine which component was deployed / removed exactly without being overwhelmed by the full-blown parameter list.

Tests were added to cover the proper functionality.

The output looks like this:

```
[components/examples/test-components]$ ../../bin/components deploy
Loading plugins...
Deploy running...
Deploying "NestedService" with parameters:
  "name":"foo"
Deploying "ComponentsTest" 
Deployment complete!
Getting info...
ComponentsTest - Service
|- NestedService - NestedService
   name: NestedService
   version: 0.3.0

[components/examples/test-components]$ ../../bin/components deploy
Loading plugins...
Deploy running...
Deploying "NestedService" with parameters:
  "name":"foo"
Deploying "ComponentsTest" 
Removing "ComponentsTest" 
Removing "NestedService" with parameters:
  "name":"foo"
Deployment complete!
Getting info...
ComponentsTest - Service
|- NestedService - NestedService
   name: NestedService
   version: 0.3.0

[components/examples/test-components]$ ../../bin/components remove
Loading plugins...
Remove running...
Removing "ComponentsTest" 
Removing "NestedService" with parameters:
  "name":"foo"
Removal complete
```