### PR TITLE
Allow remove command for nested templates

### DIFF
--- a/src/legacy.js
+++ b/src/legacy.js
@@ -31,7 +31,10 @@ const runningComponents = () => {
   // load components if user runs a keyword command, or "sls --all" or "sls --target" (that last one for china)
   if (
     componentKeywords.has(process.argv[2]) ||
-    (process.argv[2] === 'deploy' && utils.runningTemplate(process.cwd())) ||
+    // only allow deploy & remove commands for nested templates
+    // to save up on extensive FS operations for all the other possible framework v1 commands
+    ((process.argv[2] === 'deploy' || process.argv[2] === 'remove') &&
+      utils.runningTemplate(process.cwd())) ||
     args.target
   ) {
     return true;


### PR DESCRIPTION
Previously I've only allowed the deploy command for nested templates, but that was short-sighted. We also need to allow for removal.

The purpose of this whole command restriction is to save up on extensive FS operation caused by checking the child directories on **every framework v1 command**, a valid concern raised by @medikoo 