### PR TITLE
Bump dep to v1.0.6 to redirect login to app.serverless.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "@serverless/inquirer": "^1.1.2",
-    "@serverless/platform-client": "^1.0.0",
+    "@serverless/platform-client": "^1.0.6",
     "@serverless/platform-client-china": "^1.0.18",
     "@serverless/platform-sdk": "^2.3.1",
     "@serverless/utils": "^1.1.0",


### PR DESCRIPTION
## What has been implemented?

Bumps platform-client so that `sls login` points to `app.serverless.com`
