### PR TITLE
Fix process.env resolution

### DIFF
--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -2,8 +2,6 @@
  * Serverless Components: Utilities
  */
 
-const path = require('path')
-const dotenv = require('dotenv')
 const args = require('minimist')(process.argv.slice(2))
 const {
   readConfigFile,
@@ -12,7 +10,7 @@ const {
   refreshToken,
   listTenants
 } = require('@serverless/platform-sdk')
-const { fileExistsSync, loadInstanceConfig, resolveInputVariables } = require('../utils')
+const { loadInstanceConfig, resolveInputVariables } = require('../utils')
 
 const getDefaultOrgName = async () => {
   const res = readConfigFile()
@@ -50,19 +48,7 @@ const getDefaultOrgName = async () => {
  * Load credentials from a ".env" or ".env.[stage]" file
  * @param {*} stage
  */
-const loadInstanceCredentials = (stage) => {
-  // Load env vars
-  let envVars = {}
-  const defaultEnvFilePath = path.join(process.cwd(), `.env`)
-  const stageEnvFilePath = path.join(process.cwd(), `.env.${stage}`)
-
-  // Load environment variables via .env file
-  if (stage && fileExistsSync(stageEnvFilePath)) {
-    envVars = dotenv.config({ path: path.resolve(stageEnvFilePath) }).parsed || {}
-  } else if (fileExistsSync(defaultEnvFilePath)) {
-    envVars = dotenv.config({ path: path.resolve(defaultEnvFilePath) }).parsed || {}
-  }
-
+const loadInstanceCredentials = () => {
   // Known Provider Environment Variables and their SDK configuration properties
   const providers = {}
 
@@ -101,8 +87,6 @@ const loadInstanceCredentials = (stage) => {
       // Proper environment variables override what's in the .env file
       if (process.env.hasOwnProperty(providerEnvVar)) {
         credentials[provider][providerEnvVars[providerEnvVar]] = process.env[providerEnvVar]
-      } else if (envVars.hasOwnProperty(providerEnvVar)) {
-        credentials[provider][providerEnvVars[providerEnvVar]] = envVars[providerEnvVar]
       }
       continue
     }
@@ -115,7 +99,7 @@ const loadInstanceCredentials = (stage) => {
  * Reads a serverless instance config file in a given directory path
  * @param {*} directoryPath
  */
-const loadAwsInstanceConfig = async (directoryPath) => {
+const loadVendorInstanceConfig = async (directoryPath) => {
   const instanceFile = loadInstanceConfig(directoryPath)
 
   if (!instanceFile) {
@@ -241,7 +225,7 @@ const getOrCreateAccessKey = async (org) => {
 }
 
 module.exports = {
-  loadInstanceConfig: loadAwsInstanceConfig,
+  loadInstanceConfig: loadVendorInstanceConfig,
   loadInstanceCredentials,
   getOrCreateAccessKey,
   getAccessKey,

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -175,13 +175,13 @@ const loadInstanceConfig = async (directoryPath) => {
     instanceFile.stage = args.stage
   }
 
-  if (!instanceFile.org) {
-    instanceFile.org = await getDefaultOrgName()
-  }
-
   // if org flag provided, overwrite
   if (args.org) {
     instanceFile.org = args.org
+  }
+
+  if (!instanceFile.org) {
+    instanceFile.org = await getDefaultOrgName()
   }
 
   if (!instanceFile.org) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -2,7 +2,22 @@
  * Serverless Components: CLI Handler
  */
 
+const path = require('path')
 const args = require('minimist')(process.argv.slice(2))
+const { loadInstanceConfig, fileExistsSync } = require('./utils')
+const instanceConfig = loadInstanceConfig(process.cwd())
+const stage = args.stage || (instanceConfig && instanceConfig.stage) || 'dev'
+
+// Load environment variables from eventual .env files
+const dotenv = require('dotenv')
+const defaultEnvFilePath = path.join(process.cwd(), `.env`)
+const stageEnvFilePath = path.join(process.cwd(), `.env.${stage}`)
+if (stage && fileExistsSync(stageEnvFilePath)) {
+  dotenv.config({ path: path.resolve(stageEnvFilePath) })
+} else if (fileExistsSync(defaultEnvFilePath)) {
+  dotenv.config({ path: path.resolve(defaultEnvFilePath) })
+}
+
 const CLI = require('./CLI')
 const commands = require('./commands')
 

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -2,7 +2,7 @@
  * Serverless Components: Utilities
  */
 
-const { contains, isNil, last, split, merge, endsWith } = require('ramda')
+const { contains, isNil, last, split, merge, endsWith, memoizeWith, identity } = require('ramda')
 const path = require('path')
 const axios = require('axios')
 const globby = require('globby')
@@ -254,7 +254,7 @@ const getInstanceDashboardUrl = (instanceYaml) => {
  * Reads a serverless instance config file in a given directory path
  * @param {*} directoryPath
  */
-const loadInstanceConfig = (directoryPath) => {
+const loadInstanceConfig = memoizeWith(identity, (directoryPath) => {
   directoryPath = path.resolve(directoryPath)
   const ymlFilePath = path.join(directoryPath, `serverless.yml`)
   const yamlFilePath = path.join(directoryPath, `serverless.yaml`)
@@ -306,7 +306,7 @@ const loadInstanceConfig = (directoryPath) => {
   }
 
   return instanceFile
-}
+})
 
 /**
  * THIS IS USED BY SFV1.  DO NOT MODIFY OR DELETE


### PR DESCRIPTION
When working on Tencent commands, we've approached some issues, and after investigation it appeared that it's caused by fact of environment variables not being resolved from `.env` files


Ideally `.env` files should be resolved at earliest stage of a program, and further logic should simply refer to `process.env` for environment variables values.

This PR ensures it's the case.

As there's no test suite, I've tested manually by running few component commands. All worked without issues.