### PR TITLE
Remove unnecessary logStatus reportings

### DIFF
--- a/src/utils/dag/execGraph.js
+++ b/src/utils/dag/execGraph.js
@@ -4,7 +4,9 @@ import detectCircularDeps from './detectCircularDeps'
 import logStatus from './logStatus'
 
 const execNode = (iteratee, node, context) => {
+  // log status message about the current operation
   logStatus(iteratee, node, context)
+
   return iteratee(node, {
     ...context,
     // replace `log` with `debug` so that component logs are hidden by default

--- a/src/utils/dag/logStatus.js
+++ b/src/utils/dag/logStatus.js
@@ -32,26 +32,29 @@ function getParameters(instance) {
   }
 }
 
-function logCurrentStatus(iteratee, node, context) {
+function logStatus(iteratee, node, context) {
   const { prevInstance, nextInstance } = node
 
-  const componentName =
-    (nextInstance && nextInstance.constructor.name) ||
-    (prevInstance && prevInstance.constructor.name)
+  const component = nextInstance ? nextInstance : prevInstance
+  const componentName = component.constructor.name
 
-  if (iteratee.name === 'deployNode') {
-    const params = getParameters(nextInstance)
-    context.log(
-      `Deploying "${componentName}" ${not(isEmpty(params)) ? `with parameters: ${params}` : ''}`
-    )
-  } else if (iteratee.name === 'removeNode') {
-    if (prevInstance) {
-      const params = getParameters(prevInstance)
+  const rootComponents = ['App', 'Compute', 'Cron', 'Function', 'Plugin', 'Service']
+
+  if (!rootComponents.includes(component.extends)) {
+    if (iteratee.name === 'deployNode') {
+      const params = getParameters(nextInstance)
       context.log(
-        `Removing "${componentName}" ${not(isEmpty(params)) ? `with parameters: ${params}` : ''}`
+        `Deploying "${componentName}" ${not(isEmpty(params)) ? `with parameters: ${params}` : ''}`
       )
+    } else if (iteratee.name === 'removeNode') {
+      if (prevInstance) {
+        const params = getParameters(prevInstance)
+        context.log(
+          `Removing "${componentName}" ${not(isEmpty(params)) ? `with parameters: ${params}` : ''}`
+        )
+      }
     }
   }
 }
 
-export default logCurrentStatus
+export default logStatus

--- a/src/utils/dag/logStatus.test.js
+++ b/src/utils/dag/logStatus.test.js
@@ -18,8 +18,9 @@ describe('#logStatus()', () => {
     iteratee.name = 'deployNode'
     const node = {
       nextInstance: {
+        extends: 'Component',
         constructor: {
-          name: 'SomeService'
+          name: 'SomeComponent'
         },
         inputs: {
           name: 'some-name'
@@ -42,8 +43,9 @@ describe('#logStatus()', () => {
     iteratee.name = 'removeNode'
     const node = {
       prevInstance: {
+        extends: 'Component',
         constructor: {
-          name: 'SomeService'
+          name: 'SomeComponent'
         },
         inputs: {
           name: 'some-name'
@@ -66,33 +68,64 @@ describe('#logStatus()', () => {
     iteratee.name = 'deployNode'
     const node = {
       nextInstance: {
+        extends: 'Component',
         constructor: {
-          name: 'SomeService'
+          name: 'SomeComponent'
         }
       },
       prevInstance: {
+        extends: 'Component',
         constructor: {
-          name: 'SomeService'
+          name: 'SomeComponent'
         }
       }
     }
     logStatus(iteratee, node, context)
 
     expect(mockLog).toHaveBeenCalledTimes(1)
-    expect(mockLog.mock.calls[0][0]).toEqual('Deploying "SomeService" ')
+    expect(mockLog.mock.calls[0][0]).toEqual('Deploying "SomeComponent" ')
+  })
+
+  it('should not log if the component extends a root component', async () => {
+    const Provider = await context.import('Provider')
+    const provider = context.construct(Provider, state, context)
+
+    iteratee.name = 'deployNode'
+    const node = {
+      nextInstance: {
+        extends: 'App', // "App" is one of the root components
+        constructor: {
+          name: 'SomeComponent'
+        },
+        inputs: {
+          provider: provider
+        },
+        inputTypes: {
+          provider: {
+            type: 'Provider',
+            required: true
+          }
+        }
+      }
+    }
+    logStatus(iteratee, node, context)
+
+    expect(mockLog).not.toHaveBeenCalled()
   })
 
   it('should not log any status if the operation is unknown', () => {
     iteratee.name = 'UNKNOWN_OPERATION'
     const node = {
       nextInstance: {
+        extends: 'Component',
         constructor: {
-          name: 'SomeService'
+          name: 'SomeComponent'
         }
       },
       prevInstance: {
+        extends: 'Component',
         constructor: {
-          name: 'SomeService'
+          name: 'SomeComponent'
         }
       }
     }
@@ -108,8 +141,9 @@ describe('#logStatus()', () => {
     iteratee.name = 'deployNode'
     const node = {
       nextInstance: {
+        extends: 'Component',
         constructor: {
-          name: 'SomeService'
+          name: 'SomeComponent'
         },
         inputs: {
           provider: provider
@@ -125,6 +159,6 @@ describe('#logStatus()', () => {
     logStatus(iteratee, node, context)
 
     expect(mockLog).toHaveBeenCalledTimes(1)
-    expect(mockLog.mock.calls[0][0]).toMatch('Deploying "SomeService" ')
+    expect(mockLog.mock.calls[0][0]).toMatch('Deploying "SomeComponent" ')
   })
 })


### PR DESCRIPTION
This PR fixes the verbose status reportings `logStatus` performs when the graph is walked.

The implementation defines an array of `rootComponents` which each node / component is checked against. Status reports are only logged for nodes / components that don't extend one of the `rootComponets` (e.g. the `Service` the user has defined when working on a project).

This is one of many ways to solve this...

/cc @brianneisler @eahefnawy