### PR TITLE
fix some drift between commands and commands-cn

### DIFF
--- a/src/cli/commands-cn/run.js
+++ b/src/cli/commands-cn/run.js
@@ -77,11 +77,24 @@ module.exports = async (config, cli, command) => {
   } else if (command === 'remove') {
     // run remove
     cli.status('Removing', null, 'white')
+
+    // The "inputs" in serverless.yml are only for deploy.  Remove them for all other commands
+    instanceYaml.inputs = {}
+
     await sdk.remove(instanceYaml, instanceCredentials, options)
   } else {
+    // run a custom method synchronously to receive outputs directly
+    options.sync = true
+
+    // The "inputs" in serverless.yml are only for deploy.  Remove them for all other commands
+    instanceYaml.inputs = {}
+
     // run a custom method
     cli.status('Running', null, 'white')
-    await sdk.run(command, instanceYaml, instanceCredentials, options)
+    const instance = await sdk.run(command, instanceYaml, instanceCredentials, options)
+
+    cli.log()
+    cli.logOutputs(instance.outputs)
   }
   cli.close('success', 'Success')
 }


### PR DESCRIPTION
fix some drift between commands and commands-cn:

1. only use inputs for `deploy` command
2. use sync for other commands and print outputs immediately 