### PR TITLE
Fix double-render errors by creating new CLIError class that renders …

### DIFF
--- a/src/cli/CLI.js
+++ b/src/cli/CLI.js
@@ -12,6 +12,7 @@ const figures = require('figures');
 const prettyoutput = require('prettyoutput');
 const chokidar = require('chokidar');
 const { version } = require('../../package.json');
+const { CLIError } = require('./errors');
 
 // CLI Colors
 const grey = chalk.dim;
@@ -262,7 +263,7 @@ class CLI {
     ad = ad + os.EOL + grey('  • State Storage, Output Sharing & Secrets');
     ad = ad + os.EOL + grey('  • And Much More: https://serverless.com/components');
     this.log(ad);
-    this.close('error', 'Please log in by running "serverless login"', true);
+    throw new CLIError('Please log in by running "serverless login"');
   }
 
   /**
@@ -313,7 +314,7 @@ class CLI {
     // Put cursor to starting position for next view
     process.stdout.write(ansiEscapes.cursorLeft);
 
-    return this.close('error', `${error.message}`);
+    return this.close('silent');
   }
 
   /**

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -10,6 +10,7 @@ const args = require('minimist')(process.argv.slice(2));
 const { utils: platformUtils } = require('@serverless/platform-client-china');
 const { loadInstanceConfig, resolveVariables } = require('../utils');
 const { mergeDeepRight } = require('ramda');
+const { CLIError } = require('../errors');
 
 const updateEnvFile = (envs) => {
   // write env file
@@ -48,15 +49,15 @@ const loadTencentInstanceConfig = async (directoryPath) => {
   let instanceFile = loadInstanceConfig(directoryPath);
 
   if (!instanceFile) {
-    throw new Error('serverless config file was not found');
+    throw new CLIError('serverless config file was not found');
   }
 
   if (!instanceFile.name) {
-    throw new Error('Missing "name" property in serverless.yml');
+    throw new CLIError('Missing "name" property in serverless.yml');
   }
 
   if (!instanceFile.component) {
-    throw new Error('Missing "component" property in serverless.yml');
+    throw new CLIError('Missing "component" property in serverless.yml');
   }
 
   // if stage flag provided, overwrite
@@ -74,7 +75,7 @@ const loadTencentInstanceConfig = async (directoryPath) => {
   }
 
   if (!instanceFile.org) {
-    throw new Error('Missing "org" property in serverless.yml');
+    throw new CLIError('Missing "org" property in serverless.yml');
   }
 
   // if app flag provided, overwrite

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -27,6 +27,8 @@ const {
   resolveVariables,
 } = require('../utils');
 
+const { CLIError } = require('../errors');
+
 const getDefaultOrgName = async () => {
   const res = readConfigFile();
 
@@ -168,15 +170,15 @@ const loadVendorInstanceConfig = async (directoryPath, options = { disableCache:
     : loadInstanceConfig(directoryPath);
 
   if (!instanceFile) {
-    throw new Error('serverless config file was not found');
+    throw new CLIError('serverless config file was not found');
   }
 
   if (!instanceFile.name) {
-    throw new Error('Missing "name" property in serverless.yml');
+    throw new CLIError('Missing "name" property in serverless.yml');
   }
 
   if (!instanceFile.component) {
-    throw new Error('Missing "component" property in serverless.yml');
+    throw new CLIError('Missing "component" property in serverless.yml');
   }
 
   // if stage flag provided, overwrite
@@ -194,7 +196,7 @@ const loadVendorInstanceConfig = async (directoryPath, options = { disableCache:
   }
 
   if (!instanceFile.org) {
-    throw new Error('Missing "org" property in serverless.yml');
+    throw new CLIError('Missing "org" property in serverless.yml');
   }
 
   // if app flag provided, overwrite

--- a/src/cli/errors.js
+++ b/src/cli/errors.js
@@ -1,0 +1,12 @@
+'use strict';
+
+class CLIError extends Error {
+  constructor(message) {
+    super(message);
+    this.hideStackTrace = true;
+  }
+}
+
+module.exports = {
+  CLIError,
+};

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -122,7 +122,7 @@ module.exports = async () => {
       await commands.run(config, cli, command);
     }
   } catch (e) {
-    return cli.error(e);
+    return cli.error(e, e.hideStackTrace || false);
   }
 
   return null;

--- a/src/cli/serverlessFile.js
+++ b/src/cli/serverlessFile.js
@@ -5,6 +5,7 @@ const yaml = require('js-yaml');
 
 const { writeFile } = require('fs-extra');
 const { fileExistsSync, readAndParseSync } = require('./utils');
+const { CLIError } = require('./errors');
 /**
  *
  * Checks if a filename ends with yaml or yml
@@ -85,7 +86,7 @@ const writeServerlessFile = async (cli, servicePath, ymlObject) => {
     try {
       await writeFile(serverlessFileName, yaml.safeDump(ymlObject));
     } catch (error) {
-      return cli.error(`Cannot write serverless.yml file in ${servicePath}`, true);
+      throw new CLIError(`Cannot write serverless.yml file in ${servicePath}`);
     }
   }
 };

--- a/src/cli/serverlessFile.js
+++ b/src/cli/serverlessFile.js
@@ -85,8 +85,7 @@ const writeServerlessFile = async (cli, servicePath, ymlObject) => {
     try {
       await writeFile(serverlessFileName, yaml.safeDump(ymlObject));
     } catch (error) {
-      cli.error(`Cannot write serverless.yml file in ${servicePath}`);
-      throw error;
+      return cli.error(`Cannot write serverless.yml file in ${servicePath}`, true);
     }
   }
 };


### PR DESCRIPTION
…a simple error.

## What has been implemented?

Fixes a bug where we'd double-render errors whenever we'd throw them. Also fixes a bug where `deploy` without being logged in will still run until it hits a 401.
BEFORE:
![image](https://user-images.githubusercontent.com/1598537/86299049-d92fe400-bbc4-11ea-9106-ba563325a730.png)

After:
![image](https://user-images.githubusercontent.com/1598537/86299083-ed73e100-bbc4-11ea-9caa-a1feea2b971e.png)


## Steps to verify

- Run X
- ...

## Todos:

- [ ] Write tests
- [ ] Write / update documentation
- [ ] Run Prettier
