### PR TITLE
Ensure to support async close handlers on SIGINT

### DIFF
--- a/src/cli/CLI.js
+++ b/src/cli/CLI.js
@@ -79,8 +79,8 @@ class CLI {
     }
 
     // Set Event Handler: Control + C to cancel session
-    process.on('SIGINT', () => {
-      options.closeHandler();
+    process.on('SIGINT', async () => {
+      await options.closeHandler();
       process.exit();
     });
 


### PR DESCRIPTION
/cc @hkbarton 

e.g. in `dev` mode we redeploy original version before we exit
