### PR TITLE
Seclude command specific utils (to allow china SDK separation)

### DIFF
--- a/src/cli/commands/create.js
+++ b/src/cli/commands/create.js
@@ -2,7 +2,7 @@
  * CLI: Command: CREATE
  */
 
-const utils = require('../utils')
+const { isLoggedIn } = require('./utils')
 const { existsSync, copySync } = require('fs-extra')
 const path = require('path')
 
@@ -11,7 +11,7 @@ module.exports = async (config, cli) => {
   cli.start('Initializing', { timer: false })
 
   // Ensure the user is logged in, or advertise
-  if (!utils.isLoggedIn()) {
+  if (!isLoggedIn()) {
     cli.advertise()
   }
 

--- a/src/cli/commands/dev.js
+++ b/src/cli/commands/dev.js
@@ -4,7 +4,7 @@
 
 const chokidar = require('chokidar')
 const { ServerlessSDK } = require('@serverless/platform-client')
-const utils = require('../utils')
+const { getAccessKey, isLoggedIn, loadInstanceConfig, loadInstanceCredentials } = require('./utils')
 
 module.exports = async (config, cli) => {
   // Define a close handler, that removes any "dev" mode agents
@@ -24,10 +24,10 @@ module.exports = async (config, cli) => {
   cli.start('Initializing', { closeHandler })
 
   // Get access key
-  const accessKey = await utils.getAccessKey()
+  const accessKey = await getAccessKey()
 
   // Ensure the user is logged in or access key is available, or advertise
-  if (!accessKey && !utils.isLoggedIn()) {
+  if (!accessKey && !isLoggedIn()) {
     cli.advertise()
   }
 
@@ -40,10 +40,10 @@ module.exports = async (config, cli) => {
   cli.log()
 
   // Load serverless component instance.  Submit a directory where its config files should be.
-  let instanceYaml = await utils.loadInstanceConfig(process.cwd())
+  let instanceYaml = await loadInstanceConfig(process.cwd())
 
   // Load Instance Credentials
-  const instanceCredentials = await utils.loadInstanceCredentials(instanceYaml.stage)
+  const instanceCredentials = await loadInstanceCredentials(instanceYaml.stage)
 
   const sdk = new ServerlessSDK({
     accessKey,
@@ -214,12 +214,12 @@ module.exports = async (config, cli) => {
       isProcessing = true
       cli.status('Deploying', null, 'green')
       // reload serverless component instance
-      instanceYaml = await utils.loadInstanceConfig(process.cwd())
+      instanceYaml = await loadInstanceConfig(process.cwd())
       await sdk.deploy(instanceYaml, instanceCredentials, { dev: true })
       if (queuedOperation) {
         cli.status('Deploying', null, 'green')
         // reload serverless component instance
-        instanceYaml = await utils.loadInstanceConfig(process.cwd())
+        instanceYaml = await loadInstanceConfig(process.cwd())
         await sdk.deploy(instanceYaml, instanceCredentials, { dev: true })
       }
 

--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -3,7 +3,8 @@
  */
 
 const { ServerlessSDK } = require('@serverless/platform-client')
-const utils = require('../utils')
+const { getAccessKey, isLoggedIn, loadInstanceConfig } = require('./utils')
+const { getInstanceDashboardUrl } = require('../utils')
 const chalk = require('chalk')
 const moment = require('moment')
 
@@ -12,15 +13,15 @@ module.exports = async (config, cli) => {
   cli.start('Initializing', { timer: false })
 
   // Get access key
-  const accessKey = await utils.getAccessKey()
+  const accessKey = await getAccessKey()
 
   // Ensure the user is logged in or access key is available, or advertise
-  if (!accessKey && !utils.isLoggedIn()) {
+  if (!accessKey && !isLoggedIn()) {
     cli.advertise()
   }
 
   // Load YAML
-  const instanceYaml = await utils.loadInstanceConfig(process.cwd())
+  const instanceYaml = await loadInstanceConfig(process.cwd())
 
   // Presentation
   cli.logLogo()
@@ -58,7 +59,7 @@ module.exports = async (config, cli) => {
   // format last action for better UX
   const lastActionAgo = moment(instance.lastActionAt).fromNow()
 
-  const dashboardUrl = utils.getInstanceDashboardUrl(instanceYaml)
+  const dashboardUrl = getInstanceDashboardUrl(instanceYaml)
 
   // show the most important information, and link to the dashboard
   cli.log(`${chalk.grey('Status:')}       ${instance.instanceStatus}`)

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -1,5 +1,5 @@
 const { login } = require('@serverless/platform-sdk')
-const utils = require('../utils')
+const { getDefaultOrgName } = require('./utils')
 
 module.exports = async (config, cli, command) => {
   // Offer a nice presentation
@@ -14,7 +14,7 @@ module.exports = async (config, cli, command) => {
   const { username } = res.users[res.userId]
 
   // make sure default org name is set in the rc file
-  await utils.getDefaultOrgName()
+  await getDefaultOrgName()
 
   cli.close('success', `Successfully logged in as "${username}"`)
 }

--- a/src/cli/commands/login2.js
+++ b/src/cli/commands/login2.js
@@ -1,7 +1,8 @@
 const { ServerlessSDK } = require('@serverless/platform-client')
 const { urls } = require('@serverless/platform-sdk')
 const open = require('open')
-const utils = require('../utils')
+const { loadInstanceConfig } = require('./utils')
+const { loadComponentConfig } = require('../utils')
 
 module.exports = async (config, cli, command) => {
   // Offer a nice presentation
@@ -18,12 +19,12 @@ module.exports = async (config, cli, command) => {
   let componentVersion
   try {
     // load serverless.yml if available
-    instanceYaml = await utils.loadInstanceConfig(process.cwd())
+    instanceYaml = await loadInstanceConfig(process.cwd())
   } catch (e) {}
 
   try {
     // load serverless.component.yml if available
-    componentYaml = await utils.loadComponentConfig(process.cwd())
+    componentYaml = await loadComponentConfig(process.cwd())
   } catch (e) {}
 
   // parse component name and version if available

--- a/src/cli/commands/registry.js
+++ b/src/cli/commands/registry.js
@@ -3,7 +3,8 @@
  */
 
 const { ServerlessSDK } = require('@serverless/platform-client')
-const utils = require('../utils')
+const { getAccessKey, isLoggedIn } = require('./utils')
+const { loadComponentConfig } = require('../utils')
 
 /**
  * Publish a Component to the Serverless Registry
@@ -18,15 +19,15 @@ const publish = async (config, cli) => {
   cli.start('Initializing')
 
   // Get access key
-  const accessKey = await utils.getAccessKey()
+  const accessKey = await getAccessKey()
 
   // Ensure the user is logged in or access key is available, or advertise
-  if (!accessKey && !utils.isLoggedIn()) {
+  if (!accessKey && !isLoggedIn()) {
     cli.advertise()
   }
 
   // Load YAML
-  const componentYaml = await utils.loadComponentConfig(process.cwd())
+  const componentYaml = await loadComponentConfig(process.cwd())
 
   // Presentation
   cli.logRegistryLogo()

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -4,22 +4,23 @@
 
 const { ServerlessSDK } = require('@serverless/platform-client')
 const chalk = require('chalk')
-const utils = require('../utils')
+const { getAccessKey, isLoggedIn, loadInstanceConfig, loadInstanceCredentials } = require('./utils')
+const { getInstanceDashboardUrl } = require('../utils')
 
 module.exports = async (config, cli, command) => {
   // Start CLI persistance status
   cli.start('Initializing', { timer: true })
 
   // Get access key
-  const accessKey = await utils.getAccessKey()
+  const accessKey = await getAccessKey()
 
   // Ensure the user is logged in or access key is available, or advertise
-  if (!accessKey && !utils.isLoggedIn()) {
+  if (!accessKey && !isLoggedIn()) {
     cli.advertise()
   }
 
   // Load YAML
-  const instanceYaml = await utils.loadInstanceConfig(process.cwd())
+  const instanceYaml = await loadInstanceConfig(process.cwd())
 
   // Presentation
   const meta = `Action: "${command}" - Stage: "${instanceYaml.stage}" - App: "${instanceYaml.app}" - Instance: "${instanceYaml.name}"`
@@ -33,7 +34,7 @@ module.exports = async (config, cli, command) => {
   cli.status('Initializing', instanceYaml.name)
 
   // Load Instance Credentials
-  const instanceCredentials = await utils.loadInstanceCredentials(instanceYaml.stage)
+  const instanceCredentials = await loadInstanceCredentials(instanceYaml.stage)
 
   // initialize SDK
   const sdk = new ServerlessSDK({
@@ -89,7 +90,7 @@ module.exports = async (config, cli, command) => {
       )
     }
 
-    const dashboardUrl = utils.getInstanceDashboardUrl(instanceYaml)
+    const dashboardUrl = getInstanceDashboardUrl(instanceYaml)
 
     // run deploy
     cli.status('Deploying', null, 'white')

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -1,0 +1,276 @@
+/*
+ * Serverless Components: Utilities
+ */
+
+const path = require('path')
+const dotenv = require('dotenv')
+const {
+  readConfigFile,
+  writeConfigFile,
+  createAccessKeyForTenant,
+  refreshToken,
+  listTenants
+} = require('@serverless/platform-sdk')
+const { fileExistsSync, readFileSync, resolveInputVariables } = require('../utils')
+
+const getDefaultOrgName = async () => {
+  const res = readConfigFile()
+
+  if (!res.userId) {
+    return null
+  }
+
+  let { defaultOrgName } = res.users[res.userId].dashboard
+
+  // if defaultOrgName is not in RC file, fetch it from the platform
+  if (!defaultOrgName) {
+    await refreshToken()
+
+    const userConfigFile = readConfigFile()
+
+    const { username, dashboard } = userConfigFile.users[userConfigFile.userId]
+    const { idToken } = dashboard
+    const orgsList = await listTenants({ username, idToken })
+
+    // filter by owner
+    const filteredOrgsList = orgsList.filter((org) => org.role === 'owner')
+
+    defaultOrgName = filteredOrgsList[0].orgName
+
+    res.users[res.userId].dashboard.defaultOrgName = defaultOrgName
+
+    writeConfigFile(res)
+  }
+
+  return defaultOrgName
+}
+
+/**
+ * Reads a serverless instance config file in a given directory path
+ * @param {*} directoryPath
+ */
+const loadInstanceConfig = async (directoryPath) => {
+  directoryPath = path.resolve(directoryPath)
+  const ymlFilePath = path.join(directoryPath, `serverless.yml`)
+  const yamlFilePath = path.join(directoryPath, `serverless.yaml`)
+  const jsonFilePath = path.join(directoryPath, `serverless.json`)
+  let filePath
+  let isYaml = false
+  let instanceFile
+
+  // Check to see if exists and is yaml or json file
+  if (fileExistsSync(ymlFilePath)) {
+    filePath = ymlFilePath
+    isYaml = true
+  }
+  if (fileExistsSync(yamlFilePath)) {
+    filePath = yamlFilePath
+    isYaml = true
+  }
+  if (fileExistsSync(jsonFilePath)) {
+    filePath = jsonFilePath
+  }
+
+  if (!filePath) {
+    throw new Error(`serverless config file was not found`)
+  }
+
+  // Read file
+  if (isYaml) {
+    try {
+      instanceFile = readFileSync(filePath)
+    } catch (e) {
+      // todo currently our YAML parser does not support
+      // CF schema (!Ref for example). So we silent that error
+      // because the framework can deal with that
+      if (e.name !== 'YAMLException') {
+        throw e
+      }
+    }
+  } else {
+    instanceFile = readFileSync(filePath)
+  }
+
+  if (!instanceFile.name) {
+    throw new Error(`Missing "name" property in serverless.yml`)
+  }
+
+  if (!instanceFile.component) {
+    throw new Error(`Missing "component" property in serverless.yml`)
+  }
+
+  // Set default stage
+  if (!instanceFile.stage) {
+    instanceFile.stage = 'dev'
+  }
+
+  if (!instanceFile.org) {
+    instanceFile.org = await getDefaultOrgName()
+  }
+
+  if (!instanceFile.org) {
+    throw new Error(`Missing "org" property in serverless.yml`)
+  }
+
+  if (!instanceFile.app) {
+    instanceFile.app = instanceFile.name
+  }
+
+  if (instanceFile.inputs) {
+    instanceFile.inputs = resolveInputVariables(instanceFile.inputs)
+  }
+
+  return instanceFile
+}
+
+/**
+ * Check whether the user is logged in
+ */
+const isLoggedIn = () => {
+  const userConfigFile = readConfigFile()
+  // If userId is null, they are not logged in.  They also might be a new user.
+  if (!userConfigFile.userId) {
+    return false
+  }
+  if (!userConfigFile.users[userConfigFile.userId]) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Gets the logged in user's token id, or access key if its in env
+ */
+const getAccessKey = async () => {
+  // if access key in env, use that for CI/CD
+  if (process.env.SERVERLESS_ACCESS_KEY) {
+    return process.env.SERVERLESS_ACCESS_KEY
+  }
+
+  if (!isLoggedIn()) {
+    return null
+  }
+
+  // refresh token if it's expired.
+  // this platform-sdk method returns immediately if the idToken did not expire
+  // if it did expire, it'll refresh it and update the config file
+  await refreshToken()
+
+  // read config file from user machine
+  const userConfigFile = readConfigFile()
+
+  // Verify config file and that the user is logged in
+  if (!userConfigFile || !userConfigFile.users || !userConfigFile.users[userConfigFile.userId]) {
+    return null
+  }
+
+  const user = userConfigFile.users[userConfigFile.userId]
+
+  return user.dashboard.idToken
+}
+
+/**
+ * Gets or creates an access key based on org
+ * @param {*} org
+ */
+const getOrCreateAccessKey = async (org) => {
+  if (process.env.SERVERLESS_ACCESS_KEY) {
+    return process.env.SERVERLESS_ACCESS_KEY
+  }
+
+  // read config file from the user machine
+  const userConfigFile = readConfigFile()
+
+  // Verify config file
+  if (!userConfigFile || !userConfigFile.users || !userConfigFile.users[userConfigFile.userId]) {
+    return null
+  }
+
+  const user = userConfigFile.users[userConfigFile.userId]
+
+  if (!user.dashboard.accessKeys[org]) {
+    // create access key and save it
+    const accessKey = await createAccessKeyForTenant(org)
+    userConfigFile.users[userConfigFile.userId].dashboard.accessKeys[org] = accessKey
+    writeConfigFile(userConfigFile)
+    return accessKey
+  }
+
+  // return the access key for the specified org
+  // return user.dashboard.accessKeys[org]
+  return user.dashboard.idToken
+}
+
+/**
+ * Load credentials from a ".env" or ".env.[stage]" file
+ * @param {*} stage
+ */
+const loadInstanceCredentials = (stage) => {
+  // Load env vars
+  let envVars = {}
+  const defaultEnvFilePath = path.join(process.cwd(), `.env`)
+  const stageEnvFilePath = path.join(process.cwd(), `.env.${stage}`)
+
+  // Load environment variables via .env file
+  if (stage && fileExistsSync(stageEnvFilePath)) {
+    envVars = dotenv.config({ path: path.resolve(stageEnvFilePath) }).parsed || {}
+  } else if (fileExistsSync(defaultEnvFilePath)) {
+    envVars = dotenv.config({ path: path.resolve(defaultEnvFilePath) }).parsed || {}
+  }
+
+  // Known Provider Environment Variables and their SDK configuration properties
+  const providers = {}
+
+  // AWS
+  providers.aws = {}
+  providers.aws.AWS_ACCESS_KEY_ID = 'accessKeyId'
+  providers.aws.AWS_SECRET_ACCESS_KEY = 'secretAccessKey'
+  providers.aws.AWS_REGION = 'region'
+
+  // Google
+  providers.google = {}
+  providers.google.GOOGLE_APPLICATION_CREDENTIALS = 'applicationCredentials'
+  providers.google.GOOGLE_PROJECT_ID = 'projectId'
+  providers.google.GOOGLE_CLIENT_EMAIL = 'clientEmail'
+  providers.google.GOOGLE_PRIVATE_KEY = 'privateKey'
+
+  // Tencent
+  providers.tencent = {}
+  providers.tencent.TENCENT_APP_ID = 'AppId'
+  providers.tencent.TENCENT_SECRET_ID = 'SecretId'
+  providers.tencent.TENCENT_SECRET_KEY = 'SecretKey'
+
+  // Docker
+  providers.docker = {}
+  providers.docker.DOCKER_USERNAME = 'username'
+  providers.docker.DOCKER_PASSWORD = 'password'
+
+  const credentials = {}
+
+  for (const provider in providers) {
+    const providerEnvVars = providers[provider]
+    for (const providerEnvVar in providerEnvVars) {
+      if (!credentials[provider]) {
+        credentials[provider] = {}
+      }
+      // Proper environment variables override what's in the .env file
+      if (process.env.hasOwnProperty(providerEnvVar)) {
+        credentials[provider][providerEnvVars[providerEnvVar]] = process.env[providerEnvVar]
+      } else if (envVars.hasOwnProperty(providerEnvVar)) {
+        credentials[provider][providerEnvVars[providerEnvVar]] = envVars[providerEnvVar]
+      }
+      continue
+    }
+  }
+
+  return credentials
+}
+
+module.exports = {
+  loadInstanceConfig,
+  loadInstanceCredentials,
+  getOrCreateAccessKey,
+  getAccessKey,
+  isLoggedIn,
+  getDefaultOrgName
+}

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -347,6 +347,12 @@ const legacyLoadComponentConfig = (directoryPath) => {
   return componentFile
 }
 
+// Same as internal Tencent check:
+// https://github.com/serverless-tencent/serverless-tencent-tools/blob/3c1cabbdb21c0b3ba37248b9c2f609ec552bf8fc/sdk/others/isInChina.js#L12
+const IS_IN_CHINA = Boolean(
+  new Date().getTimezoneOffset() == -480 || String(process.env.LC_CTYPE).indexOf('zh_CN')
+)
+
 module.exports = {
   sleep,
   request,
@@ -360,5 +366,6 @@ module.exports = {
   pack,
   getInstanceDashboardUrl,
   legacyLoadComponentConfig,
-  legacyLoadInstanceConfig
+  legacyLoadInstanceConfig,
+  IS_IN_CHINA
 }

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -10,14 +10,6 @@ const AdmZip = require('adm-zip')
 const fse = require('fs-extra')
 const YAML = require('js-yaml')
 const traverse = require('traverse')
-const dotenv = require('dotenv')
-const {
-  readConfigFile,
-  writeConfigFile,
-  createAccessKeyForTenant,
-  refreshToken,
-  listTenants
-} = require('@serverless/platform-sdk')
 
 /**
  * Wait for a number of miliseconds
@@ -104,38 +96,6 @@ const readFileSync = (filePath, options = {}) => {
   return contents.toString().trim()
 }
 
-const getDefaultOrgName = async () => {
-  const res = readConfigFile()
-
-  if (!res.userId) {
-    return null
-  }
-
-  let { defaultOrgName } = res.users[res.userId].dashboard
-
-  // if defaultOrgName is not in RC file, fetch it from the platform
-  if (!defaultOrgName) {
-    await refreshToken()
-
-    const userConfigFile = readConfigFile()
-
-    const { username, dashboard } = userConfigFile.users[userConfigFile.userId]
-    const { idToken } = dashboard
-    const orgsList = await listTenants({ username, idToken })
-
-    // filter by owner
-    const filteredOrgsList = orgsList.filter((org) => org.role === 'owner')
-
-    defaultOrgName = filteredOrgsList[0].orgName
-
-    res.users[res.userId].dashboard.defaultOrgName = defaultOrgName
-
-    writeConfigFile(res)
-  }
-
-  return defaultOrgName
-}
-
 /**
  * Resolves any variables that require resolving before the engine.
  * This currently supports only ${env}.  All others should be resolved within the deployment engine.
@@ -168,84 +128,6 @@ const resolveInputVariables = (inputs) => {
     return resolveInputVariables(resolvedInputs)
   }
   return resolvedInputs
-}
-
-/**
- * Reads a serverless instance config file in a given directory path
- * @param {*} directoryPath
- */
-const loadInstanceConfig = async (directoryPath) => {
-  directoryPath = path.resolve(directoryPath)
-  const ymlFilePath = path.join(directoryPath, `serverless.yml`)
-  const yamlFilePath = path.join(directoryPath, `serverless.yaml`)
-  const jsonFilePath = path.join(directoryPath, `serverless.json`)
-  let filePath
-  let isYaml = false
-  let instanceFile
-
-  // Check to see if exists and is yaml or json file
-  if (fileExistsSync(ymlFilePath)) {
-    filePath = ymlFilePath
-    isYaml = true
-  }
-  if (fileExistsSync(yamlFilePath)) {
-    filePath = yamlFilePath
-    isYaml = true
-  }
-  if (fileExistsSync(jsonFilePath)) {
-    filePath = jsonFilePath
-  }
-
-  if (!filePath) {
-    throw new Error(`serverless config file was not found`)
-  }
-
-  // Read file
-  if (isYaml) {
-    try {
-      instanceFile = readFileSync(filePath)
-    } catch (e) {
-      // todo currently our YAML parser does not support
-      // CF schema (!Ref for example). So we silent that error
-      // because the framework can deal with that
-      if (e.name !== 'YAMLException') {
-        throw e
-      }
-    }
-  } else {
-    instanceFile = readFileSync(filePath)
-  }
-
-  if (!instanceFile.name) {
-    throw new Error(`Missing "name" property in serverless.yml`)
-  }
-
-  if (!instanceFile.component) {
-    throw new Error(`Missing "component" property in serverless.yml`)
-  }
-
-  // Set default stage
-  if (!instanceFile.stage) {
-    instanceFile.stage = 'dev'
-  }
-
-  if (!instanceFile.org) {
-    instanceFile.org = await getDefaultOrgName()
-  }
-
-  if (!instanceFile.org) {
-    throw new Error(`Missing "org" property in serverless.yml`)
-  }
-
-  if (!instanceFile.app) {
-    instanceFile.app = instanceFile.name
-  }
-
-  if (instanceFile.inputs) {
-    instanceFile.inputs = resolveInputVariables(instanceFile.inputs)
-  }
-
-  return instanceFile
 }
 
 /**
@@ -313,84 +195,6 @@ const getDirSize = async (p) => {
 }
 
 /**
- * Check whether the user is logged in
- */
-const isLoggedIn = () => {
-  const userConfigFile = readConfigFile()
-  // If userId is null, they are not logged in.  They also might be a new user.
-  if (!userConfigFile.userId) {
-    return false
-  }
-  if (!userConfigFile.users[userConfigFile.userId]) {
-    return false
-  }
-  return true
-}
-
-/**
- * Gets the logged in user's token id, or access key if its in env
- */
-const getAccessKey = async () => {
-  // if access key in env, use that for CI/CD
-  if (process.env.SERVERLESS_ACCESS_KEY) {
-    return process.env.SERVERLESS_ACCESS_KEY
-  }
-
-  if (!isLoggedIn()) {
-    return null
-  }
-
-  // refresh token if it's expired.
-  // this platform-sdk method returns immediately if the idToken did not expire
-  // if it did expire, it'll refresh it and update the config file
-  await refreshToken()
-
-  // read config file from user machine
-  const userConfigFile = readConfigFile()
-
-  // Verify config file and that the user is logged in
-  if (!userConfigFile || !userConfigFile.users || !userConfigFile.users[userConfigFile.userId]) {
-    return null
-  }
-
-  const user = userConfigFile.users[userConfigFile.userId]
-
-  return user.dashboard.idToken
-}
-
-/**
- * Gets or creates an access key based on org
- * @param {*} org
- */
-const getOrCreateAccessKey = async (org) => {
-  if (process.env.SERVERLESS_ACCESS_KEY) {
-    return process.env.SERVERLESS_ACCESS_KEY
-  }
-
-  // read config file from the user machine
-  const userConfigFile = readConfigFile()
-
-  // Verify config file
-  if (!userConfigFile || !userConfigFile.users || !userConfigFile.users[userConfigFile.userId]) {
-    return null
-  }
-
-  const user = userConfigFile.users[userConfigFile.userId]
-
-  if (!user.dashboard.accessKeys[org]) {
-    // create access key and save it
-    const accessKey = await createAccessKeyForTenant(org)
-    userConfigFile.users[userConfigFile.userId].dashboard.accessKeys[org] = accessKey
-    writeConfigFile(userConfigFile)
-    return accessKey
-  }
-
-  // return the access key for the specified org
-  // return user.dashboard.accessKeys[org]
-  return user.dashboard.idToken
-}
-
-/**
  * Package files into a zip
  * @param {*} inputDirPath
  * @param {*} outputFilePath
@@ -433,71 +237,6 @@ const pack = async (inputDirPath, outputFilePath, include = [], exclude = []) =>
   zip.writeZip(outputFilePath)
 
   return outputFilePath
-}
-
-/**
- * Load credentials from a ".env" or ".env.[stage]" file
- * @param {*} stage
- */
-const loadInstanceCredentials = (stage) => {
-  // Load env vars
-  let envVars = {}
-  const defaultEnvFilePath = path.join(process.cwd(), `.env`)
-  const stageEnvFilePath = path.join(process.cwd(), `.env.${stage}`)
-
-  // Load environment variables via .env file
-  if (stage && fileExistsSync(stageEnvFilePath)) {
-    envVars = dotenv.config({ path: path.resolve(stageEnvFilePath) }).parsed || {}
-  } else if (fileExistsSync(defaultEnvFilePath)) {
-    envVars = dotenv.config({ path: path.resolve(defaultEnvFilePath) }).parsed || {}
-  }
-
-  // Known Provider Environment Variables and their SDK configuration properties
-  const providers = {}
-
-  // AWS
-  providers.aws = {}
-  providers.aws.AWS_ACCESS_KEY_ID = 'accessKeyId'
-  providers.aws.AWS_SECRET_ACCESS_KEY = 'secretAccessKey'
-  providers.aws.AWS_REGION = 'region'
-
-  // Google
-  providers.google = {}
-  providers.google.GOOGLE_APPLICATION_CREDENTIALS = 'applicationCredentials'
-  providers.google.GOOGLE_PROJECT_ID = 'projectId'
-  providers.google.GOOGLE_CLIENT_EMAIL = 'clientEmail'
-  providers.google.GOOGLE_PRIVATE_KEY = 'privateKey'
-
-  // Tencent
-  providers.tencent = {}
-  providers.tencent.TENCENT_APP_ID = 'AppId'
-  providers.tencent.TENCENT_SECRET_ID = 'SecretId'
-  providers.tencent.TENCENT_SECRET_KEY = 'SecretKey'
-
-  // Docker
-  providers.docker = {}
-  providers.docker.DOCKER_USERNAME = 'username'
-  providers.docker.DOCKER_PASSWORD = 'password'
-
-  const credentials = {}
-
-  for (const provider in providers) {
-    const providerEnvVars = providers[provider]
-    for (const providerEnvVar in providerEnvVars) {
-      if (!credentials[provider]) {
-        credentials[provider] = {}
-      }
-      // Proper environment variables override what's in the .env file
-      if (process.env.hasOwnProperty(providerEnvVar)) {
-        credentials[provider][providerEnvVars[providerEnvVar]] = process.env[providerEnvVar]
-      } else if (envVars.hasOwnProperty(providerEnvVar)) {
-        credentials[provider][providerEnvVars[providerEnvVar]] = envVars[providerEnvVar]
-      }
-      continue
-    }
-  }
-
-  return credentials
 }
 
 const getInstanceDashboardUrl = (instanceYaml) => {
@@ -616,16 +355,10 @@ module.exports = {
   isYamlPath,
   isJsonPath,
   loadComponentConfig,
-  loadInstanceConfig,
-  loadInstanceCredentials,
   resolveInputVariables,
   getDirSize,
-  getOrCreateAccessKey,
-  getAccessKey,
   pack,
-  isLoggedIn,
   getInstanceDashboardUrl,
-  getDefaultOrgName,
   legacyLoadComponentConfig,
   legacyLoadInstanceConfig
 }


### PR DESCRIPTION
Goal is to use two different SDK's conditionally, and to separate completely work on Tencent dedicated commands from AWS commands.

This PR, secludes utils that are specific to AWS SDK, into it's commands folder.

Having that @hkbarton will follow with next PR which will introduce a `commands-cn` folder which will serve command dedicated for Tencent platform

Additionally I've configured `IS_IN_CHINA` constant into utils, to be used for chinese users detection