### PR TITLE
Fix IS_IN_CHINA resolution

### DIFF
--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -349,9 +349,8 @@ const legacyLoadComponentConfig = (directoryPath) => {
 
 // Same as internal Tencent check:
 // https://github.com/serverless-tencent/serverless-tencent-tools/blob/3c1cabbdb21c0b3ba37248b9c2f609ec552bf8fc/sdk/others/isInChina.js#L12
-const IS_IN_CHINA = Boolean(
-  new Date().getTimezoneOffset() == -480 || String(process.env.LC_CTYPE).indexOf('zh_CN')
-)
+const IS_IN_CHINA =
+  new Date().getTimezoneOffset() == -480 || String(process.env.LC_CTYPE).includes('zh_CN')
 
 module.exports = {
   sleep,


### PR DESCRIPTION
Initially I blindly copied the check from https://github.com/serverless-tencent/serverless-tencent-tools/blob/3c1cabbdb21c0b3ba37248b9c2f609ec552bf8fc/sdk/others/isInChina.js#L12

Still it appears it's faulty. This patch fixes it (I've also proposed a patch for `serverless-tencent-tools`: https://github.com/serverless-tencent/serverless-tencent-tools/pull/6)