### PR TITLE
Support removal of serverless.yml file at top of template

### DIFF
--- a/src/cli/commands/init/index.js
+++ b/src/cli/commands/init/index.js
@@ -103,7 +103,7 @@ const run = async (cli, cliParam) => {
     cli.status('Setting up your new app');
     // Recursively unpack each directory in a template
     // Set org attr in sls.yml for each
-    await unpacker.unpack(servicePath);
+    await unpacker.unpack(servicePath, true);
   }
   return directory;
 };

--- a/src/cli/commands/init/unpacker.js
+++ b/src/cli/commands/init/unpacker.js
@@ -22,10 +22,10 @@ class Unpacker {
    * Recursive method
    * @param {*} dir
    */
-  async unpack(dir) {
+  async unpack(dir, isTopLevel = false) {
     // Check if the directory contains a serverless.yml/yaml/json/js.
     // If it does, we need to unpack it
-    if (getServerlessFilePath(dir)) {
+    if (getServerlessFilePath(dir) || isTopLevel) {
       this.cli.status(`Installing node_modules via npm in ${dir}`);
       if (await fs.exists(path.resolve(dir, 'package.json'))) {
         await spawn('npm', ['install'], { cwd: dir });
@@ -39,7 +39,7 @@ class Unpacker {
           // Check if the file is a directory, or a file
           const stats = await fs.stat(`${dir}/${file}`);
           if (stats.isDirectory()) {
-            return this.unpack(path.resolve(dir, file));
+            return this.unpack(path.resolve(dir, file), false);
           }
           return null;
         })


### PR DESCRIPTION
Modify recursive call to accept isTopLevel to ignore serverless.yml check before recursing

## What has been implemented?

Modifies recursive call to ignore a missing serverless.yml for the top-level use case.

## Steps to verify

- Run `sls init fullstack-app`
- note that node modules successfully installed
