### PR TITLE
add commands to support China/Tencent user

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@serverless/platform-client": "latest",
+    "@serverless/tencent-platform-client": "latest",
     "@serverless/platform-sdk": "^2.3.0",
     "adm-zip": "^0.4.14",
     "ansi-escapes": "^4.2.0",

--- a/src/cli/commands-cn/create.js
+++ b/src/cli/commands-cn/create.js
@@ -1,0 +1,42 @@
+/*
+ * CLI: Command: CREATE
+ */
+
+const utils = require('./utils')
+const { existsSync, copySync } = require('fs-extra')
+const path = require('path')
+
+module.exports = async (config, cli) => {
+  // Start CLI persistance status
+  cli.start('Initializing', { timer: false })
+
+  // Presentation
+  cli.logLogo()
+  cli.log()
+
+  const templatesDir = path.join(__dirname, '..', '..', '..', 'templates')
+  const templateName = config.t || config.template
+  if (!templateName) {
+    throw new Error('Need to specify template name by using -t or --template option.')
+  }
+  const templatePath = path.join(templatesDir, templateName)
+  const destinationPath = process.cwd()
+
+  cli.status('Creating', templateName)
+
+  // throw error if invalid template
+  if (!existsSync(templatePath)) {
+    throw new Error(`Template "${templateName}" does not exist.`)
+  }
+
+  // copy template content
+  copySync(templatePath, destinationPath)
+
+  cli.log(`- Successfully created "${templateName}" instance in the currennt working directory.`)
+
+  cli.log(`- Don't forget to update serverless.yml and install dependencies if needed.`)
+
+  cli.log(`- Whenever you're ready, run "serverless deploy" to deploy your new instance.`)
+
+  cli.close('success', 'Created')
+}

--- a/src/cli/commands-cn/dev.js
+++ b/src/cli/commands-cn/dev.js
@@ -1,0 +1,216 @@
+/*
+ * CLI: Command: Dev
+ */
+
+const path = require('path')
+const { Writable } = require('stream')
+const ansiEscapes = require('ansi-escapes')
+const chokidar = require('chokidar')
+const { ServerlessSDK, utils: tencentUtils } = require('@serverless/tencent-platform-client')
+const utils = require('./utils')
+
+class LogForwardingOutput extends Writable {
+  constructor(options) {
+    super(options)
+  }
+
+  _write(chunk, encoding, callback) {
+    process.stdout.write(ansiEscapes.eraseDown)
+    process.stdout._write(chunk, encoding, callback)
+    process.stdout.write(ansiEscapes.cursorLeft)
+  }
+
+  _writev(chunks, callback) {
+    process.stdout.write(ansiEscapes.eraseDown)
+    process.stdout._writev(chunks, callback)
+    process.stdout.write(ansiEscapes.cursorLeft)
+  }
+}
+
+const logForwardingOutput = new LogForwardingOutput()
+
+/*
+ * Deploy changes and hookup event callback which will be called when
+ * deploying status has been changed.
+ * @param sdk - instance of ServerlessSDK
+ * @param instance - instance object
+ * @param credentials - credentials used for deploy
+ * @param enventCallback - event callback, when set to false, it will remove all event listener
+ */
+async function deploy(sdk, instance, credentials) {
+  const getInstanceInfo = async () => {
+    const { instance: instanceInfo } = await sdk.getInstance(
+      instance.org,
+      instance.stage,
+      instance.app,
+      instance.name
+    )
+    return instanceInfo
+  }
+
+  let instanceInfo = {}
+
+  try {
+    await sdk.deploy(instance, credentials)
+    const instanceStatusPollingStartTime = new Date().getTime()
+    instanceInfo = await getInstanceInfo()
+    while (instanceInfo.instanceStatus === 'deploying') {
+      instanceInfo = await getInstanceInfo()
+      if (Date.now() - instanceStatusPollingStartTime > 24000) {
+        throw new Error('Deployment timeout, please retry in a few seconds')
+      }
+    }
+  } catch (e) {
+    instanceInfo.instanceStatus = 'error'
+    instanceInfo.deploymentError = e
+  }
+
+  return instanceInfo
+}
+
+async function updateDeploymentStatus(cli, instanceInfo, startDebug) {
+  const { instanceStatus, instanceName, deploymentError, deploymentErrorStack } = instanceInfo
+  const d = new Date()
+  const header = `${d.toLocaleTimeString()} - ${instanceName} - deployment`
+
+  const cliEventCallback = (msg, option) => {
+    cli.log(msg, option && option.type === 'error' ? 'red' : 'grey')
+  }
+  cliEventCallback.stdout = logForwardingOutput
+
+  switch (instanceStatus) {
+    case 'active':
+      const {
+        state: { lambdaArn, region }
+      } = instanceInfo
+      if (lambdaArn && region) {
+        await tencentUtils.stopTencentRemoteLogAndDebug(lambdaArn, region, cliEventCallback)
+        if (startDebug) {
+          await tencentUtils.startTencentRemoteLogAndDebug(lambdaArn, region, cliEventCallback)
+        }
+      }
+      cli.log(header, 'grey')
+      cli.logOutputs(instanceInfo.outputs)
+      cli.status('Watching')
+      return true
+    case 'error':
+      cli.log(`${header} error`, 'grey')
+      cli.log(deploymentErrorStack || deploymentError, 'red')
+      cli.status('Watching')
+      break
+    default:
+      cli.log(`Deployment failed due to unknown deployment status: ${instanceStatus}`, 'red')
+  }
+  return false
+}
+
+module.exports = async (config, cli) => {
+  // Define a close handler, that removes any "dev" mode agents
+  const closeHandler = async () => {
+    // Set new close listener
+    process.on('SIGINT', () => {
+      cli.close('error', 'Dev Mode Canceled.  Run "serverless deploy" To Remove Dev Mode Agent.')
+    })
+
+    cli.status('Disabling Dev Mode & Closing', null, 'green')
+    const deployedInstance = await deploy(sdk, instanceYaml, instanceCredentials)
+    if (await updateDeploymentStatus(cli, deployedInstance, false)) {
+      cli.close('success', 'Dev Mode Closed')
+    }
+  }
+
+  // Start CLI persistance status
+  cli.start('Initializing', { closeHandler })
+
+  await utils.login()
+
+  // Presentation
+  cli.logLogo()
+  cli.log(
+    'Dev Mode - Watching your Component for changes and enabling streaming logs, if supported...',
+    'grey'
+  )
+  cli.log()
+
+  // Load serverless component instance.  Submit a directory where its config files should be.
+  let instanceDir = process.cwd()
+  if (config.target) {
+    instanceDir = path.join(instanceDir, config.target)
+  }
+  let instanceYaml = await utils.loadInstanceConfig(instanceDir)
+
+  // Load Instance Credentials
+  const instanceCredentials = await utils.loadInstanceCredentials(instanceYaml.stage)
+
+  const sdk = new ServerlessSDK({
+    context: {
+      orgName: instanceYaml.org
+    }
+  })
+
+  cli.status('Initializing', instanceYaml.name)
+
+  // Filter configuration
+  const filter = {
+    stageName: instanceYaml.stage,
+    appName: instanceYaml.app,
+    instanceName: instanceYaml.name,
+    events: []
+  }
+
+  // User wants to receive all messages at the app level
+  if (config.filter && config.filter === 'app' && filter.instanceName) {
+    delete filter.instanceName
+    cli.log('Enabling filtering at the activity at the application level', 'grey')
+    cli.log()
+  }
+
+  /**
+   * Watch logic
+   */
+
+  let isProcessing = false // whether there's already a deployment in progress
+  let queuedOperation = false // whether there's another deployment queued
+
+  // Set watcher
+  const watcher = chokidar.watch(process.cwd(), { ignored: /\.serverless/ })
+
+  watcher.on('ready', async () => {
+    cli.status('Enabling Dev Mode', null, 'green')
+    const deployedInstance = await deploy(sdk, instanceYaml, instanceCredentials)
+    await updateDeploymentStatus(cli, deployedInstance, true)
+  })
+
+  watcher.on('change', async () => {
+    // Skip if processing already and there is a queued operation
+    if (isProcessing && queuedOperation) {
+      return
+    }
+
+    // If already deploying and user made more changes, queue another deploy operation to be run after the first one
+    if (isProcessing && !queuedOperation) {
+      queuedOperation = true
+      return
+    }
+
+    // If it's not processin and there is no queued operation
+    if (!isProcessing) {
+      let deployedInstance
+      isProcessing = true
+      cli.status('Deploying', null, 'green')
+      // reload serverless component instance
+      instanceYaml = await utils.loadInstanceConfig(instanceDir)
+      deployedInstance = await deploy(sdk, instanceYaml, instanceCredentials)
+      if (queuedOperation) {
+        cli.status('Deploying', null, 'green')
+        // reload serverless component instance
+        instanceYaml = await utils.loadInstanceConfig(instanceDir)
+        deployedInstance = await deploy(sdk, instanceYaml, instanceCredentials)
+      }
+
+      await updateDeploymentStatus(cli, deployedInstance, true)
+      isProcessing = false
+      queuedOperation = false
+    }
+  })
+}

--- a/src/cli/commands-cn/index.js
+++ b/src/cli/commands-cn/index.js
@@ -1,0 +1,13 @@
+const run = require('./run')
+const info = require('./info')
+const create = require('./create')
+const dev = require('./dev')
+const registry = require('./registry')
+
+module.exports = {
+  run,
+  info,
+  create,
+  dev,
+  registry
+}

--- a/src/cli/commands-cn/info.js
+++ b/src/cli/commands-cn/info.js
@@ -1,0 +1,79 @@
+/*
+ * CLI: Command: INFO
+ */
+
+const path = require('path')
+const { ServerlessSDK } = require('@serverless/tencent-platform-client')
+const utils = require('./utils')
+const chalk = require('chalk')
+const moment = require('moment')
+
+module.exports = async (config, cli) => {
+  // Start CLI persistance status
+  cli.start('Initializing', { timer: false })
+
+  await utils.login()
+
+  // Load YAML
+  let instanceDir = process.cwd()
+  if (config.target) {
+    instanceDir = path.join(instanceDir, config.target)
+  }
+  const instanceYaml = await utils.loadInstanceConfig(instanceDir)
+
+  // Presentation
+  cli.logLogo()
+  cli.log()
+
+  cli.status('Initializing', instanceYaml.name)
+
+  // initialize SDK
+  const sdk = new ServerlessSDK()
+
+  // don't show the status in debug mode due to formatting issues
+  if (!config.debug) {
+    cli.status('Loading Info', null, 'white')
+  }
+
+  // Fetch info
+  let instance = await sdk.getInstance(
+    instanceYaml.org,
+    instanceYaml.stage,
+    instanceYaml.app,
+    instanceYaml.name
+  )
+
+  instance = instance.instance // eslint-disable-line
+
+  // Throw a helpful error if the instance was not deployed
+  if (!instance) {
+    throw new Error(
+      `Instance "${instanceYaml.name}" is not active. Please deploy the instance first, then run "serverless info" again.`
+    )
+  }
+
+  // format last action for better UX
+  const lastActionAgo = moment(instance.lastActionAt).fromNow()
+
+  // show the most important information, and link to the dashboard
+  cli.log(`${chalk.grey('Status:')}       ${instance.instanceStatus}`)
+  cli.log(`${chalk.grey('Last Action:')}  ${instance.lastAction} (${lastActionAgo})`)
+  cli.log(`${chalk.grey('Deployments:')}  ${instance.instanceMetrics.deployments}`)
+  // const dashboardUrl = utils.getInstanceDashboardUrl(instanceYaml)
+  // cli.log(`${chalk.grey('More Info:')}    ${dashboardUrl}`)
+
+  // show state only in debug mode
+  if (config.debug) {
+    cli.log()
+    cli.log(`${chalk.grey('State:')}`)
+    cli.log()
+    cli.logOutputs(instance.state)
+    cli.log()
+    cli.log(`${chalk.grey('Outputs:')}`)
+  }
+
+  cli.log()
+  cli.logOutputs(instance.outputs)
+
+  cli.close('success', 'Info successfully loaded')
+}

--- a/src/cli/commands-cn/registry.js
+++ b/src/cli/commands-cn/registry.js
@@ -1,0 +1,132 @@
+/*
+ * CLI: Command: Registry
+ */
+
+const { ServerlessSDK } = require('@serverless/tencent-platform-client')
+const utils = require('./utils')
+const { loadComponentConfig } = require('../utils')
+
+/**
+ * Publish a Component to the Serverless Registry
+ * @param {*} config
+ * @param {*} cli
+ */
+const publish = async (config, cli) => {
+  // Disable timer
+  config.timer = false
+
+  // Start CLI persistance status
+  cli.start('Initializing')
+
+  await utils.login()
+
+  // Load YAML
+  const componentYaml = await loadComponentConfig(process.cwd())
+
+  // Presentation
+  cli.logRegistryLogo()
+  cli.log(
+    `Publishing "${componentYaml.name}@${config.dev ? 'dev' : componentYaml.version}"...`,
+    'grey'
+  )
+
+  const sdk = new ServerlessSDK()
+
+  // If "--dev" flag is used, set the version the API expects
+  if (config.dev) {
+    componentYaml.version = '0.0.0-dev'
+  }
+
+  // Publish
+  cli.status('Publishing')
+
+  let component
+  try {
+    component = await sdk.publishComponent(componentYaml)
+  } catch (error) {
+    if (error.message.includes('409')) {
+      error.message = error.message.replace('409 - ', '')
+      cli.error(error.message, true)
+    } else {
+      throw error
+    }
+  }
+
+  if (component.component && component.component.version === '0.0.0-dev') {
+    component.component.version = 'dev'
+  }
+
+  cli.close(
+    'success',
+    `Successfully published ${component.component.componentName}@${component.component.version}`
+  )
+}
+
+/**
+ * Get a Component from the Serverless Registry
+ * @param {*} config
+ * @param {*} cli
+ */
+const getComponent = async (config, cli) => {
+  const componentName = config.params[0]
+
+  // Start CLI persistance status
+  cli.start(`Fetching versions for: ${componentName}`)
+
+  const sdk = new ServerlessSDK()
+  const data = await sdk.getComponent(componentName)
+
+  if (!data.component) {
+    cli.error(`Component "${componentName}" not found in the Serverless Registry.`, true)
+  }
+
+  const devVersion = data.versions.indexOf('0.0.0-dev')
+  if (devVersion !== -1) {
+    data.versions.splice(devVersion, 1)
+  }
+
+  cli.logRegistryLogo()
+  cli.log()
+  cli.log(`Component: ${componentName}`)
+  cli.log(`Description: ${data.component.description}`)
+  cli.log(`Latest Version: ${data.component.version}`)
+  cli.log(`Author: ${data.component.author}`)
+  cli.log(`Repo: ${data.component.repo}`)
+  cli.log()
+  cli.log(`Available Versions:`)
+  cli.log(`${data.versions.join(', ')}`)
+
+  cli.close('success', `Component information listed for "${componentName}"`)
+}
+
+/**
+ * List Featured
+ * @param {*} config
+ * @param {*} cli
+ */
+const listFeatured = async (config, cli) => {
+  cli.logRegistryLogo()
+  cli.log()
+
+  cli.log(`Featured Components:`)
+  cli.log()
+  cli.log(`  express - https://github.com/serverless-components/tencent-express/tree/v2`)
+  cli.log(`  website - https://github.com/serverless-components/tencent-website/tree/v2`)
+  cli.log(`  scf - https://github.com/serverless-components/tencent-scf/tree/v2`)
+  cli.log()
+  cli.log(`Find more here: https://github.com/serverless-components`)
+  cli.log()
+}
+
+/**
+ * Route Registry Command
+ */
+module.exports = async (config, cli) => {
+  if (!config.params[0]) {
+    return await listFeatured(config, cli)
+  }
+  if (config.params[0] === 'publish') {
+    return await publish(config, cli)
+  }
+  return await getComponent(config, cli)
+}

--- a/src/cli/commands-cn/run.js
+++ b/src/cli/commands-cn/run.js
@@ -1,0 +1,82 @@
+/*
+ * CLI: Command: RUN
+ */
+
+const path = require('path')
+const { ServerlessSDK } = require('@serverless/tencent-platform-client')
+const utils = require('./utils')
+
+module.exports = async (config, cli, command) => {
+  // Start CLI persistance status
+  cli.start('Initializing', { timer: true })
+
+  await utils.login()
+
+  // Load YAML
+  let instanceDir = process.cwd()
+  if (config.target) {
+    instanceDir = path.join(instanceDir, config.target)
+  }
+  const instanceYaml = await utils.loadInstanceConfig(instanceDir)
+
+  // Presentation
+  const meta = `Action: "${command}" - Stage: "${instanceYaml.stage}" - App: "${instanceYaml.app}" - Instance: "${instanceYaml.name}"`
+  if (!config.debug) {
+    cli.logLogo()
+    cli.log(meta, 'grey')
+  } else {
+    cli.log(meta)
+  }
+
+  cli.status('Initializing', instanceYaml.name)
+
+  // Load Instance Credentials
+  const instanceCredentials = await utils.loadInstanceCredentials(instanceYaml.stage)
+
+  // initialize SDK
+  const sdk = new ServerlessSDK({
+    context: {
+      orgName: instanceYaml.org
+    }
+  })
+
+  // Prepare Options
+  const options = {}
+  options.debug = config.debug
+  options.dev = config.dev
+
+  // Connect to Serverless Platform Events, if in debug mode
+  if (options.debug) {
+    // TODO: to be implement for tencent
+    delete options.debug
+  }
+
+  if (command === 'deploy') {
+    // Warn about dev agent
+    if (options.dev) {
+      cli.log()
+      cli.log(
+        '"--dev" option detected.  Dev Agent will be added to your code.  Do not deploy this in your production stage.',
+        'grey'
+      )
+    }
+
+    // run deploy
+    cli.status('Deploying', null, 'white')
+    const instance = await sdk.deploy(instanceYaml, instanceCredentials, options)
+    cli.log()
+    cli.logOutputs(instance.outputs)
+    cli.log()
+    // const dashboardUrl = utils.getInstanceDashboardUrl(instanceYaml)
+    // cli.log(`${chalk.grey(`Full details: ${dashboardUrl}`)}`)
+  } else if (command === 'remove') {
+    // run remove
+    cli.status('Removing', null, 'white')
+    await sdk.remove(instanceYaml, instanceCredentials, options)
+  } else {
+    // run a custom method
+    cli.status('Running', null, 'white')
+    await sdk.run(command, instanceYaml, instanceCredentials, options)
+  }
+  cli.close('success', 'Success')
+}

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -1,0 +1,162 @@
+/*
+ * Serverless Components: Utilities
+ */
+
+const path = require('path')
+const fs = require('fs')
+const args = require('minimist')(process.argv.slice(2))
+const { utils: platformUtils } = require('@serverless/tencent-platform-client')
+const { loadInstanceConfig, resolveInputVariables } = require('../utils')
+
+const updateEnvFile = (envs) => {
+  // write env file
+  const envFilePath = path.join(process.cwd(), '.env')
+
+  let envFileContent = ''
+  if (fs.existsSync(envFilePath)) {
+    envFileContent = fs.readFileSync(envFilePath, 'utf8')
+  }
+
+  // update process.env and existing key in .env file
+  for (let [key, value] of Object.entries(envs)) {
+    process.env[key] = value
+    const regex = new RegExp(`${key}=[^\n]+(\n|$)`)
+    envFileContent = envFileContent.replace(regex, '')
+  }
+
+  fs.writeFileSync(
+    envFilePath,
+    `${envFileContent}\n${Object.entries(envs).reduce(
+      (a, [key, value]) => (a += `${key}=${value}\n`),
+      ''
+    )}`
+  )
+}
+
+const getDefaultOrgName = async () => {
+  return await platformUtils.getOrgId()
+}
+
+/**
+ * Reads a serverless instance config file in a given directory path
+ * @param {*} directoryPath
+ */
+const loadTencentInstanceConfig = async (directoryPath) => {
+  const instanceFile = loadInstanceConfig(directoryPath)
+
+  if (!instanceFile) {
+    throw new Error(`serverless config file was not found`)
+  }
+
+  if (!instanceFile.name) {
+    throw new Error(`Missing "name" property in serverless.yml`)
+  }
+
+  if (!instanceFile.component) {
+    throw new Error(`Missing "component" property in serverless.yml`)
+  }
+
+  // if stage flag provided, overwrite
+  if (args.stage) {
+    instanceFile.stage = args.stage
+  }
+
+  // if org flag provided, overwrite
+  if (args.org) {
+    instanceFile.org = args.org
+  }
+
+  if (!instanceFile.org) {
+    instanceFile.org = await getDefaultOrgName()
+  }
+
+  if (!instanceFile.org) {
+    throw new Error(`Missing "org" property in serverless.yml`)
+  }
+
+  // if app flag provided, overwrite
+  if (args.app) {
+    instanceFile.app = args.app
+  }
+
+  if (!instanceFile.app) {
+    instanceFile.app = instanceFile.name
+  }
+
+  if (instanceFile.inputs) {
+    // load credentials to process .env files before resolving env variables
+    await loadInstanceCredentials(instanceFile.stage)
+    instanceFile.inputs = resolveInputVariables(instanceFile.inputs)
+    if (instanceFile.inputs.src) {
+      if (typeof instanceFile.inputs.src === 'string') {
+        instanceFile.inputs.src = path.resolve(directoryPath, instanceFile.inputs.src)
+      } else if (typeof instanceFile.inputs.src === 'object' && instanceFile.inputs.src.src) {
+        instanceFile.inputs.src.src = path.resolve(directoryPath, instanceFile.inputs.src.src)
+      }
+    }
+  }
+
+  return instanceFile
+}
+
+/**
+ * Gets the logged in user's token id, or access key if its in env
+ */
+const login = async () => {
+  const [reLoggedIn, credentials] = await platformUtils.loginWithTencent()
+  if (reLoggedIn) {
+    const { secret_id, secret_key, appid, token } = credentials
+    updateEnvFile({
+      TENCENT_APP_ID: appid,
+      TENCENT_SECRET_ID: secret_id,
+      TENCENT_SECRET_KEY: secret_key,
+      TENCENT_TOKEN: token
+    })
+  }
+}
+
+/**
+ * Load credentials from a ".env" or ".env.[stage]" file
+ * @param {*} stage
+ */
+const loadInstanceCredentials = (stage) => {
+  // Load env vars TODO
+  const envVars = {}
+
+  // Known Provider Environment Variables and their SDK configuration properties
+  const providers = {}
+
+  // Tencent
+  providers.tencent = {}
+  providers.tencent.TENCENT_APP_ID = 'AppId'
+  providers.tencent.TENCENT_SECRET_ID = 'SecretId'
+  providers.tencent.TENCENT_SECRET_KEY = 'SecretKey'
+  providers.tencent.TENCENT_TOKEN = 'Token'
+
+  const credentials = {}
+
+  for (const provider in providers) {
+    const providerEnvVars = providers[provider]
+    for (const providerEnvVar in providerEnvVars) {
+      if (!credentials[provider]) {
+        credentials[provider] = {}
+      }
+      // Proper environment variables override what's in the .env file
+      if (process.env.hasOwnProperty(providerEnvVar)) {
+        credentials[provider][providerEnvVars[providerEnvVar]] = process.env[providerEnvVar]
+      } else if (envVars.hasOwnProperty(providerEnvVar)) {
+        credentials[provider][providerEnvVars[providerEnvVar]] = envVars[providerEnvVar]
+      }
+      continue
+    }
+  }
+
+  return credentials
+}
+
+module.exports = {
+  loadInstanceConfig: loadTencentInstanceConfig,
+  loadInstanceCredentials,
+  login,
+  getDefaultOrgName
+}

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -65,12 +65,6 @@ const loadInstanceCredentials = () => {
   providers.google.GOOGLE_CLIENT_EMAIL = 'clientEmail'
   providers.google.GOOGLE_PRIVATE_KEY = 'privateKey'
 
-  // Tencent
-  providers.tencent = {}
-  providers.tencent.TENCENT_APP_ID = 'AppId'
-  providers.tencent.TENCENT_SECRET_ID = 'SecretId'
-  providers.tencent.TENCENT_SECRET_KEY = 'SecretKey'
-
   // Docker
   providers.docker = {}
   providers.docker.DOCKER_USERNAME = 'username'

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -18,8 +18,15 @@ if (stage && fileExistsSync(stageEnvFilePath)) {
   dotenv.config({ path: path.resolve(defaultEnvFilePath) })
 }
 
+const { utils: platformUtils } = require('@serverless/tencent-platform-client')
 const CLI = require('./CLI')
-const commands = require('./commands')
+
+let commands
+if (platformUtils.isChinaUser()) {
+  commands = require('./commands-cn')
+} else {
+  commands = require('./commands')
+}
 
 module.exports = async () => {
   const command = args._[0] || 'deploy'

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -405,15 +405,6 @@ const legacyLoadComponentConfig = (directoryPath) => {
   return componentFile
 }
 
-const IS_IN_CHINA = (() => {
-  if (process.env.SLS_GEO_LOCATION === 'cn') {
-    return true
-  }
-  return new Intl.DateTimeFormat('en', { timeZoneName: 'long' })
-    .format()
-    .includes('China Standard Time')
-})()
-
 module.exports = {
   sleep,
   request,
@@ -428,6 +419,5 @@ module.exports = {
   getInstanceDashboardUrl,
   loadInstanceConfig,
   legacyLoadComponentConfig,
-  legacyLoadInstanceConfig,
-  IS_IN_CHINA
+  legacyLoadInstanceConfig
 }


### PR DESCRIPTION
## What has been implemented?

Add commands to support Tencent/Chinese users. It includes:

- add reference of `@serverless/tencent-platform-client`
- update IS_IN_CHINA flag, so if the user manually set `process.env.SERVERLESS_PLATFORM_VENDOR === 'aws'` we won't treat them as China user, or if the user manually set `process.env.SERVERLESS_PLATFORM_VENDOR === 'tencent'` we'll treat them as China user regardless the zimezone
- based on IS_IN_CHINA flag, dynamically require different command set
- add command sets for China/Tencent user
