### PR TITLE
Fix IS_IN_CHINA resolution

### DIFF
--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -347,10 +347,14 @@ const legacyLoadComponentConfig = (directoryPath) => {
   return componentFile
 }
 
-// Same as internal Tencent check:
-// https://github.com/serverless-tencent/serverless-tencent-tools/blob/3c1cabbdb21c0b3ba37248b9c2f609ec552bf8fc/sdk/others/isInChina.js#L12
-const IS_IN_CHINA =
-  new Date().getTimezoneOffset() == -480 || String(process.env.LC_CTYPE).includes('zh_CN')
+const IS_IN_CHINA = (() => {
+  if (process.env.SLS_GEO_LOCATION === 'cn') {
+    return true
+  }
+  return new Intl.DateTimeFormat('en', { timeZoneName: 'long' })
+    .format()
+    .includes('China Standard Time')
+})()
 
 module.exports = {
   sleep,


### PR DESCRIPTION
Base strictly on Timezone name, as timezone difference collides with other regions (as e.g. Western Australia) . This follows same check as introduced in a framework here: https://github.com/serverless/serverless/pull/7521

I've introduced also support for `SLS_GEO_LOCATION` through which we can force chinese behavior locally.
