### PR TITLE
Support backend notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@serverless/platform-client": "^0.25.7",
     "@serverless/platform-client-china": "^1.0.12",
     "@serverless/platform-sdk": "^2.3.0",
+    "@serverless/utils": "^1.1.0",
     "adm-zip": "^0.4.14",
     "ansi-escapes": "^4.3.1",
     "axios": "^0.19.2",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -18,6 +18,9 @@ const https = require('https');
 const semver = require('semver');
 const chalk = require('chalk');
 const HttpsProxyAgent = require('https-proxy-agent');
+const processBackendNotificationRequest = require('@serverless/utils/process-backend-notification-request');
+const generateNotifiationsPayload = require('./notifications/generate-payload');
+const requestNotification = require('./notifications/request');
 
 module.exports = async () => {
   const args = minimist(process.argv.slice(2));
@@ -103,6 +106,13 @@ module.exports = async () => {
     return cli.logVersion();
   }
 
+  const deferredNotificationsData =
+    command === 'deploy'
+      ? requestNotification(
+          Object.assign(generateNotifiationsPayload(instanceConfig), { command: 'deploy' })
+        )
+      : null;
+
   try {
     if (commands[command]) {
       await commands[command](config, cli, command);
@@ -112,5 +122,18 @@ module.exports = async () => {
   } catch (e) {
     return cli.error(e);
   }
+
+  if (deferredNotificationsData) {
+    const notification = processBackendNotificationRequest(await deferredNotificationsData);
+    if (notification) {
+      const borderLength = notification.message.length;
+      cli.log(
+        `${'*'.repeat(borderLength)}\n${chalk.bold(notification.message)}\n${'*'.repeat(
+          borderLength
+        )}\n`
+      );
+    }
+  }
+
   return null;
 };

--- a/src/cli/notifications/generate-payload.js
+++ b/src/cli/notifications/generate-payload.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { version } = require('../../../package');
+
+module.exports = (instanceConfig) => {
+  return {
+    cliName: '@serverless/components',
+    config: {
+      component: instanceConfig.component,
+    },
+    versions: {
+      '@serverless/components': version,
+    },
+    isDashboardEnabled: Boolean(instanceConfig.org),
+  };
+};

--- a/src/cli/notifications/request.js
+++ b/src/cli/notifications/request.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const notificationsUrl = require('@serverless/utils/analytics-and-notfications-url');
+
+module.exports = async (payload) => {
+  if (!notificationsUrl) return null;
+
+  const http = notificationsUrl.startsWith('http:') ? require('http') : require('https');
+
+  const requestBody = JSON.stringify(payload);
+
+  return new Promise((resolve) => {
+    const request = http.request(
+      notificationsUrl,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': requestBody.length,
+        },
+      },
+      (response) => {
+        if (response.statusCode !== 200) {
+          // ignore errors
+          resolve(null);
+          return;
+        }
+        let responseBody = '';
+        response.on('data', (chunk) => (responseBody += chunk));
+        response.on('error', () => {
+          resolve(null);
+        });
+        response.on('end', () => {
+          resolve(
+            (() => {
+              try {
+                return JSON.parse(responseBody);
+              } catch (error) {
+                return null;
+              }
+            })()
+          );
+        });
+      }
+    );
+    request.on('error', () => {
+      resolve(null);
+    });
+
+    request.write(requestBody);
+    request.end();
+  });
+};


### PR DESCRIPTION
Brings support for backend notifications in Components v2 (as outlined in https://github.com/serverless/roadmap/issues/321)

- [x] ~Depends on https://github.com/serverless/utils/pull/53 which needs to be merged first and `@serverless/util` at `v1.0.0` needs to be published~