### PR TITLE
fix: fix typo in the cli command help

### DIFF
--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -43,7 +43,7 @@ ${command(
 )}          Publishes the package in the current working directory to the Serverless Registry
 ${command('  --dev')}                     Overwrites the version property and set it to dev
 
-${command('serverless registry')}         Lists featured pacakges in the Serverless Registry
+${command('serverless registry')}         Lists featured packages in the Serverless Registry
 
 ${command(
   'serverless registry {name}'


### PR DESCRIPTION
## What has been implemented?

fixes typo in the cli command help

