### PR TITLE
Adds support for various returned objects in define method

### DIFF
--- a/examples/demo/SimpleService/serverless.yml
+++ b/examples/demo/SimpleService/serverless.yml
@@ -6,38 +6,18 @@ providers:
     type: AwsProvider
     inputs:
       region: us-east-1
-#
-#compute:
-#  type: AwsLambdaCompute
-#  inputs:
-#    provider: ${this.providers.aws}
-#    runtime: nodejs
-#
-#functions:
-#  hello:
-#    compute: ${this.compute}
-#    handler: index.hello
-#    code: ./code
-#    memory: 1024
-#    timeout: 20
-#    ufs: true
 
-components:
-  policy:
-    type: AwsIamPolicy
-    inputs:
-      # Provider is required for each AWS resource.
-      provider: ${this.providers.aws}
-      policyName: some-new-policy-name
-      document:
-        Version: '2012-10-17'
-        Statement:
-          # This statement grants access to the users table.
-          - Resource:
-              - arn:aws:dynamodb:us-east-1:552750238299:table/ServerlessWebappUser-ServerlessWebApp-prod-hbrizf9b
-            Effect: Allow
-            Action:
-              - dynamodb:GetItem
-              - dynamodb:PutItem
-#              - dynamodb:UpdateItem
-#              - dynamodb:DeleteItem
+compute:
+  type: AwsLambdaCompute
+  inputs:
+    provider: ${this.providers.aws}
+    runtime: nodejs
+
+functions:
+  helloAgain1:
+    compute: ${this.compute}
+    handler: index.hello
+    code: ./code
+    memory: 1024
+    timeout: 20
+    ufs: true

--- a/registry/AwsProvider/src/index.js
+++ b/registry/AwsProvider/src/index.js
@@ -1,4 +1,3 @@
-import { isEmpty } from '@serverless/utils'
 import AWS from 'aws-sdk'
 
 const AwsProvider = (SuperClass) =>
@@ -26,10 +25,6 @@ const AwsProvider = (SuperClass) =>
     validate() {
       if (!/.+-.+.\d+/.test(this.region)) {
         throw new Error(`Invalid region "${this.region}" in your AWS provider setup`)
-      }
-
-      if (!this.credentials || isEmpty(this.credentials)) {
-        throw new Error(`Credentials not set in your AWS provider setup`)
       }
     }
   }

--- a/registry/AwsProvider/src/index.test.js
+++ b/registry/AwsProvider/src/index.test.js
@@ -90,27 +90,5 @@ describe('AwsProvider', () => {
 
       expect(() => awsProvider.validate()).toThrow('Invalid region')
     })
-
-    it('should throw if credentials are not set', async () => {
-      const inputs = {
-        credentials: null,
-        region: 'us-east-1'
-      }
-
-      const awsProvider = await context.construct(AwsProvider, inputs)
-
-      expect(() => awsProvider.validate()).toThrow('Credentials not set')
-    })
-
-    it('should throw if credentials is an empty object', async () => {
-      const inputs = {
-        credentials: {},
-        region: 'us-east-1'
-      }
-
-      const awsProvider = await context.construct(AwsProvider, inputs)
-
-      expect(() => awsProvider.validate()).toThrow('Credentials not set')
-    })
   })
 })

--- a/src/utils/type/loadType.js
+++ b/src/utils/type/loadType.js
@@ -1,3 +1,4 @@
+import isType from './isType'
 import defType from './defType'
 import loadTypeMeta from './loadTypeMeta'
 
@@ -22,6 +23,10 @@ import loadTypeMeta from './loadTypeMeta'
  *  const OtherComponent = await loadType('https://example.com/OtherComponent.zip')
  */
 const loadType = async (query, context) => {
+  // type already loaded
+  if (isType(query)) {
+    return query
+  }
   const typeMeta = await loadTypeMeta(query.trim(), context)
   return defType(typeMeta, context)
 }


### PR DESCRIPTION
In order to make it easier to programmatically define components we should make this function more like defining components in serverless.yml.
```
define() {
  return {
    foo: {
      type: ‘FooComponent’,
      inputs: ...
    },
    bar: {
      type: ‘./path/to/BarComponent’,
      inputs: ...
    }
  }
}
```
We should also support pointing to types that are already loaded. 

const FooComponent = await context.loadType(‘FooComponent’)
```
define() {
  return {
    foo: {
      type: FooComponent,
      inputs: ...
    }
  }
}
```
As well as component instances that have already been constructed

const FooComponent = await context.loadType(‘FooComponent’)
```
define() {
  return {
    foo: context.construct(FooComponent, {})
  }
}
```