### PR TITLE
Add support for variable child component definitions with any depth

### DIFF
--- a/src/plugins/Deploy/index.js
+++ b/src/plugins/Deploy/index.js
@@ -19,8 +19,8 @@ const Deploy = {
     //       operation: string (the operation to perform on the component)
     //    }
     //
-    //  2. add all children in the nextInstance children tree to the graph as nodes. You can do this by using the walkReduceComponentChildrenDepthFirst method and passing the graph along as the accumulator.
-    //    - walkReduceComponentChildrenDepthFirst on nextInstance
+    //  2. add all children in the nextInstance children tree to the graph as nodes. You can do this by using the walkReduceAllComponentsDepthFirst method and passing the graph along as the accumulator.
+    //    - walkReduceAllComponentsDepthFirst on nextInstance
     //    - for each child add the child as the nextInstance and the child's id as the instanceId on the node
     //    - call `shouldDeploy` to retrieve the operation that is meant to be performed on that node, add the operation returned from shouldDeploy to the node. If undefined is returned from shouldDeploy, it means no operation should be performed on that node.
     //    - Note that there is a special "replace" operation returned from shouldDeploy. If "replace" is received it means that the node should be both removed and deployed.
@@ -30,7 +30,7 @@ const Deploy = {
     //
     //    - return the graph as the accumulator
     //
-    //  3. walkReduceComponentChildrenDepthFirst on the prevInstance tree
+    //  3. walkReduceAllComponentsDepthFirst on the prevInstance tree
     //    - as you walk through each instance on the tree, load the corresponding node from the graph and set the prevInstance property on the node.
     //    - If the node does not exist on the graph, it means the node needs to be removed. Add the node to the graph. Set the prevInstance property, the instanceId and the operation to "remove". Also add an edge from the instances parent to the child that will be removed. You can access a child's parent using the `instance.parent` property
     //

--- a/src/utils/component/defineComponent.test.js
+++ b/src/utils/component/defineComponent.test.js
@@ -1,0 +1,122 @@
+import path from 'path'
+import { keys, prop } from '@serverless/utils'
+import defineComponent from './defineComponent'
+import { createTestContext } from '../../../test'
+
+describe('#defineComponent()', () => {
+  const cwd = path.resolve(__dirname, '..')
+  const state = {}
+  let context
+  let Component
+  let Object
+
+  beforeEach(async () => {
+    context = await createTestContext({ cwd })
+    Component = await context.import('Component')
+    Object = await context.import('Object')
+  })
+
+  it('should throw if the passed-in component is not of type Component', async () => {
+    const object = context.construct(Object, state, context)
+
+    // TODO: rewrite to use `await expect toThrow`
+    // for more info see: https://github.com/facebook/jest/issues/1377
+    try {
+      await defineComponent(object, state, context)
+    } catch (error) {
+      expect(error.message).toMatch(/expected component parameter to be a component/)
+    }
+  })
+
+  describe('when running the components "define" function', async () => {
+    let component
+
+    beforeEach(async () => {
+      component = context.construct(Component, state, context)
+    })
+
+    it('should return component instances based on the passed-in object structure', async () => {
+      component.define = () => ({
+        component1: {
+          type: '../../registry/Component',
+          inputs: {}
+        },
+        components: {
+          component2: {
+            type: '../../registry/Component',
+            inputs: {}
+          }
+        },
+        functions: {
+          function1: {
+            type: '../../registry/Component',
+            inputs: {}
+          },
+          function2: {
+            type: '../../registry/Component',
+            inputs: {}
+          }
+        },
+        arrayProp: [
+          { component3: { type: '../../registry/Component', inputs: {} } },
+          { component4: { type: '../../registry/Component', inputs: {} } }
+        ]
+      })
+
+      const res = await defineComponent(component, state, context)
+
+      expect(res).toBeInstanceOf(Component.class)
+      expect(keys(prop('children', res))).toHaveLength(4)
+      expect(res.children.component1).toBeInstanceOf(Component.class)
+      expect(res.children.components.component2).toBeInstanceOf(Component.class)
+      expect(res.children.functions.function1).toBeInstanceOf(Component.class)
+      expect(res.children.functions.function2).toBeInstanceOf(Component.class)
+      expect(res.children.functions.function2).toBeInstanceOf(Component.class)
+      expect(res.children.arrayProp[0].component3).toBeInstanceOf(Component.class)
+      expect(res.children.arrayProp[1].component4).toBeInstanceOf(Component.class)
+    })
+
+    it('should support the mix of "type" / "inputs", loaded types and instance definitions', async () => {
+      const instance = context.construct(Component, state, context)
+      component.define = () => ({
+        component1: instance,
+        component2: {
+          type: Component,
+          inputs: {}
+        },
+        component3: {
+          type: '../../registry/Component',
+          inputs: {}
+        }
+      })
+
+      const res = await defineComponent(component, state, context)
+
+      expect(keys(prop('children', res))).toHaveLength(3)
+      expect(res.children.component1).toBeInstanceOf(Component.class)
+      expect(res.children.component2).toBeInstanceOf(Component.class)
+      expect(res.children.component3).toBeInstanceOf(Component.class)
+    })
+
+    it('should only resolve components one level deep', async () => {
+      component.define = () => ({
+        myComponent1: {
+          type: '../../registry/Component',
+          inputs: {},
+          myComponent2: {
+            type: '../../registry/Component',
+            inputs: {}
+          }
+        }
+      })
+
+      const res = await defineComponent(component, state, context)
+
+      // NOTE: this Object was extended above to be our customized Component
+      expect(res).toBeInstanceOf(Object.class)
+      expect(keys(prop('children', res))).toHaveLength(1)
+      expect(res.children.myComponent1).toBeInstanceOf(Component.class)
+      expect(res.children.myComponent1.myComponent2).toBeUndefined()
+    })
+  })
+})

--- a/src/utils/component/getChildrenIds.js
+++ b/src/utils/component/getChildrenIds.js
@@ -1,22 +1,26 @@
-import { append, get, isNil, keys, reduce, resolve } from '@serverless/utils'
+import { view, lensPath } from 'ramda'
+import { append, get, equals, walkReduce, resolve } from '@serverless/utils'
 
 const getChildrenIds = (component) => {
   const children = get('children', component)
   if (children) {
-    return reduce(
-      (accum, childKey) => {
-        const instanceId = resolve(get('instanceId', children[childKey]))
-        if (isNil(instanceId)) {
-          throw new Error(
-            `Found a child without an instanceId while getting children ids. This should not happen. The child was ${
-              children[childKey]
-            } and belongs to parent ${component}`
-          )
+    let currChildStartPath = []
+    return walkReduce(
+      (accum, value, pathParts) => {
+        // the first iteration starts with an empty array
+        if (pathParts.length) {
+          const pathPartWoLastElement = pathParts.slice(0, pathParts.length - 1)
+          const lastPathPart = pathParts.slice(-1).pop()
+          if (lastPathPart === 'instanceId' && equals(currChildStartPath, pathPartWoLastElement)) {
+            const instanceId = resolve(view(lensPath(pathParts), children))
+            return append(instanceId, accum)
+          }
+          currChildStartPath = pathParts
         }
-        return append(instanceId, accum)
+        return accum
       },
       [],
-      keys(children)
+      children
     )
   }
   return []

--- a/src/utils/component/getChildrenIds.test.js
+++ b/src/utils/component/getChildrenIds.test.js
@@ -8,12 +8,27 @@ describe('#getChildrenIds()', () => {
           instanceId: 'sub-component-a'
         },
         childB: {
-          instanceId: 'sub-component-b'
+          instanceId: 'sub-component-b',
+          childC: {
+            instanceId: 'sub-component-c',
+            childD: {
+              instanceId: 'sub-component-d'
+            }
+          }
+        },
+        childE: {
+          instanceId: 'sub-component-e'
         }
       }
     }
 
-    expect(getChildrenIds(component)).toEqual(['sub-component-a', 'sub-component-b'])
+    expect(getChildrenIds(component)).toEqual([
+      'sub-component-a',
+      'sub-component-b',
+      'sub-component-c',
+      'sub-component-d',
+      'sub-component-e'
+    ])
   })
 
   it('should return the components children ids in an array from an array', () => {
@@ -23,12 +38,25 @@ describe('#getChildrenIds()', () => {
           instanceId: 'sub-component-a'
         },
         {
-          instanceId: 'sub-component-b'
+          childB: {
+            instanceId: 'sub-component-b',
+            childC: {
+              instanceId: 'sub-component-c'
+            }
+          }
+        },
+        {
+          instanceId: 'sub-component-d'
         }
       ]
     }
 
-    expect(getChildrenIds(component)).toEqual(['sub-component-a', 'sub-component-b'])
+    expect(getChildrenIds(component)).toEqual([
+      'sub-component-a',
+      'sub-component-b',
+      'sub-component-c',
+      'sub-component-d'
+    ])
   })
 
   it('should return an empty array if no children ids can be found in an children object', () => {

--- a/src/utils/component/index.js
+++ b/src/utils/component/index.js
@@ -9,6 +9,8 @@ export { default as getVariableInstanceIds } from './getVariableInstanceIds'
 export { default as isComponent } from './isComponent'
 export { default as resolveComponentEvaluables } from './resolveComponentEvaluables'
 export { default as setKey } from './setKey'
+export { default as walkReduceAllComponents } from './walkReduceAllComponents'
+export { default as walkReduceAllComponentsDepthFirst } from './walkReduceAllComponentsDepthFirst'
 export { default as walkReduceComponentChildren } from './walkReduceComponentChildren'
 export {
   default as walkReduceComponentChildrenDepthFirst

--- a/src/utils/component/resolveComponentEvaluables.test.js
+++ b/src/utils/component/resolveComponentEvaluables.test.js
@@ -16,9 +16,15 @@ describe('#resolveComponentEvaluables()', () => {
     const parentComponent = context.construct(Component, {})
     const componentA = context.construct(Component, {})
     const componentB = context.construct(Component, {})
+    const componentC = context.construct(Component, {})
+    const componentD = context.construct(Component, {})
     parentComponent.children = {
       a: componentA,
-      b: componentB
+      b: componentB,
+      c: [{ componentC }],
+      nested: {
+        d: componentD
+      }
     }
     componentA.parent = parentComponent
     componentB.parent = parentComponent

--- a/src/utils/component/walkReduceAllComponents.js
+++ b/src/utils/component/walkReduceAllComponents.js
@@ -1,4 +1,4 @@
-import { concat, forEach, isObjectLike, resolve, walk, isEmpty } from '@serverless/utils'
+import { concat, forEach, isObjectLike, resolve, walk } from '@serverless/utils'
 import isComponent from './isComponent'
 
 const reduceWalkee = (accum, value, keys, iteratee, recur) => {
@@ -7,19 +7,21 @@ const reduceWalkee = (accum, value, keys, iteratee, recur) => {
   let result = accum
   if (isObjectLike(value) && !visited.has(value)) {
     visited.add(value)
-    if (isComponent(value) && !isEmpty(keys)) {
+    if (isComponent(value)) {
       result = iteratee(accum, value, keys)
-    } else {
-      forEach((childValue, childKdx) => {
-        const newKeys = concat(keys, [childKdx])
-        result = recur(result, resolve(childValue), newKeys, iteratee)
-      }, value)
     }
+    forEach((childValue, childKdx) => {
+      const newKeys = concat(keys, [childKdx])
+      result = recur(result, resolve(childValue), newKeys, iteratee)
+    }, value)
   }
   return result
 }
 
 /**
+ * ---------
+ * TODO: update
+ * ---------
  * Walk reduce the component and component's children using the given reducer function
  *
  * @func
@@ -28,7 +30,7 @@ const reduceWalkee = (accum, value, keys, iteratee, recur) => {
  * @param {Component} component The component to walk.
  * @returns {*} The final, accumulated value.
  */
-const walkReduceComponentChildren = (iteratee, accum, component) =>
+const walkReduceAllComponents = (iteratee, accum, component) =>
   walk(reduceWalkee, iteratee, accum, component, [])
 
-export default walkReduceComponentChildren
+export default walkReduceAllComponents

--- a/src/utils/component/walkReduceAllComponentsDepthFirst.js
+++ b/src/utils/component/walkReduceAllComponentsDepthFirst.js
@@ -1,4 +1,4 @@
-import { concat, forEach, isObjectLike, resolve, walk, isEmpty } from '@serverless/utils'
+import { concat, forEach, isObjectLike, resolve, walk } from '@serverless/utils'
 import isComponent from './isComponent'
 
 const reduceWalkee = (accum, value, keys, iteratee, recur) => {
@@ -7,19 +7,21 @@ const reduceWalkee = (accum, value, keys, iteratee, recur) => {
   let result = accum
   if (isObjectLike(value) && !visited.has(value)) {
     visited.add(value)
-    if (isComponent(value) && !isEmpty(keys)) {
+    forEach((childValue, childKdx) => {
+      const newKeys = concat(keys, [childKdx])
+      result = recur(result, resolve(childValue), newKeys, iteratee)
+    }, value)
+    if (isComponent(value)) {
       result = iteratee(accum, value, keys)
-    } else {
-      forEach((childValue, childKdx) => {
-        const newKeys = concat(keys, [childKdx])
-        result = recur(result, resolve(childValue), newKeys, iteratee)
-      }, value)
     }
   }
   return result
 }
 
 /**
+ * ---------
+ * TODO: update
+ * ---------
  * Walk reduce the component and component's children using the given reducer function
  *
  * @func
@@ -28,7 +30,7 @@ const reduceWalkee = (accum, value, keys, iteratee, recur) => {
  * @param {Component} component The component to walk.
  * @returns {*} The final, accumulated value.
  */
-const walkReduceComponentChildren = (iteratee, accum, component) =>
+const walkReduceAllComponentsDepthFirst = (iteratee, accum, component) =>
   walk(reduceWalkee, iteratee, accum, component, [])
 
-export default walkReduceComponentChildren
+export default walkReduceAllComponentsDepthFirst

--- a/src/utils/component/walkReduceComponentChildren.test.js
+++ b/src/utils/component/walkReduceComponentChildren.test.js
@@ -1,0 +1,90 @@
+import path from 'path'
+import { createTestContext } from '../../../test'
+import walkReduceComponentChildren from './walkReduceComponentChildren'
+
+describe('#walkReduceComponentChildren()', () => {
+  const cwd = path.resolve(__dirname, '..')
+  let context
+  let Component
+
+  beforeEach(async () => {
+    context = await createTestContext({ cwd })
+    Component = await context.import('Component')
+  })
+
+  it('should walk reduce the component and components children defined via an object', async () => {
+    const component = context.construct(Component, {})
+    const child = context.construct(Component, {})
+
+    component.children = {
+      nested1: {
+        child1: child,
+        nested2: {
+          child2: child
+        }
+      },
+      child3: child,
+      arrayProp: [{ child4: child }],
+      child5: child
+    }
+
+    const result = walkReduceComponentChildren(
+      (accum, value, keys) => {
+        accum.push(keys)
+        return accum
+      },
+      [],
+      component
+    )
+
+    expect(result).toEqual([
+      ['children', 'nested1', 'child1'],
+      ['children', 'nested1', 'nested2', 'child2'],
+      ['children', 'child3'],
+      ['children', 'arrayProp', 0, 'child4'],
+      ['children', 'child5']
+    ])
+  })
+
+  it('should walk reduce the component and components children defined via an array', async () => {
+    const component = context.construct(Component, {})
+    const child = context.construct(Component, {})
+
+    component.children = [
+      {
+        nested1: {
+          child1: child,
+          nested2: {
+            child2: child
+          }
+        }
+      },
+      {
+        child3: child
+      },
+      {
+        arrayProp: [{ child4: child }]
+      },
+      {
+        child5: child
+      }
+    ]
+
+    const result = walkReduceComponentChildren(
+      (accum, value, keys) => {
+        accum.push(keys)
+        return accum
+      },
+      [],
+      component
+    )
+
+    expect(result).toEqual([
+      ['children', 0, 'nested1', 'child1'],
+      ['children', 0, 'nested1', 'nested2', 'child2'],
+      ['children', 1, 'child3'],
+      ['children', 2, 'arrayProp', 0, 'child4'],
+      ['children', 3, 'child5']
+    ])
+  })
+})

--- a/src/utils/component/walkReduceComponentChildrenDepthFirst.test.js
+++ b/src/utils/component/walkReduceComponentChildrenDepthFirst.test.js
@@ -1,0 +1,90 @@
+import path from 'path'
+import { createTestContext } from '../../../test'
+import walkReduceComponentChildrenDepthFirst from './walkReduceComponentChildrenDepthFirst'
+
+describe('#walkReduceComponentChildrenDepthFirst()', () => {
+  const cwd = path.resolve(__dirname, '..')
+  let context
+  let Component
+
+  beforeEach(async () => {
+    context = await createTestContext({ cwd })
+    Component = await context.import('Component')
+  })
+
+  it('should walk reduce the component and components children defined via an object', async () => {
+    const component = context.construct(Component, {})
+    const child = context.construct(Component, {})
+
+    component.children = {
+      nested1: {
+        child1: child,
+        nested2: {
+          child2: child
+        }
+      },
+      child3: child,
+      arrayProp: [{ child4: child }],
+      child5: child
+    }
+
+    const result = walkReduceComponentChildrenDepthFirst(
+      (accum, value, keys) => {
+        accum.push(keys)
+        return accum
+      },
+      [],
+      component
+    )
+
+    expect(result).toEqual([
+      ['children', 'nested1', 'nested2', 'child2'],
+      ['children', 'nested1', 'child1'],
+      ['children', 'child3'],
+      ['children', 'arrayProp', 0, 'child4'],
+      ['children', 'child5']
+    ])
+  })
+
+  it('should walk reduce the component and components children defined via an array', async () => {
+    const component = context.construct(Component, {})
+    const child = context.construct(Component, {})
+
+    component.children = [
+      {
+        nested1: {
+          child1: child,
+          nested2: {
+            child2: child
+          }
+        }
+      },
+      {
+        child3: child
+      },
+      {
+        arrayProp: [{ child4: child }]
+      },
+      {
+        child5: child
+      }
+    ]
+
+    const result = walkReduceComponentChildrenDepthFirst(
+      (accum, value, keys) => {
+        accum.push(keys)
+        return accum
+      },
+      [],
+      component
+    )
+
+    expect(result).toEqual([
+      ['children', 0, 'nested1', 'nested2', 'child2'],
+      ['children', 0, 'nested1', 'child1'],
+      ['children', 1, 'child3'],
+      ['children', 2, 'arrayProp', 0, 'child4'],
+      ['children', 3, 'child5']
+    ])
+  })
+})

--- a/src/utils/dag/buildGraph.js
+++ b/src/utils/dag/buildGraph.js
@@ -4,14 +4,14 @@ import { SYMBOL_STATE } from '../constants'
 import getChildrenIds from '../component/getChildrenIds'
 import getDependenciesIds from '../component/getDependenciesIds'
 import getParentId from '../component/getParentId'
-import walkReduceComponentChildrenDepthFirst from '../component/walkReduceComponentChildrenDepthFirst'
+import walkReduceAllComponentsDepthFirst from '../component/walkReduceAllComponentsDepthFirst'
 
 const buildGraph = (nextInstance, prevInstance) => {
   let graph = new Graph()
 
   if (prevInstance && prevInstance.instanceId) {
     // prevInstance nodes
-    graph = walkReduceComponentChildrenDepthFirst(
+    graph = walkReduceAllComponentsDepthFirst(
       (accum, currentInstance) => {
         if (!currentInstance.instanceId) {
           throw new Error(
@@ -39,7 +39,7 @@ const buildGraph = (nextInstance, prevInstance) => {
 
   // nextInstance nodes
   if (nextInstance && nextInstance.instanceId) {
-    graph = walkReduceComponentChildrenDepthFirst(
+    graph = walkReduceAllComponentsDepthFirst(
       (accum, currentInstance) => {
         if (!currentInstance.instanceId) {
           throw new Error(
@@ -83,7 +83,7 @@ const buildGraph = (nextInstance, prevInstance) => {
 
   if (prevInstance && prevInstance.instanceId) {
     // prevInstance edges
-    graph = walkReduceComponentChildrenDepthFirst(
+    graph = walkReduceAllComponentsDepthFirst(
       (accum, currentInstance) => {
         // Add the removed node's child edges
         const childrenIds = getChildrenIds(currentInstance)

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -33,6 +33,8 @@ describe('index', () => {
       isComponent: expect.any(Function),
       resolveComponentEvaluables: expect.any(Function),
       setKey: expect.any(Function),
+      walkReduceAllComponents: expect.any(Function),
+      walkReduceAllComponentsDepthFirst: expect.any(Function),
       walkReduceComponentChildren: expect.any(Function),
       walkReduceComponentChildrenDepthFirst: expect.any(Function)
     })

--- a/src/utils/type/isTypeConstruct.js
+++ b/src/utils/type/isTypeConstruct.js
@@ -1,8 +1,12 @@
+import isType from './isType'
 import { getProp, isObject, isString } from '@serverless/utils'
 
 // TODO BRN: What happens if no inputs are required? Should we always require at least an empty object? We won't be able to tell the difference between a type identifier for a prop vs a type instantiation
 
-const isTypeConstruct = (value) =>
-  isString(getProp('type', value)) && isObject(getProp('inputs', value))
+const isTypeConstruct = (value) => {
+  const type = getProp('type', value)
+  const inputs = getProp('inputs', value)
+  return (isString(type) || isType(type)) && isObject(inputs)
+}
 
 export default isTypeConstruct

--- a/src/utils/type/isTypeConstruct.test.js
+++ b/src/utils/type/isTypeConstruct.test.js
@@ -1,10 +1,24 @@
 import isTypeConstruct from './isTypeConstruct'
 
 describe('#isTypeConstruct()', () => {
+  const TypeMock = {
+    class: class {},
+    constructor: class {},
+    main: {},
+    props: {},
+    root: '/foo'
+  }
+
   it('should identify constructs when they have both type and inputs', () => {
     expect(
       isTypeConstruct({
         type: 'Test',
+        inputs: {}
+      })
+    ).toBe(true)
+    expect(
+      isTypeConstruct({
+        type: TypeMock,
         inputs: {}
       })
     ).toBe(true)

--- a/src/utils/type/loadType.js
+++ b/src/utils/type/loadType.js
@@ -1,3 +1,4 @@
+import isType from './isType'
 import defType from './defType'
 import loadTypeMeta from './utils/loadTypeMeta'
 
@@ -22,6 +23,9 @@ import loadTypeMeta from './utils/loadTypeMeta'
  *  const OtherComponent = await loadType('https://example.com/OtherComponent.zip')
  */
 const loadType = async (query, context) => {
+  if (isType(query)) {
+    return query
+  }
   const typeMeta = await loadTypeMeta(query.trim(), context)
   return defType(typeMeta, context)
 }

--- a/src/utils/type/loadType.test.js
+++ b/src/utils/type/loadType.test.js
@@ -2,9 +2,21 @@ import createContext from '../context/createContext'
 import loadType from './loadType'
 
 describe('#loadType()', () => {
+  let context
+
+  beforeEach(async () => {
+    context = await createContext()
+  })
+
   it('should load type by name', async () => {
-    const context = await createContext({})
     const Component = await loadType('Component', context)
     expect(Component).toEqual(expect.any(Object))
+  })
+
+  it('should return the type if it was already loaded', async () => {
+    const Component = await context.import('Component')
+
+    const res = await loadType(Component, context)
+    expect(res).toEqual(Component)
   })
 })

--- a/tests/integration/define-types.test.js
+++ b/tests/integration/define-types.test.js
@@ -1,12 +1,18 @@
-import { createContext } from '../../src/utils'
+import { createTestContext } from '../../test'
 
 jest.setTimeout(50000)
 
 describe('Integration Test - define types', () => {
-  it('should load the Object type by name', async () => {
-    const context = await createContext({
+  const state = {}
+  let context
+
+  beforeEach(async () => {
+    context = await createTestContext({
       cwd: __dirname
     })
+  })
+
+  it('should load the Object type by name', async () => {
     const ObjectType = await context.import('Object')
     expect(ObjectType).toEqual({
       class: expect.any(Function),
@@ -25,5 +31,31 @@ describe('Integration Test - define types', () => {
       query: 'Object',
       root: expect.stringMatching(/^.*Object$/)
     })
+  })
+
+  it('should create component instances at every property level', async () => {
+    const Parent = await context.import('./define-types/Parent')
+    const Child = await context.import('./define-types/Child')
+    const instance = context.construct(Parent, state, context)
+
+    expect(instance.components.childA).toBeInstanceOf(Child.class)
+    expect(instance.components.childB).toBeInstanceOf(Child.class)
+    expect(instance.objectProp.childC).toBeInstanceOf(Child.class)
+    expect(instance.arrayProp[0].childD).toBeInstanceOf(Child.class)
+    expect(instance.deeply.nested.childs.childE).toBeInstanceOf(Child.class)
+  })
+
+  it('should store all component instances at the "children" property based on their respective levels', async () => {
+    const Parent = await context.import('./define-types/Parent')
+    const Child = await context.import('./define-types/Child')
+    let instance = context.construct(Parent, state, context)
+
+    instance = await context.defineComponent(instance, state, context)
+
+    expect(instance.children.components.childA).toBeInstanceOf(Child.class)
+    expect(instance.children.components.childB).toBeInstanceOf(Child.class)
+    expect(instance.children.objectProp.childC).toBeInstanceOf(Child.class)
+    expect(instance.children.arrayProp[0].childD).toBeInstanceOf(Child.class)
+    expect(instance.children.deeply.nested.childs.childE).toBeInstanceOf(Child.class)
   })
 })

--- a/tests/integration/define-types/Child/index.js
+++ b/tests/integration/define-types/Child/index.js
@@ -1,18 +1,20 @@
-import { all, map } from '@serverless/utils'
+// NOTE: commented out since GrandChild is not implemented right no
 
-const Child = async (SuperClass, superContext) => {
-  const GrandChild = await superContext.load('./GrandChild')
-
-  return {
-    async define(context) {
-      return all(
-        map({
-          grandChildA: context.construct(GrandChild, { bar: '' }),
-          grandChildB: context.construct(GrandChild, { bar: '' })
-        })
-      )
-    }
-  }
-}
-
-export default Child
+// import { all, map } from '@serverless/utils'
+//
+// const Child = async (SuperClass, superContext) => {
+//   const GrandChild = await superContext.load('./GrandChild')
+//
+//   return {
+//     async define(context) {
+//       return all(
+//         map({
+//           grandChildA: context.construct(GrandChild, { bar: '' }),
+//           grandChildB: context.construct(GrandChild, { bar: '' })
+//         })
+//       )
+//     }
+//   }
+// }
+//
+// export default Child

--- a/tests/integration/define-types/Child/serverless.yml
+++ b/tests/integration/define-types/Child/serverless.yml
@@ -1,6 +1,5 @@
 extends: Component
 name: Child
-main: ./index.js
 
 inputTypes:
   foo:

--- a/tests/integration/define-types/Parent/index.js
+++ b/tests/integration/define-types/Parent/index.js
@@ -1,3 +1,0 @@
-const Parent = {}
-
-export default Parent

--- a/tests/integration/define-types/Parent/serverless.yml
+++ b/tests/integration/define-types/Parent/serverless.yml
@@ -1,6 +1,5 @@
 extends: Component
 name: Parent
-main: ./index.js
 
 inputTypes:
   bar:
@@ -10,10 +9,30 @@ bar: ${inputs.bar}
 
 components:
   childA:
-    type: ./Child
+    type: ../Child
     inputs:
       foo: abc
   childB:
-    type: ./Child
+    type: ../Child
     inputs:
       foo: def
+
+objectProp:
+  childC:
+    type: ../Child
+    inputs:
+      foo: ghi
+
+arrayProp:
+  - childD:
+      type: ../Child
+      inputs:
+        foo: jkl
+
+deeply:
+  nested:
+    childs:
+      childE:
+        type: ../Child
+        inputs:
+          foo: jkl


### PR DESCRIPTION
This PR adds support for child component definitions at various places in the component instance (rather than only `components`).

Here's how one can validate that it works (or take a look at the tests which ships with this PR):

```yml
# ./serverless.yml

name: ComponentsTest
extends: Service

components:
  nestedService:
    type: ./nested-service
```

```yml
# ./nested-service

name: NestedService
extends: Component
```

```javascript
// ./nested-service/index.js
const { resolve } = require('@serverless/utils')

const NestedService = {
  define() {
    return {
      components: {
        foo: {
          type: 'AwsS3Bucket',
          inputs: {}
        }
      },
      fn: {
        type: 'AwsLambdaFunction',
        inputs: {}
      }
    }
  }
}

module.exports = NestedService
```

/cc @brianneisler 