### PR TITLE
fix multi service provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To get started with Serverless Components, install the latest version of the [Se
 $ npm i -g serverless
 ```
 
-After installation, run `serverless registry` to see many Component-based templates you can deploy, or see more in the [Serverless Framework Dashboard](https://app.serverless.com).  These contain Components as well as boilerplate code, to get you started quickly.
+After installation, run `serverless registry` to see many Component-based templates you can deploy, or see more in the [Serverless Framework Dashboard](https://app.serverless.com). These contain Components as well as boilerplate code, to get you started quickly.
 
 Install anything from the registry via `$ serverless init <template>`, like this:
 
@@ -1237,7 +1237,7 @@ Starts DEV MODE, which watches the Component for changes, auto-deploys on change
 
 A `serverless.yml` file can only hold 1 Component at this time. However, that does not mean you cannot deploy/remove multiple Components at the same time.
 
-Simply navigate to a parent directory, and run `serverless deploy` to deploy any `serverless.yml` files in immediate subfolders. When this happens, the Serverless Framework will quickly create a graph based on the references your Component apps are making to eachother. Depending on those references, it will prioritize what needs to be deployed first, otherwise its default is to deploy things in parallel.  This also works for `serverless remove`.
+Simply navigate to a parent directory, and run `serverless deploy` to deploy any `serverless.yml` files in immediate subfolders. When this happens, the Serverless Framework will quickly create a graph based on the references your Component apps are making to eachother. Depending on those references, it will prioritize what needs to be deployed first, otherwise its default is to deploy things in parallel. This also works for `serverless remove`.
 
 For context, here is why we designed `serverless.yml` to only hold 1 Component at a time:
 

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -25,8 +25,8 @@ module.exports = async (config, cli, command) => {
     throw new Error('Please log in by running "serverless login"');
   }
 
-  // Check to see if the cwd is a template containing multiple templates
-  if (['deploy', 'remove'].includes(command) && runningTemplate(process.cwd())) {
+  // Check to see if the cwd is a template containing multiple services
+  if (runningTemplate(process.cwd())) {
     return runAll(config, cli, command);
   }
 
@@ -179,7 +179,7 @@ module.exports = async (config, cli, command) => {
     cli.log(
       `Full details: ${getDashboardUrl(
         `/${instanceYaml.org}/apps/${instanceYaml.app || instanceYaml.name}/${instanceYaml.name}/${
-          instanceYaml.stage
+        instanceYaml.stage
         }`
       )}`
     );

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -179,7 +179,7 @@ module.exports = async (config, cli, command) => {
     cli.log(
       `Full details: ${getDashboardUrl(
         `/${instanceYaml.org}/apps/${instanceYaml.app || instanceYaml.name}/${instanceYaml.name}/${
-        instanceYaml.stage
+          instanceYaml.stage
         }`
       )}`
     );

--- a/src/cli/commands/runAll.js
+++ b/src/cli/commands/runAll.js
@@ -105,8 +105,8 @@ module.exports = async (config, cli, command) => {
     const deferredNotificationsData =
       command === 'deploy'
         ? requestNotification(
-          Object.assign(generateNotificationsPayload(templateYaml), { command: 'deploy' })
-        )
+            Object.assign(generateNotificationsPayload(templateYaml), { command: 'deploy' })
+          )
         : null;
 
     if (command === 'deploy') {
@@ -116,7 +116,7 @@ module.exports = async (config, cli, command) => {
     } else {
       cli.sessionStop(
         'error',
-        `Error: You can only run "deploy" or "remove" when working with multiple services`
+        'Error: You can only run "deploy" or "remove" when working with multiple services'
       );
       return null;
     }
@@ -126,8 +126,8 @@ module.exports = async (config, cli, command) => {
     // Remove all inputs for the "remove" command
     if (command === 'remove' && allComponents) {
       Object.keys(allComponents).forEach((c) => {
-        allComponents[c].inputs = {}
-      })
+        allComponents[c].inputs = {};
+      });
     }
 
     const allComponentsWithDependencies = setDependencies(allComponents);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -110,7 +110,7 @@ module.exports = async () => {
     commands = require('./commands');
   }
 
-  let command = args._[0] || 'deploy';
+  let command = args._[0] || null;
 
   /**
    * Intercept "publish" command.  Any "registry" command is also intercepted.
@@ -137,6 +137,11 @@ module.exports = async () => {
   }
 
   try {
+
+    if (!command) {
+      throw new Error('Please enter a valid command. Run "serverless help" to see all available commands.')
+    }
+
     if (commands[command]) {
       await commands[command](config, cli, command);
     } else {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -137,9 +137,10 @@ module.exports = async () => {
   }
 
   try {
-
     if (!command) {
-      throw new Error('Please enter a valid command. Run "serverless help" to see all available commands.')
+      throw new Error(
+        'Please enter a valid command. Run "serverless help" to see all available commands.'
+      );
     }
 
     if (commands[command]) {


### PR DESCRIPTION
Currently, the `serverless` command still tries to do a deploy w/ component-related projects, and the command experience when using a project with multiple services doesn't can fail when using a different command than deploy and remove.  This PR tries to fix/improve a lot of this.