### PR TITLE
feat: Add templates to CLI onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "graphlib": "^2.1.8",
     "https-proxy-agent": "^5.0.0",
     "ini": "^1.3.5",
+    "inquirer-autocomplete-prompt": "^1.0.2",
     "js-yaml": "^3.14.0",
     "minimist": "^1.2.5",
     "moment": "^2.27.0",

--- a/src/cli/commands-cn/index.js
+++ b/src/cli/commands-cn/index.js
@@ -2,7 +2,7 @@
 
 const run = require('./run');
 const info = require('./info');
-const init = require('./init');
+const { init } = require('./init');
 const dev = require('./dev');
 const registry = require('./registry');
 const help = require('./help');

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -20,6 +20,31 @@ module.exports = async () => {
   const instanceConfig = loadInstanceConfig(process.cwd());
   const stage = args.stage || (instanceConfig && instanceConfig.stage) || 'dev';
 
+  const params = [];
+  if (args._[1]) {
+    params.push(args._[1]);
+  }
+  if (args._[2]) {
+    params.push(args._[2]);
+  }
+  if (args._[3]) {
+    params.push(args._[3]);
+  }
+  if (args._[4]) {
+    params.push(args._[4]);
+  }
+
+  const config = { ...args, params };
+  if (config._) {
+    delete config._;
+  }
+
+  config.platformStage = process.env.SERVERLESS_PLATFORM_STAGE || 'prod';
+  config.debug = process.env.SLS_DEBUG || !!args.debug;
+
+  // Initialize CLI utilities
+  const cli = new CLI(config);
+
   /**
    * Load environment variables from .env files, 2 directories up
    * Nearest to current working directory is preferred
@@ -70,7 +95,7 @@ module.exports = async () => {
    */
   if (process.argv.length === 2 && isChinaUser() && !(await isProjectPath(process.cwd()))) {
     // Interactive onboarding
-    return require('./interactive-onboarding/cn')();
+    return require('./interactive-onboarding/cn')(config, cli);
   }
 
   let commands;
@@ -99,35 +124,10 @@ module.exports = async () => {
     command = 'help';
   }
 
-  const params = [];
-  if (args._[1]) {
-    params.push(args._[1]);
-  }
-  if (args._[2]) {
-    params.push(args._[2]);
-  }
-  if (args._[3]) {
-    params.push(args._[3]);
-  }
-  if (args._[4]) {
-    params.push(args._[4]);
-  }
-
-  const config = { ...args, params };
-  if (config._) {
-    delete config._;
-  }
-
-  config.platformStage = process.env.SERVERLESS_PLATFORM_STAGE || 'prod';
-  config.debug = process.env.SLS_DEBUG || !!args.debug;
-
   // Add stage environment variable
   if (args.stage && !process.env.SERVERLESS_STAGE) {
     process.env.SERVERLESS_STAGE = args.stage;
   }
-
-  // Initialize CLI utilities
-  const cli = new CLI(config);
 
   // Handle version command. Log and exit.
   // TODO: Move this to a command file like all others. Don't handle this here.

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -42,6 +42,11 @@ module.exports = async () => {
   config.platformStage = process.env.SERVERLESS_PLATFORM_STAGE || 'prod';
   config.debug = process.env.SLS_DEBUG || !!args.debug;
 
+  // Add stage environment variable
+  if (args.stage && !process.env.SERVERLESS_STAGE) {
+    process.env.SERVERLESS_STAGE = args.stage;
+  }
+
   // Initialize CLI utilities
   const cli = new CLI(config);
 
@@ -122,11 +127,6 @@ module.exports = async () => {
    */
   if (args.help || args.h || args['help-components']) {
     command = 'help';
-  }
-
-  // Add stage environment variable
-  if (args.stage && !process.env.SERVERLESS_STAGE) {
-    process.env.SERVERLESS_STAGE = args.stage;
   }
 
   // Handle version command. Log and exit.

--- a/src/cli/interactive-onboarding/cn.js
+++ b/src/cli/interactive-onboarding/cn.js
@@ -1,45 +1,31 @@
 'use strict';
 
 const path = require('path');
-const https = require('https');
-const urlUtils = require('url');
-const fs = require('fs');
-const os = require('os');
-const crypto = require('crypto');
-const { mkdir } = require('fs-extra');
 const chalk = require('chalk');
-const AdmZip = require('adm-zip');
 const inquirer = require('@serverless/inquirer');
 const confirm = require('@serverless/inquirer/utils/confirm');
+const { ServerlessSDK } = require('@serverless/platform-client-china');
 const { isProjectPath } = require('../utils');
+const { initTemplateFromCli } = require('../commands-cn/init');
 
 const isValidProjectName = RegExp.prototype.test.bind(/^[a-zA-Z][a-zA-Z0-9-]{0,100}$/);
 
-const cosUrl = 'https://serverless-templates-1300862921.cos.ap-beijing.myqcloud.com/';
+// Add search for user to choice different project templates
+inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
 
-const initializeProjectChoices = [
-  {
-    name: 'Express.js app',
-    value: { id: 'express', name: 'Express.js' },
-  },
-  {
-    name: 'SCF Function',
-    value: { id: 'scf', name: 'SCF Function' },
-  },
-  {
-    name: 'Website app',
-    value: { id: 'website', name: 'Website' },
-  },
-];
-
-const projectTypeChoice = async () =>
+const projectTypeChoice = async (choices) =>
   (
     await inquirer.prompt({
       // EN: What do you want to make?
       message: '请选择你希望创建的 Serverless 应用',
-      type: 'list',
+      type: 'autocomplete',
       name: 'projectType',
-      choices: initializeProjectChoices,
+      source: (_, input) => {
+        if (input !== undefined) {
+          return Promise.resolve(choices.filter((choice) => choice.name.includes(input)));
+        }
+        return Promise.resolve(choices);
+      },
     })
   ).projectType;
 
@@ -73,42 +59,16 @@ const projectNameInput = async (workingDir) =>
     })
   ).projectName.trim();
 
-const createProject = async (projectType, projectDir) => {
-  const tmpFilename = path.resolve(os.tmpdir(), crypto.randomBytes(5).toString('hex'));
-  process.stdout.write(
-    // EN: Downloading ${projectType.name} app...
-    `Serverless: ${chalk.yellow(`正在安装 ${projectType.name} 应用...`)}\n`
-  );
-  await Promise.all([
-    mkdir(projectDir),
-    (async () => {
-      const url = urlUtils.parse(`${cosUrl}${projectType.id}-demo.zip`);
+const getTemplatesFromRegistry = async (sdk) => {
+  const { templates = [] } = await sdk.listPackages(null, { isFeatured: true });
 
-      await new Promise((resolve, reject) => {
-        const req = https.request(
-          {
-            protocol: url.protocol,
-            hostname: url.hostname,
-            port: url.port,
-            path: url.path,
-            method: 'GET',
-          },
-          (res) => {
-            const stream = res.pipe(fs.createWriteStream(tmpFilename));
-            stream.on('error', reject);
-            stream.on('finish', resolve);
-          }
-        );
-        req.end();
-      });
-    })(),
-  ]);
-
-  const zip = new AdmZip(tmpFilename);
-  zip.extractAllTo(projectDir);
+  return templates.map((item) => ({
+    name: item.name,
+    value: { id: item.componentName, name: item.name },
+  }));
 };
 
-module.exports = async () => {
+module.exports = async (config, cli) => {
   // We assume we're not in service|component context
   // As this function is configured to be invoked only in such case
   if (
@@ -119,14 +79,39 @@ module.exports = async () => {
   ) {
     return null;
   }
+  const sdk = new ServerlessSDK();
 
-  const projectType = await projectTypeChoice();
+  // Fetch latest templates from registry
+  const templatesChoices = await getTemplatesFromRegistry(sdk);
+  if (templatesChoices.length === 0) {
+    // EN: Can not find any template in registry!
+    cli.log(chalk.red('当前注册中心无可用模版!\n'));
+    return null;
+  }
+
+  const projectType = await projectTypeChoice(templatesChoices);
   const workingDir = process.cwd();
   const projectName = await projectNameInput(workingDir);
+
   const projectDir = path.join(workingDir, projectName);
-  await createProject(projectType, projectDir);
+  const { id: packageName, name } = projectType;
+
+  cli.log(
+    // EN: Downloading ${projectType.name} app...
+    `Serverless: ${chalk.yellow(`正在安装 ${name} 应用...`)}\n`
+  );
+
+  // Get detailed information about the selected template
+  const registryPackage = await sdk.getPackage(packageName);
+
+  // Start CLI persistance status
+  cli.sessionStart('Installing', { timer: false });
+  // Start initialing the template on cli
+  await initTemplateFromCli(projectDir, packageName, registryPackage, cli);
+  cli.sessionStop('success', 'Created');
+
   // EN: Project successfully created in '${projectName}' folder
-  process.stdout.write(`\n${chalk.green(`${projectName} 项目已成功创建！`)}\n`);
+  cli.log(`\n${chalk.green(`${projectName} 项目已成功创建！`)}\n`);
 
   if (
     // EN: Do you want to deploy your project on the cloud now?

--- a/src/cli/interactive-onboarding/cn.js
+++ b/src/cli/interactive-onboarding/cn.js
@@ -20,11 +20,11 @@ const projectTypeChoice = async (choices) =>
       message: '请选择你希望创建的 Serverless 应用',
       type: 'autocomplete',
       name: 'projectType',
-      source: (_, input) => {
-        if (input !== undefined) {
-          return Promise.resolve(choices.filter((choice) => choice.name.includes(input)));
+      source: async (_, input) => {
+        if (input) {
+          return choices.filter((choice) => choice.name.includes(input));
         }
-        return Promise.resolve(choices);
+        return choices;
       },
     })
   ).projectType;


### PR DESCRIPTION
## What has been implemented?

1. Get data from registry api
2. Users can search for templates by entering name of template
3. Same behavior with `sls init` after choosing a template

Closes https://github.com/serverless/roadmap-tencent/issues/481

## Steps to verify

- Run the local `bin` binary in a non-serverless project 
- Select templates from list
- Input project name
- User can deploy project immediately after creating it successfully

## Todos:

- [ ] Support inputs
- [ ] Support multi-language runtime for templates, like `SCF`
