### PR TITLE
Fix process exit logic

### DIFF
--- a/src/cli/CLI.js
+++ b/src/cli/CLI.js
@@ -67,7 +67,7 @@ class CLI {
     // Start counting seconds
     setInterval(() => {
       this._.timerSeconds = Math.floor((Date.now() - this._.timerStarted) / 1000);
-    }, 1000);
+    }, 1000).unref();
 
     // Set default close handler, if one was not provided
     if (!options.closeHandler) {
@@ -125,11 +125,8 @@ class CLI {
     process.stdout.write(ansiEscapes.cursorLeft);
     process.stdout.write(ansiEscapes.cursorShow);
 
-    if (reason === 'error') {
-      process.exit(1);
-    } else {
-      process.exit(0);
-    }
+    if (reason === 'error') process.exitCode = 1;
+    this._isClosed = true;
   }
 
   /**
@@ -340,6 +337,7 @@ class CLI {
    * Repetitively renders status and more on a regular interval
    */
   async _renderEngine() {
+    if (this._isClosed) return null;
     /**
      * Debug Mode
      */


### PR DESCRIPTION
Introducing hard `process.exit`'s does not allow background tasks to end normally, also may hide async setup issues (e.g. incorrectly setup orphaned async flows, or unhandled rejections).

Additionally it prevents to use project programmatically, as e.g. here: https://github.com/serverlessinc/platform-cn/blob/75836c9628d9b27d8a7ca9487100a31abf3407c8/sp-metrics/code/.scripts/deploy.js#L81 (`finally` has no chance for being executed).

(it was also reported for Components v1 at https://github.com/serverless/cli/issues/9 )

This patch ensures that CLI process ends naturally.