### PR TITLE
Change README environment var references

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ stage: prod
 
 inputs:
   name: ${org}-${stage}-${app}-${name} # Results in "acme-prod-ecommerce-rest-api"
-  region: ${env:REGION} # Results in whatever your environment variable REGION= is set to.
+  region: ${env.REGION} # Results in whatever your environment variable REGION= is set to.
   roleArn: ${output:prod:my-app:role.arn} # Fetches an output from another component instance that is already deployed
   roleArn: ${output:${stage}:${app}:role.arn} # You can combine variables too
 ```
@@ -501,7 +501,7 @@ inputs:
 
 You can reference Environment Variables (e.g. those that you defined in the `.env` file or that you've set in your environment manually) directly in `serverless.yml` by using the `${env}` Variable.
 
-For example, if you want to reference the `REGION` environment variable, you could do that with `${env:REGION}`.
+For example, if you want to reference the `REGION` environment variable, you could do that with `${env.REGION}`.
 
 ```yml
 component: express
@@ -511,7 +511,7 @@ name: rest-api
 stage: prod
 
 inputs:
-  region: ${env:REGION}
+  region: ${env.REGION}
 ```
 
 #### Variables: Outputs


### PR DESCRIPTION
## What has been implemented?

Potentially addresses #580. (I am not sure if `env.` is the desired behavior, but this change seems small enough it made sense to just submit a fix for the documentation directly; if you prefer to change the behavior, ignore this.)

## Steps to verify

* This is just a documentation change. You can attempt to deploy an app using `{env:FOO}` in the configuration file to verify that the syntax does not work, while `{env.FOO}` does work (at least with serverless 1.67.1).

## Todos:

* [ X ] Write / update documentation

