### PR TITLE
Add logStatus catch all logic for circular JSON objects

### DIFF
--- a/src/utils/dag/logStatus.js
+++ b/src/utils/dag/logStatus.js
@@ -3,7 +3,7 @@ import { filter, assoc, reduce, resolve, not, isEmpty } from '@serverless/utils'
 function getParameters(instance) {
   if (instance.inputs && instance.inputTypes) {
     const requiredParams = filter((inputType) => !!inputType.required, instance.inputTypes)
-    const paramsAsObject = reduce(
+    let paramsAsObject = reduce(
       (accum, _, key) => {
         const value = resolve(instance.inputs[key])
         // TODO: replace with a universal util function which checks whether we're
@@ -19,7 +19,14 @@ function getParameters(instance) {
     )
 
     if (not(isEmpty(paramsAsObject))) {
-      return JSON.stringify(paramsAsObject, null, 2)
+      try {
+        paramsAsObject = JSON.stringify(paramsAsObject, null, 2)
+      } catch (error) {
+        // simply reassign to an empty object
+        paramsAsObject = {}
+      } finally {
+        return paramsAsObject
+      }
     }
     return paramsAsObject
   }


### PR DESCRIPTION
Fixes an issue where the status logging bailed when a JSON has circular references.

This is a catch-all since I already fixed this behavior for components, but it seems like there are more datastructures which can cause these issues.

/cc @eahefnawy 