### PR TITLE
fix: don't swallow exception of incorrect yaml format

### DIFF
--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -301,6 +301,8 @@ const loadInstanceConfig = memoizeWith(identity, (directoryPath) => {
       // because the framework can deal with that
       if (e.name !== 'YAMLException') {
         throw e
+      } else {
+        throw new Error(`The serverless.yml file has icorrect format. Details: ${e.message}`)
       }
     }
   } else {


### PR DESCRIPTION
Fix the bug that we swallowed exception of parsing incorrect YAML format, and throw some other unrelated exception later down the logic.
