### PR TITLE
Auto resolve credentials in AwsProvider

### DIFF
--- a/registry/AwsProvider/src/index.js
+++ b/registry/AwsProvider/src/index.js
@@ -1,5 +1,9 @@
-import { isEmpty } from '@serverless/utils'
+import { assoc, isEmpty, reduce, resolve } from '@serverless/utils'
 import AWS from 'aws-sdk'
+
+function resolveCredentials(credentials) {
+  return reduce((accum, value, key) => assoc(key, resolve(value), accum), {}, credentials)
+}
 
 const AwsProvider = (SuperClass) =>
   class extends SuperClass {
@@ -14,13 +18,13 @@ const AwsProvider = (SuperClass) =>
     getSdk() {
       this.validate()
       // TODO BRN: This won't work for multi provider/region
-      AWS.config.update({ region: this.region, credentials: this.credentials })
+      AWS.config.update({ region: this.region, credentials: resolveCredentials(this.credentials) })
       return AWS
     }
 
     getCredentials() {
       this.validate()
-      return { region: this.region, credentials: this.credentials }
+      return { region: this.region, credentials: resolveCredentials(this.credentials) }
     }
 
     validate() {

--- a/registry/AwsProvider/src/index.test.js
+++ b/registry/AwsProvider/src/index.test.js
@@ -2,6 +2,9 @@ import AWS from 'aws-sdk'
 import path from 'path'
 import { createTestContext } from '../../../test'
 
+// TODO: move this into @serverless/utils ?!
+import newVariable from '../../../dist/utils/variable/newVariable'
+
 describe('AwsProvider', () => {
   let context
   let AwsProvider
@@ -48,6 +51,28 @@ describe('AwsProvider', () => {
       expect(AwsSdk).toEqual(AWS)
       expect(AWS.config.update).toBeCalledWith(inputs)
     })
+
+    it('should auto-resolve variables in credentials', async () => {
+      const inputs = {
+        credentials: {
+          accessKeyId: newVariable("${false || 'abc'}", {}),
+          secretAccessKey: newVariable("${false || 'zxc'}", {})
+        },
+        region: 'us-east-1'
+      }
+
+      const awsProvider = await context.construct(AwsProvider, inputs)
+      const AwsSdk = awsProvider.getSdk()
+
+      expect(AwsSdk).toEqual(AWS)
+      expect(AWS.config.update).toBeCalledWith({
+        credentials: {
+          accessKeyId: 'abc',
+          secretAccessKey: 'zxc'
+        },
+        region: 'us-east-1'
+      })
+    })
   })
 
   describe('#getCredentials()', () => {
@@ -64,6 +89,27 @@ describe('AwsProvider', () => {
       const credentials = awsProvider.getCredentials()
 
       expect(credentials).toEqual(inputs)
+    })
+
+    it('should auto-resolve variables in credentials', async () => {
+      const inputs = {
+        credentials: {
+          accessKeyId: newVariable("${false || 'abc'}", {}),
+          secretAccessKey: newVariable("${false || 'zxc'}", {})
+        },
+        region: 'us-east-1'
+      }
+
+      const awsProvider = await context.construct(AwsProvider, inputs)
+      const credentials = awsProvider.getCredentials()
+
+      expect(credentials).toEqual({
+        credentials: {
+          accessKeyId: 'abc',
+          secretAccessKey: 'zxc'
+        },
+        region: 'us-east-1'
+      })
     })
   })
 


### PR DESCRIPTION
This needs to be in place so that the component `sync` function works since we're using `provider` there.