### PR TITLE
fix: should allow reference variables in env file at app level

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@serverless/inquirer": "^1.1.0",
     "@serverless/platform-client": "^0.25.7",
-    "@serverless/platform-client-china": "^1.0.10",
+    "@serverless/platform-client-china": "^1.0.12",
     "@serverless/platform-sdk": "^2.3.0",
     "adm-zip": "^0.4.14",
     "ansi-escapes": "^4.3.1",

--- a/src/cli/commands-cn/run.js
+++ b/src/cli/commands-cn/run.js
@@ -52,12 +52,6 @@ module.exports = async (config, cli, command) => {
   options.debug = config.debug;
   options.dev = config.dev;
 
-  // Connect to Serverless Platform Events, if in debug mode
-  if (options.debug) {
-    // TODO: to be implement for tencent
-    delete options.debug;
-  }
-
   if (command === 'deploy') {
     // Warn about dev agent
     if (options.dev) {

--- a/src/cli/commands-cn/runAll.js
+++ b/src/cli/commands-cn/runAll.js
@@ -45,7 +45,7 @@ module.exports = async (config, cli, command) => {
 
   // TODO not support for tencent yet
   // Connect to Serverless Platform Events, if in debug mode
-  // options.debug = config.debug
+  options.debug = config.debug;
 
   if (command === 'remove') {
     cli.status('Removing', null, 'white');

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -8,7 +8,7 @@ const path = require('path');
 const fs = require('fs');
 const args = require('minimist')(process.argv.slice(2));
 const { utils: platformUtils } = require('@serverless/platform-client-china');
-const { loadInstanceConfig, resolveInputVariables } = require('../utils');
+const { loadInstanceConfig, resolveVariables } = require('../utils');
 
 const updateEnvFile = (envs) => {
   // write env file
@@ -44,7 +44,7 @@ const getDefaultOrgName = async () => {
  * @param {*} directoryPath
  */
 const loadTencentInstanceConfig = async (directoryPath) => {
-  const instanceFile = loadInstanceConfig(directoryPath);
+  let instanceFile = loadInstanceConfig(directoryPath);
 
   if (!instanceFile) {
     throw new Error('serverless config file was not found');
@@ -88,7 +88,7 @@ const loadTencentInstanceConfig = async (directoryPath) => {
   if (instanceFile.inputs) {
     // load credentials to process .env files before resolving env variables
     await loadInstanceCredentials(instanceFile.stage);
-    instanceFile.inputs = resolveInputVariables(instanceFile.inputs);
+    instanceFile = resolveVariables(instanceFile);
     if (instanceFile.inputs.src) {
       if (typeof instanceFile.inputs.src === 'string') {
         instanceFile.inputs.src = path.resolve(directoryPath, instanceFile.inputs.src);

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -20,7 +20,7 @@ const { join, basename } = require('path');
 
 const { readFileSync } = require('fs');
 const ini = require('ini');
-const { fileExistsSync, loadInstanceConfig, resolveInputVariables } = require('../utils');
+const { fileExistsSync, loadInstanceConfig, resolveVariables } = require('../utils');
 
 const getDefaultOrgName = async () => {
   const res = readConfigFile();
@@ -158,7 +158,7 @@ const loadInstanceCredentials = () => {
  * @param {*} directoryPath
  */
 const loadVendorInstanceConfig = async (directoryPath) => {
-  const instanceFile = loadInstanceConfig(directoryPath);
+  let instanceFile = loadInstanceConfig(directoryPath);
 
   if (!instanceFile) {
     throw new Error('serverless config file was not found');
@@ -198,7 +198,7 @@ const loadVendorInstanceConfig = async (directoryPath) => {
   if (instanceFile.inputs) {
     // load credentials to process .env files before resolving env variables
     await loadInstanceCredentials(instanceFile.stage);
-    instanceFile.inputs = resolveInputVariables(instanceFile.inputs);
+    instanceFile = resolveVariables(instanceFile);
 
     if (instanceFile.inputs.src) {
       if (typeof instanceFile.inputs.src === 'object') {

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -127,7 +127,7 @@ const readFileSync = (filePath, options = {}) => {
  * This currently supports only ${env}.  All others should be resolved within the deployment engine.
  * @param {*} inputs
  */
-const resolveInputVariables = (inputs) => {
+const resolveVariables = (inputs) => {
   const regex = /\${(\w*:?[\w\d.-]+)}/g;
   let variableResolved = false;
   const resolvedInputs = traverse(inputs).forEach(function (value) {
@@ -151,7 +151,7 @@ const resolveInputVariables = (inputs) => {
     }
   });
   if (variableResolved) {
-    return resolveInputVariables(resolvedInputs);
+    return resolveVariables(resolvedInputs);
   }
   return resolvedInputs;
 };
@@ -633,7 +633,7 @@ module.exports = {
   isYamlPath,
   isJsonPath,
   loadComponentConfig,
-  resolveInputVariables,
+  resolveVariables,
   getDirSize,
   pack,
   getInstanceDashboardUrl,


### PR DESCRIPTION
## What has been implemented?

This change allows reference variables in `.env` at the top level of `serverless.yml`, before referencing variables is only allowed in the `inputs` section.

