### PR TITLE
Adds support for idempotency for AwsS3Bucket deployment

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -2,7 +2,8 @@ const mocks = {
   // S3
   createBucketMock: jest.fn().mockReturnValue('bucket-abc'),
   getBucketLocationMock: jest.fn().mockImplementation((params) => {
-    if (params.Bucket === 'already-removed-bucket') {
+    // also covers integration tests bucket...
+    if (params.Bucket === 'already-removed-bucket' || params.Bucket === 'mysuperbucket') {
       const error = new Error()
       error.code = 'NoSuchBucket'
       return Promise.reject(error)

--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -3,7 +3,7 @@ const mocks = {
   createBucketMock: jest.fn().mockReturnValue('bucket-abc'),
   getBucketLocationMock: jest.fn().mockImplementation((params) => {
     // also covers integration tests bucket...
-    if (params.Bucket === 'already-removed-bucket' || params.Bucket === 'mysuperbucket') {
+    if (params.Bucket === 'already-removed-bucket' || params.Bucket === 'deploy-bucket') {
       const error = new Error()
       error.code = 'NoSuchBucket'
       return Promise.reject(error)

--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -1,6 +1,14 @@
 const mocks = {
   // S3
   createBucketMock: jest.fn().mockReturnValue('bucket-abc'),
+  getBucketLocationMock: jest.fn().mockImplementation((params) => {
+    if (params.Bucket === 'already-removed-bucket') {
+      const error = new Error()
+      error.code = 'NoSuchBucket'
+      return Promise.reject(error)
+    }
+    return Promise.resolve()
+  }),
   deleteBucketMock: jest.fn().mockImplementation((params) => {
     if (params.Bucket === 'already-removed-bucket') {
       const error = new Error()
@@ -346,6 +354,9 @@ const S3 = function() {
   return {
     createBucket: (obj) => ({
       promise: () => mocks.createBucketMock(obj)
+    }),
+    getBucketLocation: (obj) => ({
+      promise: () => mocks.getBucketLocationMock(obj)
     }),
     listObjectsV2: (obj) => ({
       promise: () => mocks.listObjectsV2Mock(obj)

--- a/registry/AwsS3Bucket/src/index.js
+++ b/registry/AwsS3Bucket/src/index.js
@@ -32,6 +32,7 @@ const AwsS3Bucket = (SuperClass) =>
         await S3.getBucketLocation({ Bucket: resolve(this.bucketName) }).promise()
       } catch (e) {
         if (e.code === 'NoSuchBucket') {
+          console.log('dude')
           return 'removed'
         }
         throw e

--- a/registry/AwsS3Bucket/src/index.js
+++ b/registry/AwsS3Bucket/src/index.js
@@ -32,7 +32,6 @@ const AwsS3Bucket = (SuperClass) =>
         await S3.getBucketLocation({ Bucket: resolve(this.bucketName) }).promise()
       } catch (e) {
         if (e.code === 'NoSuchBucket') {
-          console.log('dude')
           return 'removed'
         }
         throw e

--- a/registry/AwsS3Bucket/src/indext.test.js
+++ b/registry/AwsS3Bucket/src/indext.test.js
@@ -121,6 +121,28 @@ describe('AwsS3Bucket', () => {
     expect(AWS.mocks.deleteBucketMock).not.toBeCalled()
   })
 
+  it('sync should return removed if bucket removed from provider', async () => {
+    let awsS3Bucket = await context.construct(AwsS3Bucket, {
+      provider,
+      bucketName: 'already-removed-bucket'
+    })
+    awsS3Bucket = await context.defineComponent(awsS3Bucket)
+    awsS3Bucket = resolveComponentEvaluables(awsS3Bucket)
+    const res = await awsS3Bucket.sync(context)
+    expect(res).toBe('removed')
+  })
+
+  it('sync should NOT return removed if bucket not removed from provider', async () => {
+    let awsS3Bucket = await context.construct(AwsS3Bucket, {
+      provider,
+      bucketName: 'existing-bucket'
+    })
+    awsS3Bucket = await context.defineComponent(awsS3Bucket)
+    awsS3Bucket = resolveComponentEvaluables(awsS3Bucket)
+    await awsS3Bucket.sync(context)
+    expect(awsS3Bucket.bucketName).toBe('existing-bucket')
+  })
+
   it('shouldDeploy should return undefined when no changes have occurred', async () => {
     let awsS3Bucket = await context.construct(AwsS3Bucket, {
       provider,

--- a/tests/integration/library-usage.test.js
+++ b/tests/integration/library-usage.test.js
@@ -28,7 +28,7 @@ describe('Integration Test - Library Usage', () => {
     })
   })
 
-  describe.only('when using a path to a project', () => {
+  describe('when using a path to a project', () => {
     const testServiceDir = path.join(__dirname, 'library-usage')
     const testServiceDirDeploy = path.join(__dirname, 'library-usage', 'deploy')
     const testServiceDirRemove = path.join(__dirname, 'library-usage', 'remove')

--- a/tests/integration/library-usage.test.js
+++ b/tests/integration/library-usage.test.js
@@ -28,8 +28,10 @@ describe('Integration Test - Library Usage', () => {
     })
   })
 
-  describe('when using a path to a project', () => {
+  describe.only('when using a path to a project', () => {
     const testServiceDir = path.join(__dirname, 'library-usage')
+    const testServiceDirDeploy = path.join(__dirname, 'library-usage', 'deploy')
+    const testServiceDirRemove = path.join(__dirname, 'library-usage', 'remove')
     testServiceStateDirectory = path.join(testServiceDir, '.serverless')
     testServiceZipFile = path.join(testServiceDir, 'library-usage@0.0.1.zip')
 
@@ -44,13 +46,13 @@ describe('Integration Test - Library Usage', () => {
     describe('when running through a typical component usage lifecycle', () => {
       it('should deploy the "AwsS3Bucket" component', async () => {
         const context = await deploy({
-          cwd: testServiceDir,
+          cwd: testServiceDirDeploy,
           overrides: {
             debug: () => {},
             log: () => {}
           }
         })
-        expect(AWS.mocks.createBucketMock).toBeCalledWith({ Bucket: 'mysuperbucket' }) // forces bucket to lowercase
+        expect(AWS.mocks.createBucketMock).toBeCalledWith({ Bucket: 'deploy-bucket' }) // forces bucket to lowercase
         const service = context.instance
         expect(service).not.toBeFalsy()
         expect(service).toMatchObject({
@@ -61,30 +63,30 @@ describe('Integration Test - Library Usage', () => {
         const bucket = service.components.myBucket
         expect(bucket).not.toBeFalsy()
         expect(bucket).toMatchObject({
-          bucketName: 'mysuperbucket',
+          bucketName: 'deploy-bucket',
           instanceId: expect.any(String)
         })
       })
 
       it('should remove the "AwsS3Bucket" components', async () => {
         let context = await deploy({
-          cwd: testServiceDir,
+          cwd: testServiceDirRemove,
           overrides: {
             debug: () => {},
             log: () => {}
           }
         })
         context = await remove({
-          cwd: testServiceDir,
+          cwd: testServiceDirRemove,
           overrides: {
             debug: () => {},
             log: () => {}
           }
         })
-        expect(AWS.mocks.deleteBucketMock).toBeCalledWith({ Bucket: 'mysuperbucket' })
-        expect(AWS.mocks.listObjectsV2Mock).toBeCalledWith({ Bucket: 'mysuperbucket' })
+        expect(AWS.mocks.deleteBucketMock).toBeCalledWith({ Bucket: 'remove-bucket' })
+        expect(AWS.mocks.listObjectsV2Mock).toBeCalledWith({ Bucket: 'remove-bucket' })
         expect(AWS.mocks.deleteObjectsMock).toBeCalledWith({
-          Bucket: 'mysuperbucket',
+          Bucket: 'remove-bucket',
           Delete: { Objects: [{ Key: 'abc' }] }
         })
         expect(context.instance).toBeFalsy()

--- a/tests/integration/library-usage/deploy/serverless.yml
+++ b/tests/integration/library-usage/deploy/serverless.yml
@@ -1,0 +1,18 @@
+name: LibraryUsage
+extends: Service
+
+providers:
+  aws:
+    type: AwsProvider
+    inputs:
+      credentials:
+        accessKeyId: xxxxx
+        secretAccessKey: xxxxx
+      region: us-east-1
+
+components:
+  myBucket:
+    type: AwsS3Bucket
+    inputs:
+      bucketName: deploy-bucket
+      provider: ${this.providers.aws}

--- a/tests/integration/library-usage/remove/serverless.yml
+++ b/tests/integration/library-usage/remove/serverless.yml
@@ -1,0 +1,18 @@
+name: LibraryUsage
+extends: Service
+
+providers:
+  aws:
+    type: AwsProvider
+    inputs:
+      credentials:
+        accessKeyId: xxxxx
+        secretAccessKey: xxxxx
+      region: us-east-1
+
+components:
+  myBucket:
+    type: AwsS3Bucket
+    inputs:
+      bucketName: remove-bucket
+      provider: ${this.providers.aws}


### PR DESCRIPTION
## Steps to Verify

- make first deployment of new s3 bucket
- delete `.serverless` folder
- run deploy again -> framework will not deploy as no changes happened
- delete bucket from s3 console
- run deploy again -> framework will create bucket again even though it exists in `.serverless` folder