### PR TITLE
Adds support for idempotency to AwsIamPolicy

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -112,6 +112,62 @@ const mocks = {
 
   // IAM
   createRoleMock: jest.fn().mockReturnValue({ Role: { Arn: 'arn:aws:iam::XXXXX:role/test-role' } }),
+  getPolicyMock: jest.fn().mockImplementation((params) => {
+    if (params.PolicyArn === 'arn:aws:iam::558750028299:policy/already-removed-policy') {
+      const error = new Error()
+      error.code = 'NoSuchEntity'
+      return Promise.reject(error)
+    }
+
+    const res = {
+      ResponseMetadata: { RequestId: '65e4b4a8-fd48-11y8-819e-a96de5c76b01' },
+      Policy: {
+        PolicyName: params.PolicyName,
+        PolicyId: 'ANPAJNETMGAOTZZAKLZQM',
+        Arn: `arn:aws:iam::558750028299:policy/some-policy-name`,
+        Path: '/',
+        DefaultVersionId: 'v1',
+        AttachmentCount: 0,
+        PermissionsBoundaryUsageCount: 0,
+        IsAttachable: true
+      }
+    }
+
+    return Promise.resolve(res)
+  }),
+  getPolicyVersionMock: jest.fn().mockImplementation((params) => {
+    if (params.PolicyArn === 'arn:aws:iam::558750028299:policy/already-removed-policy') {
+      const error = new Error()
+      error.code = 'NoSuchEntity'
+      return Promise.reject(error)
+    }
+
+    const res = {
+      ResponseMetadata: { RequestId: '6661381d-fd48-11e8-9fad-b76520f2a049' },
+      PolicyVersion: {
+        Document:
+          '%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Resource%22%3A%5B%22arn%3Aaws%3Adynamodb%3Aus-east-1%3A558750028299%3Atable%2FServerlessWebappUser-ServerlessWebApp-prod-hbrizf9d%22%5D%2C%22Effect%22%3A%22Allow%22%2C%22Action%22%3A%5B%22dynamodb%3AGetItem%22%2C%22dynamodb%3APutItem%22%2C%22dynamodb%3AUpdateItem%22%2C%22dynamodb%3ADeleteItem%22%5D%7D%5D%7D',
+        VersionId: 'v1',
+        IsDefaultVersion: true
+      }
+    }
+
+    return Promise.resolve(res)
+  }),
+  listPolicyVersionsMock: jest.fn().mockImplementation(() => {
+    const res = {
+      ResponseMetadata: { RequestId: '3a16c546-fd8d-11e8-819e-a96de5c76b01' },
+      Versions: [
+        { VersionId: 'v3', IsDefaultVersion: true },
+        { VersionId: 'v2', IsDefaultVersion: false },
+        { VersionId: 'v1', IsDefaultVersion: false }
+      ],
+      IsTruncated: false
+    }
+
+    return Promise.resolve(res)
+  }),
+  deletePolicyVersionMock: jest.fn(),
   getRoleMock: jest.fn().mockImplementation((params) => {
     if (params.RoleName === 'already-removed-role') {
       const error = new Error()
@@ -295,6 +351,18 @@ const IAM = function() {
     }),
     getRole: (obj) => ({
       promise: () => mocks.getRoleMock(obj)
+    }),
+    getPolicy: (obj) => ({
+      promise: () => mocks.getPolicyMock(obj)
+    }),
+    getPolicyVersion: (obj) => ({
+      promise: () => mocks.getPolicyVersionMock(obj)
+    }),
+    listPolicyVersions: (obj) => ({
+      promise: () => mocks.listPolicyVersionsMock(obj)
+    }),
+    deletePolicyVersion: (obj) => ({
+      promise: () => mocks.deletePolicyVersionMock(obj)
     }),
     deleteRole: (obj) => ({
       promise: () => mocks.deleteRoleMock(obj)

--- a/registry/AwsIamPolicy/src/index.js
+++ b/registry/AwsIamPolicy/src/index.js
@@ -114,6 +114,7 @@ const AwsIamPolicy = (SuperClass) =>
           VersionId: getPolicyRes.Policy.DefaultVersionId
         }
         const getPolicyVersionRes = await IAM.getPolicyVersion(getPolicyVersionParams).promise()
+
         this.document = JSON.parse(decodeURIComponent(getPolicyVersionRes.PolicyVersion.Document))
       } catch (e) {
         if (e.code === 'NoSuchEntity') {

--- a/registry/AwsIamPolicy/src/index.js
+++ b/registry/AwsIamPolicy/src/index.js
@@ -1,4 +1,16 @@
-import { get, all, sleep, map, or, resolvable, pick, keys, not, equals } from '@serverless/utils'
+import {
+  get,
+  all,
+  sleep,
+  map,
+  or,
+  resolvable,
+  resolve,
+  pick,
+  keys,
+  not,
+  equals
+} from '@serverless/utils'
 
 const createPolicy = async (IAM, { policyName, document }) => {
   const policyRes = await IAM.createPolicy({
@@ -37,6 +49,28 @@ const deletePolicy = async (IAM, arn) => {
       )
     )
   ])
+
+  // delete non default versions...
+  const listPolicyVersionRes = await IAM.listPolicyVersions({
+    PolicyArn: arn
+  }).promise()
+
+  const nonDefaultVersions = listPolicyVersionRes.Versions.filter(
+    (version) => !version.IsDefaultVersion
+  )
+
+  await all(
+    map(
+      (version) =>
+        IAM.deletePolicyVersion({
+          PolicyArn: arn,
+          VersionId: version.VersionId
+        }).promise(),
+      nonDefaultVersions
+    )
+  )
+
+  // then delete the policy with its default version...
   await IAM.deletePolicy({
     PolicyArn: arn
   }).promise()
@@ -51,12 +85,42 @@ const AwsIamPolicy = (SuperClass) =>
 
       this.provider = inputs.provider
       this.policyName = resolvable(() => or(inputs.policyName, `policy-${this.instanceId}`))
+
       this.document = inputs.document
     }
 
     hydrate(prevInstance) {
       super.hydrate(prevInstance)
       this.arn = get('arn', prevInstance)
+    }
+
+    async sync() {
+      let { provider } = this
+      provider = resolve(provider)
+      const accountId = await provider.getAccountId()
+      const AWS = provider.getSdk()
+      const IAM = new AWS.IAM()
+
+      try {
+        // first, we get the policy to know the latest version...
+        const getPolicyParams = {
+          PolicyArn: `arn:aws:iam::${accountId}:policy/${resolve(this.policyName)}`
+        }
+        const getPolicyRes = await IAM.getPolicy(getPolicyParams).promise()
+
+        // second, we fetch that latest version
+        const getPolicyVersionParams = {
+          PolicyArn: `arn:aws:iam::${accountId}:policy/${resolve(this.policyName)}`,
+          VersionId: getPolicyRes.Policy.DefaultVersionId
+        }
+        const getPolicyVersionRes = await IAM.getPolicyVersion(getPolicyVersionParams).promise()
+        this.document = JSON.parse(decodeURIComponent(getPolicyVersionRes.PolicyVersion.Document))
+      } catch (e) {
+        if (e.code === 'NoSuchEntity') {
+          return 'removed'
+        }
+        throw e
+      }
     }
 
     shouldDeploy(prevInstance) {
@@ -68,10 +132,13 @@ const AwsIamPolicy = (SuperClass) =>
 
       // make sure any added suffix from prevInstance is preserved
       // otherwise name will always be different
-      if (prevInstance && this.policyName === `policy-${this.instanceId}`) {
+      if (
+        prevInstance &&
+        this.policyName === `policy-${this.instanceId}` &&
+        prevInstance.policyName.includes(`policy-${this.instanceId}`)
+      ) {
         this.policyName = prevInstance.policyName
       }
-
       // if config changed, change the name to trigger replace
       if (prevInstance && configChanged && this.policyName.includes(`policy-${this.instanceId}`)) {
         this.policyName = `policy-${this.instanceId}-${Math.random()


### PR DESCRIPTION
Adds sync method to AwsIamPolicy, and improves removal to take policy versions into consideration (necessary if users made changes to the policy in the AWS console)