### PR TITLE
fix: respect global proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "fs-extra": "^7.0.1",
+    "global-agent": "^2.1.8",
     "global-tunnel-ng": "^2.7.1",
     "js-yaml": "^3.13.1",
     "package-json": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "fs-extra": "^7.0.1",
+    "global-tunnel-ng": "^2.7.1",
     "js-yaml": "^3.13.1",
     "package-json": "^6.3.0",
     "ramda": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "js-yaml": "^3.13.1",
     "package-json": "^6.3.0",
     "ramda": "^0.26.1",
+    "registry-url": "^5.1.0",
     "semver": "^6.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Sometimes, users can not access to `https://registry.npmjs.org` directly, so they add global proxies for it. But  `got` lib (`package-json` depends on it) don't respect it, so they will get a `ECONNREFUSED` error. Refer to this issue https://github.com/sindresorhus/got/issues/560, so we need [global-tunnel-ng](https://github.com/np-maintain/global-tunnel).