### PR TITLE
ensure serverless.yml inputs are for "deploy" only

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -105,12 +105,18 @@ module.exports = async (config, cli, command) => {
     // cli.log()
     // cli.log(`${chalk.grey(`Full details: ${dashboardUrl}`)}`)
   } else if (command === 'remove') {
-    // run remove
     cli.status('Removing', null, 'white')
+
+    // The "inputs" in serverless.yml are only for deploy.  Remove them for all other commands
+    instanceYaml.inputs = {}
+
     await sdk.remove(instanceYaml, instanceCredentials, options)
   } else {
     // run a custom method synchronously to receive outputs directly
     options.sync = true
+
+    // The "inputs" in serverless.yml are only for deploy.  Remove them for all other commands
+    instanceYaml.inputs = {}
 
     cli.status('Running', null, 'white')
     const instance = await sdk.run(command, instanceYaml, instanceCredentials, options)


### PR DESCRIPTION
## What has been implemented?

`serverless.yml` `inputs` property was only meant for the `deploy` action, not `remove` or any custom actions.  `inputs` actions other than deploy need to be handled separately, via a method we have not yet considered.

This fixes the first problem and prevents `inputs` from being automatically submit for custom actions and especially `remove` actions, which users currently use more within the CLI.

cc @hkbarton
