### PR TITLE
Ensure support for templates in notifications

### DIFF
--- a/src/cli/commands-cn/runAll.js
+++ b/src/cli/commands-cn/runAll.js
@@ -9,6 +9,9 @@ const {
   executeGraph,
 } = require('../utils');
 const { login, loadInstanceCredentials, getTemplate } = require('./utils');
+const generateNotificationsPayload = require('../notifications/generate-payload');
+const requestNotification = require('../notifications/request');
+const printNotification = require('../notifications/print-notification');
 
 module.exports = async (config, cli, command) => {
   cli.start('Initializing', { timer: true });
@@ -47,6 +50,13 @@ module.exports = async (config, cli, command) => {
   // Connect to Serverless Platform Events, if in debug mode
   options.debug = config.debug;
 
+  const deferredNotificationsData =
+    command === 'deploy'
+      ? requestNotification(
+          Object.assign(generateNotificationsPayload(templateYaml), { command: 'deploy' })
+        )
+      : null;
+
   if (command === 'remove') {
     cli.status('Removing', null, 'white');
   } else {
@@ -81,4 +91,5 @@ module.exports = async (config, cli, command) => {
   }
 
   cli.close('success', 'Success');
+  if (deferredNotificationsData) printNotification(cli, await deferredNotificationsData);
 };

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -12,6 +12,9 @@ const {
   loadInstanceCredentials,
 } = require('./utils');
 const runAll = require('./runAll');
+const generateNotificationsPayload = require('../notifications/generate-payload');
+const requestNotification = require('../notifications/request');
+const printNotification = require('../notifications/print-notification');
 
 module.exports = async (config, cli, command) => {
   if (config.all) {
@@ -90,7 +93,12 @@ module.exports = async (config, cli, command) => {
       });
     }
 
+    let deferredNotificationsData;
     if (command === 'deploy') {
+      deferredNotificationsData = requestNotification(
+        Object.assign(generateNotificationsPayload(instanceYaml), { command: 'deploy' })
+      );
+
       // Warn about dev agent
       if (options.dev) {
         cli.log();
@@ -131,6 +139,7 @@ module.exports = async (config, cli, command) => {
     }
 
     cli.close('success', 'Success');
+    if (deferredNotificationsData) printNotification(cli, await deferredNotificationsData);
   } finally {
     sdk.disconnect();
   }

--- a/src/cli/commands/runAll.js
+++ b/src/cli/commands/runAll.js
@@ -9,6 +9,9 @@ const {
   executeGraph,
 } = require('../utils');
 const { getAccessKey, isLoggedIn, loadInstanceCredentials, getTemplate } = require('./utils');
+const generateNotificationsPayload = require('../notifications/generate-payload');
+const requestNotification = require('../notifications/request');
+const printNotification = require('../notifications/print-notification');
 
 module.exports = async (config, cli, command) => {
   cli.start('Initializing', { timer: true });
@@ -85,6 +88,13 @@ module.exports = async (config, cli, command) => {
       });
     }
 
+    const deferredNotificationsData =
+      command === 'deploy'
+        ? requestNotification(
+            Object.assign(generateNotificationsPayload(templateYaml), { command: 'deploy' })
+          )
+        : null;
+
     if (command === 'remove') {
       cli.status('Removing', null, 'white');
     } else {
@@ -119,6 +129,7 @@ module.exports = async (config, cli, command) => {
     }
 
     cli.close('success', 'Success');
+    if (deferredNotificationsData) printNotification(cli, await deferredNotificationsData);
   } finally {
     sdk.disconnect();
   }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -18,9 +18,6 @@ const https = require('https');
 const semver = require('semver');
 const chalk = require('chalk');
 const HttpsProxyAgent = require('https-proxy-agent');
-const processBackendNotificationRequest = require('@serverless/utils/process-backend-notification-request');
-const generateNotifiationsPayload = require('./notifications/generate-payload');
-const requestNotification = require('./notifications/request');
 
 module.exports = async () => {
   const args = minimist(process.argv.slice(2));
@@ -106,13 +103,6 @@ module.exports = async () => {
     return cli.logVersion();
   }
 
-  const deferredNotificationsData =
-    command === 'deploy'
-      ? requestNotification(
-          Object.assign(generateNotifiationsPayload(instanceConfig), { command: 'deploy' })
-        )
-      : null;
-
   try {
     if (commands[command]) {
       await commands[command](config, cli, command);
@@ -121,18 +111,6 @@ module.exports = async () => {
     }
   } catch (e) {
     return cli.error(e);
-  }
-
-  if (deferredNotificationsData) {
-    const notification = processBackendNotificationRequest(await deferredNotificationsData);
-    if (notification) {
-      const borderLength = notification.message.length;
-      cli.log(
-        `${'*'.repeat(borderLength)}\n${chalk.bold(notification.message)}\n${'*'.repeat(
-          borderLength
-        )}\n`
-      );
-    }
   }
 
   return null;

--- a/src/cli/notifications/generate-payload.js
+++ b/src/cli/notifications/generate-payload.js
@@ -2,15 +2,25 @@
 
 const { version } = require('../../../package');
 
-module.exports = (instanceConfig) => {
+module.exports = (serviceConfig) => {
+  const config = {};
+
+  if (serviceConfig.component) {
+    config.component = serviceConfig.component;
+  } else {
+    config.components = [];
+    for (const componentConfig of Object.values(serviceConfig)) {
+      if (componentConfig.component) {
+        config.components.push({ component: componentConfig.component });
+      }
+    }
+  }
   return {
     cliName: '@serverless/components',
-    config: {
-      component: instanceConfig.component,
-    },
+    config,
     versions: {
       '@serverless/components': version,
     },
-    isDashboardEnabled: Boolean(instanceConfig.org),
+    isDashboardEnabled: Boolean(serviceConfig.org),
   };
 };

--- a/src/cli/notifications/print-notification.js
+++ b/src/cli/notifications/print-notification.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const chalk = require('chalk');
+const processBackendNotificationRequest = require('@serverless/utils/process-backend-notification-request');
+
+module.epxorts = async (cli, notifications) => {
+  const notification = processBackendNotificationRequest(notifications);
+  if (notification) {
+    const borderLength = Math.min(notification.message.length, process.stdout.columns) || 10;
+    cli.log(
+      `${'*'.repeat(borderLength)}\n${chalk.bold(notification.message)}\n${'*'.repeat(
+        borderLength
+      )}\n`
+    );
+  }
+};


### PR DESCRIPTION
Initial notifications payload generator didn't took into account case where deploy multiple components.

Deployment then was crashing with:

```
% sls deploy --all
(node:11248) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'component' of null
    at module.exports (/Users/medikoo/npm-packages/@serverless/components/src/cli/notifications/generate-payload.js:9:33)
    at Object.module.exports (/Users/medikoo/npm-packages/@serverless/components/src/cli/index.js:112:25)
    at Object.<anonymous> (/Users/medikoo/npm-packages/serverless/bin/serverless.js:35:18)
    at Module._compile (internal/modules/cjs/loader.js:1200:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
    at Module.load (internal/modules/cjs/loader.js:1049:32)
    at Function.Module._load (internal/modules/cjs/loader.js:937:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47
(Use `node --trace-warnings ...` to show where the warning was created)
(node:11248) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:11248) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

This PR fixes that