### PR TITLE
Fix templates that involve parcel builds

### DIFF
--- a/templates/fullstack-application/dashboard/package.json
+++ b/templates/fullstack-application/dashboard/package.json
@@ -15,8 +15,13 @@
     "react-dom": "^16.5.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
+    "@babel/core": "^7.6.4",
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
+    "@babel/plugin-transform-react-jsx": "^7.3.0",
+    "@babel/plugin-transform-runtime": "^7.6.2",
+    "@babel/runtime": "^7.6.3",
     "babel-preset-nano-react-app": "^0.1.0",
+    "cssnano": "^4.1.10",
     "parcel-bundler": "^1.11.0",
     "parcel-plugin-clean-dist": "0.0.6"
   },

--- a/templates/website/package.json
+++ b/templates/website/package.json
@@ -15,8 +15,13 @@
     "react-dom": "^16.5.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
+    "@babel/core": "^7.6.4",
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
+    "@babel/plugin-transform-react-jsx": "^7.3.0",
+    "@babel/plugin-transform-runtime": "^7.6.2",
+    "@babel/runtime": "^7.6.3",
     "babel-preset-nano-react-app": "^0.1.0",
+    "cssnano": "^4.1.10",
     "parcel-bundler": "^1.11.0",
     "parcel-plugin-clean-dist": "0.0.6"
   },


### PR DESCRIPTION
When testing them locally, I've approached errors as `Cannot find module '@babel/plugin-transform-runtime'`  and  `Cannot resolve dependency '@babel/runtime/regenerator'`

Parcel adds some missing dependencies to package.json on it's own, but for some reason it stumbles with above errors if those are not listed