### PR TITLE
Fix handling of SIGINT signal

### DIFF
--- a/src/cli/CLI.js
+++ b/src/cli/CLI.js
@@ -79,7 +79,10 @@ class CLI {
     }
 
     // Set Event Handler: Control + C to cancel session
-    process.on('SIGINT', options.closeHandler);
+    process.on('SIGINT', () => {
+      options.closeHandler();
+      process.exit();
+    });
 
     if (status) {
       this.status(status);

--- a/src/cli/commands-cn/dev.js
+++ b/src/cli/commands-cn/dev.js
@@ -110,6 +110,7 @@ module.exports = async (config, cli) => {
     // Set new close listener
     process.on('SIGINT', () => {
       cli.close('error', 'Dev Mode Canceled.');
+      process.exit();
     });
 
     cli.status('Disabling Dev Mode & Closing', null, 'green');

--- a/src/cli/commands/dev.js
+++ b/src/cli/commands/dev.js
@@ -18,6 +18,7 @@ module.exports = async (config, cli) => {
     // Set new close listener
     process.on('SIGINT', () => {
       cli.close('error', 'Dev Mode Canceled.  Run "serverless deploy" To Remove Dev Mode Agent.');
+      process.exit();
     });
 
     sdk.disconnect();


### PR DESCRIPTION
With `SIGINT` case is that if there are no event handlers attached to it, Node.js by default exits process (as if `process.exit()` would be run in a middle of a logic).

If there are `SIGINT` event handlers attached, Node.js leaves exiting to us. In this scenario it seems right to invoke `process.exit()` in a handler, as it's the only way to stop e.g. stop ongoing HTTP requests (and we've received a clear intent from user to stop any ongoing operations).

~~I've also changed `.on` to `.once`, so if Ctrl-C press is doubled we do not produce duplicate close logs~~