### PR TITLE
Adds a simple help screen

### DIFF
--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/*
+ * CLI: Command: Help
+ */
+
+const chalk = require('chalk');
+const { version } = require('../../../package.json');
+
+const title = chalk.underline.bold;
+const command = chalk.dim.bold;
+
+module.exports = async (config, cli) => {
+  cli.logLogo();
+
+  cli.log(
+    `
+${command(
+  'serverless init {name}'
+)}      Initializes the specified package name or token in the current working directory
+
+${command(
+  'serverless {command}'
+)}        Runs the specified component command (deploy, remove...etc)
+${command('  --debug')}                   logs the running low-level debug statements
+${command('  --stage')}                   Overwrites the stage set in serverless.yml
+${command('  --app')}                     Overwrites the app set in serverless.yml
+${command('  --org')}                     Overwrites the org set in serverless.yml
+
+${command(
+  'serverless dev'
+)}              Watches, auto deploys and shows realtime logs of your deployed app
+${command('  --debug')}                   logs low-level debug statements during deployment
+
+${command('serverless info')}             Shows essential information about your deployed app
+${command(
+  '  --debug'
+)}                   Adds additional component state data for debugging purposes
+
+${command(
+  'serverless publish'
+)}          Publishes the package in the current working directory to the Serverless Registry
+${command('  --dev')}                     Overwrites the version property and set it to dev
+
+${command('serverless registry')}         Lists featured pacakges in the Serverless Registry
+
+${command(
+  'serverless registry {name}'
+)}  Fetches the given package name data from the Serverless Registry
+
+${command('serverless login')}            Logs into the Serverless Dashboard via the browser
+
+${command('serverless logout')}           Logs out the current user from the Serverless Dashboard
+
+${title('Version:')}          v${version}
+${title('Documentation:')}    https://github.com/serverless/components
+  `
+  );
+};

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -7,6 +7,7 @@ const info = require('./info');
 const dev = require('./dev');
 const registry = require('./registry');
 const init = require('./init');
+const help = require('./help');
 
 module.exports = {
   login,
@@ -16,4 +17,5 @@ module.exports = {
   dev,
   registry,
   init,
+  help,
 };

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -95,7 +95,7 @@ module.exports = async () => {
   /**
    * Running "serverless --help" is equivalent to "serverless help"
    */
-  if (args.help || args.h) {
+  if (args.help || args.h || args['help-components']) {
     command = 'help';
   }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -92,6 +92,13 @@ module.exports = async () => {
     args._[1] = 'publish';
   }
 
+  /**
+   * Running "serverless --help" is equivalent to "serverless help"
+   */
+  if (args.help || args.h) {
+    command = 'help';
+  }
+
   const params = [];
   if (args._[1]) {
     params.push(args._[1]);

--- a/src/legacy.js
+++ b/src/legacy.js
@@ -19,19 +19,6 @@ const componentKeywords = new Set(['registry', 'init', 'publish']);
 const runningComponents = () => {
   const args = minimist(process.argv.slice(2));
 
-  const isRunningHelpOrVersion =
-    process.argv[2] === 'version' ||
-    process.argv[2] === 'help' ||
-    args.v ||
-    args.version ||
-    args.h ||
-    args.help;
-
-  // don't load components CLI if running version or help
-  if (isRunningHelpOrVersion) {
-    return false;
-  }
-
   let componentConfig;
   let instanceConfig;
 

--- a/src/legacy.js
+++ b/src/legacy.js
@@ -29,7 +29,8 @@ const runningComponents = () => {
     // to save up on extensive FS operations for all the other possible framework v1 commands
     ((process.argv[2] === 'deploy' || process.argv[2] === 'remove') &&
       runningTemplate(process.cwd())) ||
-    args.target
+    args.target ||
+    args['help-components']
   ) {
     return true;
   }

--- a/src/legacy.js
+++ b/src/legacy.js
@@ -30,7 +30,7 @@ const runningComponents = () => {
     ((process.argv[2] === 'deploy' || process.argv[2] === 'remove') &&
       runningTemplate(process.cwd())) ||
     args.target ||
-    args['help-components']
+    args['help-components'] // if user runs "serverless --help-components" in ANY context, show components help
   ) {
     return true;
   }


### PR DESCRIPTION
If you run `serverless help` or `serverless --help` or `serverless -h` in a components context, you'll see the following:

<img width="926" alt="Screen Shot 2020-07-14 at 4 41 36 PM" src="https://user-images.githubusercontent.com/2312463/87432763-15b20580-c5f1-11ea-9a49-ba9f278b5983.png">
