### PR TITLE
Consume all method arguments when calling built-in methods.

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -44,8 +44,8 @@ class Component {
     // Add Component class methods like the save() method
     const classMethods = Object.getOwnPropertyNames(Component.prototype)
     classMethods.forEach((classMethod) => {
-      defaultFunction[classMethod] = (classMethodInputs) =>
-        this[classMethod].call(that, classMethodInputs) // apply instance context
+      defaultFunction[classMethod] = (...classMethodInputs) =>
+        this[classMethod].call(that, ...classMethodInputs) // apply instance context
     })
 
     // Add instance methods


### PR DESCRIPTION
This PR fixes a bug with built-in class methods arguments forwarding. The way they were implemented would only consume the first argument which would cause wrong behavior on methods like `load` (which accepts 2 arguments).

This fix is required for PR [serverless/template#8](https://github.com/serverless/template/pull/8) to work properly (without it, custom methods will not have access to the component state).

@eahefnawy as always, please review and send feedback if any changes are necessary :)