### PR TITLE
fix: global proxy not work bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "fs-extra": "^7.0.1",
+    "global-tunnel-ng": "^2.7.1",
     "js-yaml": "^3.13.1",
     "package-json": "^6.3.0",
     "ramda": "^0.26.1",

--- a/src/utils/download.js
+++ b/src/utils/download.js
@@ -7,6 +7,10 @@ const semver = require('semver')
 const util = require('util')
 const exec = util.promisify(require('child_process').exec)
 const dirExists = require('./fs/dirExists')
+const globalTunnul = require('global-tunnel-ng')
+
+// Init global proxy
+globalTunnul.initialize()
 
 async function getComponentVersionToDownload(component) {
   let packageName


### PR DESCRIPTION
Sometimes, users can not access to `https://registry.npmjs.org` directly, so they add global proxies for it. But  `got` lib (`package-json` depends on it) don't respect it, so they will get a `ECONNREFUSED` error. Refer to this issue https://github.com/sindresorhus/got/issues/560, so we need [global-tunnel-ng](https://github.com/np-maintain/global-tunnel).