### PR TITLE
Skip getting default org when dashboard object is not found (ie. logged out)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/components",
-  "version": "2.34.1",
+  "version": "2.34.2",
   "description": "The Serverless Framework's new infrastructure provisioning technology — Build, compose, & deploy serverless apps in seconds...",
   "main": "./src/index.js",
   "bin": {

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -48,7 +48,7 @@ const getDashboardUrl = (urlPath) => {
 const getDefaultOrgName = async () => {
   const res = readConfigFile();
 
-  if (!res.userId) {
+  if (!res.userId || !res.users || !res.users[res.userId] || !res.users[res.userId].dashboard) {
     return null;
   }
 


### PR DESCRIPTION
Closes #742
