### PR TITLE
Allow --dir and -d to specify destination directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,8 @@ Publish a Component to the Serverless Registry.
 
 Initializes the specified package (component or template) locally to get you started quickly.
 
+`--dir`, `-d` - Specify destination directory.
+
 #### `serverless deploy`
 
 Deploys an Instance of a Component.

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -18,6 +18,7 @@ module.exports = async (config, cli) => {
 ${command(
   'serverless init {name}'
 )}      Initializes the specified package name or token in the current working directory
+${command('  --dir, -d')}                 Specify destination directory
 
 ${command(
   'serverless {command}'

--- a/src/cli/commands/init/index.js
+++ b/src/cli/commands/init/index.js
@@ -19,7 +19,7 @@ const sdk = new ServerlessSDK({
  * @param {*} cli
  * @param {*} cliParams
  */
-const run = async (cli, cliParam) => {
+const run = async (cli, cliParam, customDir) => {
   cli.sessionStart('Fetching app configuration');
   let templateUrl;
   let directory;
@@ -59,6 +59,11 @@ const run = async (cli, cliParam) => {
     templateUrl = data.downloadUrl;
     type = data.type;
   }
+
+  if (customDir) {
+    directory = customDir;
+  }
+
   cli.sessionStatus('Unpacking your new app');
   // Create template directory
   try {
@@ -101,11 +106,12 @@ const run = async (cli, cliParam) => {
 
 const init = async (config, cli) => {
   const maybeToken = config.params[0];
+  const customDir = config.dir || config.d;
   if (!maybeToken) {
     throw new Error('"init" command requires either a token or package name from the Registry');
   }
   cli.logLogo();
-  const serviceDir = await run(cli, config.params[0]);
+  const serviceDir = await run(cli, config.params[0], customDir);
   if (serviceDir) {
     cli.sessionStop(
       'success',


### PR DESCRIPTION
## What has been implemented?

Closes #714

## Steps to verify

- [ ] Run `sls help`, and note you see both --dir and -d as options
- [ ] run `sls init fullstack-app -d my-custom-dir` and see that the package is fetched from registry and set up in `my-custom-dir`
- [ ] run `sls init fullstack-app --dir my-custom-dir` and see that the package is fetched from registry and set up in `my-custom-dir`
- [ ] run `sls init website -d my-custom-dir` and see that the component is initializedin `my-custom-dir`
- [ ] repeat with an initToken from the dashboard, and note that it works as above.
