### PR TITLE
Fix and improve multi component projects detection

### DIFF
--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -455,6 +455,7 @@ const isProjectPath = async (inputPath) => {
 const runningTemplate = (root) => {
   try {
     return fse.readdirSync(root).every((fileName) => {
+      if (fileName.startsWith('.')) return true;
       const filePath = path.join(root, fileName);
       if (!fse.statSync(filePath).isDirectory()) return true;
 

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -452,32 +452,17 @@ const isProjectPath = async (inputPath) => {
   return false;
 };
 
-const runningTemplate = (root) => {
-  const directories = fse
-    .readdirSync(root)
-    .filter((f) => fse.statSync(path.join(root, f)).isDirectory());
+const runningTemplate = (root) =>
+  fse.readdirSync(root).every((fileName) => {
+    const filePath = path.join(root, fileName);
+    if (!fse.statSync(filePath).isDirectory()) return true;
 
-  let isTemplateDirectory = true;
-
-  for (const directory of directories) {
-    const directoryPath = path.join(root, directory);
-
-    const instanceYml = loadInstanceConfig(directoryPath);
+    const instanceYml = loadInstanceConfig(filePath);
 
     // if no yaml file found, or not a component yaml file
     // then it's not a template directory
-    if (!instanceYml || !instanceYml.component) {
-      isTemplateDirectory = false;
-    }
-  }
-
-  // if cwd does not have subdirectories, then it's not a temlate directory
-  if (directories.length === 0) {
-    isTemplateDirectory = false;
-  }
-
-  return isTemplateDirectory;
-};
+    return instanceYml && instanceYml.component;
+  });
 
 const getOutputs = (allComponentsWithOutputs) => {
   const outputs = {};

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -452,17 +452,22 @@ const isProjectPath = async (inputPath) => {
   return false;
 };
 
-const runningTemplate = (root) =>
-  fse.readdirSync(root).every((fileName) => {
-    const filePath = path.join(root, fileName);
-    if (!fse.statSync(filePath).isDirectory()) return true;
+const runningTemplate = (root) => {
+  try {
+    return fse.readdirSync(root).every((fileName) => {
+      const filePath = path.join(root, fileName);
+      if (!fse.statSync(filePath).isDirectory()) return true;
 
-    const instanceYml = loadInstanceConfig(filePath);
+      const instanceYml = loadInstanceConfig(filePath);
 
-    // if no yaml file found, or not a component yaml file
-    // then it's not a template directory
-    return instanceYml && instanceYml.component;
-  });
+      // if no yaml file found, or not a component yaml file
+      // then it's not a template directory
+      return instanceYml && instanceYml.component;
+    });
+  } catch (error) {
+    return false;
+  }
+};
 
 const getOutputs = (allComponentsWithOutputs) => {
   const outputs = {};

--- a/src/legacy.js
+++ b/src/legacy.js
@@ -12,11 +12,6 @@ const runningComponents = () => {
   let componentConfig;
   let instanceConfig;
 
-  // load components if trying to login inside a template directory
-  if (utils.runningTemplate(process.cwd()) && process.argv[2] === 'login') {
-    return true;
-  }
-
   // load components if user runs "sls registry" or "sls --all" or "sls --target" (that last one for china)
   if (process.argv[2] === 'registry' || args.all || args.target) {
     return true;
@@ -34,6 +29,14 @@ const runningComponents = () => {
   }
 
   if (!componentConfig && !instanceConfig) {
+    // load components if trying to login inside a template directory
+    if (
+      process.argv.length === 3 &&
+      process.argv[2] === 'login' &&
+      utils.runningTemplate(process.cwd())
+    ) {
+      return true;
+    }
     // When no in service context and plain `serverless` command, return true when user in China
     // It's to enable interactive CLI components onboarding for Chinese users
     return process.argv.length === 2 && isChinaUser();


### PR DESCRIPTION
- Optimize templates resolution to stop investigation of further directories as soon as answer is known
- Ensure to ignore any crashes in components template resolution (Fixes #623)
- Ignore any dirs starting with `.git`, so far if multicomponent project was a git repository, check assumed it's not a multicomponents project
- Ensure to check for multicomponent project only in applicable scenarios (checking it upfront in all cases was not efficient).

Tested locally