### PR TITLE
Configure "repository" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.2",
   "description": "Serverless Components Core",
   "main": "./src/index.js",
+  "repository": "serverless/components",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Package name doesn't reflect repository name as on GitHub, so it's hard to seclude that information on your own (especially when confusing old core repositories are still public on github)