### PR TITLE
Add component name and version to sls info

### DIFF
--- a/src/cli/commands/info.js
+++ b/src/cli/commands/info.js
@@ -77,6 +77,7 @@ module.exports = async (config, cli) => {
   cli.log(`${'Last Action:'}  ${instance.lastAction} (${lastActionAgo})`);
   cli.log(`${'Deployments:'}  ${instance.instanceMetrics.deployments}`);
   cli.log(`${'Status:'}       ${statusLog}`);
+  cli.log(`${'Component:'}    ${instance.componentName}@${instance.componentVersion}`);
 
   // show error stack if available
   if (instance.deploymentErrorStack) {


### PR DESCRIPTION
## What has been implemented?
One thing that I have run into, which was really hard to figure out was - `Which version of the express component am I running?!`.
We tell people in the readme that we `HIGHLY recommend pinning this to a specific version`, but users don’t even know what version they use, how to upgrade, or why/when.
I realized this when I ran `sls info` and `sls info --debug` and never saw any of this information. It’s not in the state (which is dumped with `debug`).

This PR addresses that. It looks like this:
![image](https://user-images.githubusercontent.com/1598537/90040522-a5e57800-dc8d-11ea-9898-36e0715ef019.png)
