### PR TITLE
chore: add source code download url into sls info command for CN

### DIFF
--- a/src/cli/commands-cn/info.js
+++ b/src/cli/commands-cn/info.js
@@ -42,7 +42,8 @@ module.exports = async (config, cli) => {
     instanceYaml.org,
     instanceYaml.stage,
     instanceYaml.app,
-    instanceYaml.name
+    instanceYaml.name,
+    { fetchSourceCodeUrl: true }
   );
 
   instance = instance.instance;


### PR DESCRIPTION
## What has been implemented?

add source code download URL when you run `sls info`


