### PR TITLE
Ignore watching the dist folder

### DIFF
--- a/src/cli/commands/dev.js
+++ b/src/cli/commands/dev.js
@@ -196,8 +196,17 @@ module.exports = async (config, cli) => {
   let isProcessing = false; // whether there's already a deployment in progress
   let queuedOperation = false; // whether there's another deployment queued
 
+  const ignored = [];
+
+  if (instanceYaml.inputs.src && instanceYaml.inputs.src.dist) {
+    // dont trigger a redeploy on dist changes
+    // the src changes is enough to trigger the
+    // build which updates dist
+    ignored.push(instanceYaml.inputs.src.dist);
+  }
+
   // Set watcher
-  const watcher = chokidar.watch(process.cwd(), { ignored: /\.serverless/ });
+  const watcher = chokidar.watch(process.cwd(), { ignored });
 
   watcher.on('ready', async () => {
     cli.status('Enabling Dev Mode', null, 'green');

--- a/src/cli/commands/dev.js
+++ b/src/cli/commands/dev.js
@@ -198,7 +198,7 @@ module.exports = async (config, cli) => {
 
   const ignored = [];
 
-  if (instanceYaml.inputs.src && instanceYaml.inputs.src.dist) {
+  if (instanceYaml.inputs && instanceYaml.inputs.src && instanceYaml.inputs.src.dist) {
     // dont trigger a redeploy on dist changes
     // the src changes is enough to trigger the
     // build which updates dist


### PR DESCRIPTION
When running in dev mode and a build is specified in the yaml file, changes trigger double deployments. The first is the actual change you made in `src` and the second is the `dist` change automatically made by the builder.

This PR ignores the specified dist because changes in src trigger a build & deployments.