### PR TITLE
Fix regression where sls publish is broken

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -119,7 +119,7 @@ module.exports = async () => {
    */
   if (command === 'publish') {
     command = 'registry';
-    config.params.push('publish');
+    config.params.unshift('publish');
   }
 
   /**

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -119,7 +119,7 @@ module.exports = async () => {
    */
   if (command === 'publish') {
     command = 'registry';
-    args._[1] = 'publish';
+    config.params.push('publish');
   }
 
   /**


### PR DESCRIPTION
## What has been implemented?

Fixes a bug introduced in #735 where `sls publish` was broken

## Steps to verify

- Pull this branch, run `sls publish`
- `sls registry` still shows the registry items
- `sls registry publish` still publishes

