### PR TITLE
Add support for @latest as a component version number

### DIFF
--- a/src/utils/fs/loadComponent.js
+++ b/src/utils/fs/loadComponent.js
@@ -22,7 +22,11 @@ const loadComponent = async (query) => {
 
     const url = registry[name].repo
     const ownerRepo = url.replace('https://github.com/', '')
-    const version = query.split('@')[1]
+    let version = query.split('@')[1]
+
+    if (version.toLowerCase() === 'latest') {
+      version = 'master'
+    }
 
     const ownerRepoVersion = `${ownerRepo}#${version}`
     const dirName = `${name}@${version}`


### PR DESCRIPTION
This adds support for component declarations as `AwsLambda@latest`, therefore removing the need to specify a version number.

Using `LATEST` will always pull from GitHubs `master`.