### PR TITLE
Fix AWS default profile handling

### DIFF
--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -94,6 +94,8 @@ const loadAwsCredentials = () => {
   // get the credentials for that profile
   const credentials = parsedCredentialsFile[awsCredentialsProfile];
 
+  if (!credentials) return;
+
   // set the credentials in the env to pass it to the sdk
   process.env.AWS_ACCESS_KEY_ID = credentials.aws_access_key_id;
   process.env.AWS_SECRET_ACCESS_KEY = credentials.aws_secret_access_key;

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -99,8 +99,6 @@ const loadAwsCredentials = () => {
   // set the credentials in the env to pass it to the sdk
   process.env.AWS_ACCESS_KEY_ID = credentials.aws_access_key_id;
   process.env.AWS_SECRET_ACCESS_KEY = credentials.aws_secret_access_key;
-
-  return;
 };
 
 /**


### PR DESCRIPTION
I've tried a deployment on basic component service, and was faced with following error:

```
% sls --debug

Initializing...

 TypeError: Cannot read property 'aws_access_key_id' of undefined
    at loadAwsCredentials (/Users/medikoo/npm-packages/@serverless/components/src/cli/commands/utils.js:98:47)
    at loadInstanceCredentials (/Users/medikoo/npm-packages/@serverless/components/src/cli/commands/utils.js:111:3)
    at loadVendorInstanceConfig (/Users/medikoo/npm-packages/@serverless/components/src/cli/commands/utils.js:207:11)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at Object.module.exports [as run] (/Users/medikoo/npm-packages/@serverless/components/src/cli/commands/run.js:32:24)
    at Object.module.exports (/Users/medikoo/npm-packages/@serverless/components/src/cli/index.js:110:7)

0s › Serverless › Cannot read property 'aws_access_key_id' of undefined
```

As I checked issue is that `'default'` AWS profile is blindly assumed as configured.

This patch fixes that