### PR TITLE
Fix files being omitted

### DIFF
--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -208,7 +208,7 @@ const pack = async (inputDirPath, outputFilePath, include = [], exclude = []) =>
     throw new Error('Please provide a valid format. Either a "zip" or a "tar"')
   }
 
-  const patterns = ['**']
+  const patterns = ['**/*']
 
   if (!isNil(exclude)) {
     exclude.forEach((excludedItem) => patterns.push(`!${excludedItem}`))


### PR DESCRIPTION
This is the [updated version of this PR](https://github.com/serverless-components/aws-lambda/pull/26), to work with the new GA components.

The glob `'**'` would not match files such as `[...file].js`. This is critical for the NextJS component to utilize a catch-all API route, and breaks all deployments that try to use them.

Included files before PR:

```
.file.js
[file].js
file.js
```

Included files after PR:

```
.file.js
[...file].js
[file].js
file.js
```