### PR TITLE
Add support for AWS profile with role_arn configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Components could access AWS credentials using `this.credentials.aws` with the ad
 }
 ```
 
-**Note:** These credentials are temporary by default 3600 seconds. This value can be configured via `AWS_ROLE_SESSION_DURATION` environment variable. The minimum value is 900 and the maximum is 43200.
+**Note:** These credentials are temporary, by default they last 3600 seconds. This value can be configured via `AWS_ROLE_SESSION_DURATION` environment variable. The minimum value is 900 and the maximum is 43200.
 
 #### Google Credentials
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To get started with Serverless Components, install the latest version of the [Se
 $ npm i -g serverless
 ```
 
-After installation, run `serverless registry` to see many Component-based templates you can deploy, or see more in the [Serverless Framework Dashboard](https://app.serverless.com).  These contain Components as well as boilerplate code, to get you started quickly.
+After installation, run `serverless registry` to see many Component-based templates you can deploy, or see more in the [Serverless Framework Dashboard](https://app.serverless.com). These contain Components as well as boilerplate code, to get you started quickly.
 
 Install anything from the registry via `$ serverless init <template>`, like this:
 
@@ -382,6 +382,37 @@ Components could access these AWS credentials using `this.credentials.aws`. This
 ```
 
 **Note:** For AWS, if no `.env` file was found in the current working directory or immediate parent directory, the CLI will attempt to get the credentials from AWS's shared credentials file (typically at `~/.aws/credentials`) as a fallback according to your `AWS_DEFAULT_PROFILE` or `AWS_PROFILE` environment variables, just like how it works on the AWS SDK.
+
+#### AWS Profile with AssumeRole
+
+```bash
+AWS_PROFILE=myprofile
+```
+
+The CLI will check AWS's shared credentials file (typically at `~/.aws/credentials`) for 'role_arn' and 'source_profile' configuration for provided profile
+and assume that role using [AWS STS API](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html). AWS's shared credentials should look like this:
+
+```
+[mycompanyprofile]
+aws_access_key_id = xxxxxxxxxxxxxxxxxxxx
+aws_secret_access_key = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+[myprofile]
+role_arn = arn:aws:iam::000000000000:role/MyOrganizationAccountAccessRole
+source_profile = mycompanyprofile
+```
+
+Components could access AWS credentials using `this.credentials.aws` with the addition of 'sessionToken' property. This object would look like this:
+
+```js
+{
+  accessKeyId: '123456789',
+  secretAccessKey: '123456789',
+  sessionToken: '123456789AAAAAAAAAAAAAAAAAAAAAAAA',
+}
+```
+
+**Note:** These credentials are temporary by default 3600 seconds. This value can be configured via `AWS_ROLE_SESSION_DURATION` environment variable. The minimum value is 900 and the maximum is 43200.
 
 #### Google Credentials
 
@@ -1237,7 +1268,7 @@ Starts DEV MODE, which watches the Component for changes, auto-deploys on change
 
 A `serverless.yml` file can only hold 1 Component at this time. However, that does not mean you cannot deploy/remove multiple Components at the same time.
 
-Simply navigate to a parent directory, and run `serverless deploy` to deploy any `serverless.yml` files in immediate subfolders. When this happens, the Serverless Framework will quickly create a graph based on the references your Component apps are making to eachother. Depending on those references, it will prioritize what needs to be deployed first, otherwise its default is to deploy things in parallel.  This also works for `serverless remove`.
+Simply navigate to a parent directory, and run `serverless deploy` to deploy any `serverless.yml` files in immediate subfolders. When this happens, the Serverless Framework will quickly create a graph based on the references your Component apps are making to eachother. Depending on those references, it will prioritize what needs to be deployed first, otherwise its default is to deploy things in parallel. This also works for `serverless remove`.
 
 For context, here is why we designed `serverless.yml` to only hold 1 Component at a time:
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Components could access AWS credentials using `this.credentials.aws` with the ad
 }
 ```
 
-**Note:** These credentials are temporary, by default they last 3600 seconds. This value can be configured via `AWS_ROLE_SESSION_DURATION` environment variable. The minimum value is 900 and the maximum is 43200.
+**Note:** These credentials are temporary, by default they last 3600 seconds (60 minutes). This value can be configured via `AWS_ROLE_SESSION_DURATION` environment variable. The minimum value is 900 (15 minutes) and the maximum is 43200 (12 hours).
 
 #### Google Credentials
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@serverless/utils": "^1.2.0",
     "adm-zip": "^0.4.16",
     "ansi-escapes": "^4.3.1",
-    "aws-sdk": "^2.735.0",
+    "aws4": "^1.10.1",
     "chalk": "^2.4.2",
     "child-process-ext": "^2.1.1",
     "chokidar": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@serverless/utils": "^1.2.0",
     "adm-zip": "^0.4.16",
     "ansi-escapes": "^4.3.1",
+    "aws-sdk": "^2.735.0",
     "chalk": "^2.4.2",
     "child-process-ext": "^2.1.1",
     "chokidar": "^3.4.1",

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -165,6 +165,9 @@ const loadAwsCredentials = async () => {
 
     if (!sourceCredentials) return;
 
+    // retrieve session duration configuration
+    const durationSeconds = process.env.AWS_ROLE_SESSION_DURATION || 3600;
+
     // assume profile role and retrieve credentials
     const timestamp = new Date().getTime();
     const stsResponse = await awsRequest(
@@ -174,6 +177,7 @@ const loadAwsCredentials = async () => {
         'Version=2011-06-15',
         `RoleSessionName=serverless-components-${timestamp}`,
         `RoleArn=${credentials.role_arn}`,
+        `DurationSeconds=${durationSeconds}`,
       ].join('&'),
       {
         accessKeyId: sourceCredentials.aws_access_key_id,

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -30,7 +30,7 @@ const {
 /*
  * AWS Provider clients
  */
-const STS = require('aws-sdk/clients/sts')
+const STS = require('aws-sdk/clients/sts');
 
 /**
  * Get the URL of the Serverless Framework Dashboard
@@ -121,7 +121,7 @@ const loadAwsCredentials = async () => {
 
   // check if profile use assume role
   if (credentials.source_profile && credentials.role_arn) {
-    const sourceCredentials = parsedCredentialsFile[credentials.source_profile]
+    const sourceCredentials = parsedCredentialsFile[credentials.source_profile];
 
     if (!sourceCredentials) return;
 
@@ -129,16 +129,18 @@ const loadAwsCredentials = async () => {
     const sts = new STS({
       credentials: {
         accessKeyId: sourceCredentials.aws_access_key_id,
-        secretAccessKey: sourceCredentials.aws_secret_access_key
-      }
-    })
+        secretAccessKey: sourceCredentials.aws_secret_access_key,
+      },
+    });
 
     // assume profile role and retrieve credentials
-    const timestamp = (new Date()).getTime();
-    const stsResponse = await sts.assumeRole({
-      RoleArn: credentials.role_arn,
-      RoleSessionName: `serverless-components-${timestamp}`
-    }).promise()
+    const timestamp = new Date().getTime();
+    const stsResponse = await sts
+      .assumeRole({
+        RoleArn: credentials.role_arn,
+        RoleSessionName: `serverless-components-${timestamp}`,
+      })
+      .promise();
 
     if (!stsResponse.Credentials) return;
 
@@ -147,7 +149,7 @@ const loadAwsCredentials = async () => {
     process.env.AWS_SECRET_ACCESS_KEY = stsResponse.Credentials.SecretAccessKey;
     process.env.AWS_SESSION_TOKEN = stsResponse.Credentials.SessionToken;
 
-    return
+    return;
   }
 
   // set the credentials in the env to pass it to the sdk

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -49,7 +49,7 @@ const fileExistsSync = (filePath) => {
 const fileExists = async (filePath) => {
   try {
     const stats = await fse.lstat(filePath);
-    return stats.isFile();
+    return stats.isFile() || stats.isSymbolicLink();
   } catch (error) {
     return false;
   }

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -36,7 +36,7 @@ const sleep = async (wait) => new Promise((resolve) => setTimeout(() => resolve(
 const fileExistsSync = (filePath) => {
   try {
     const stats = fse.lstatSync(filePath);
-    return stats.isFile();
+    return stats.isFile() || stats.isSymbolicLink();
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
## What has been implemented?

**Allow usage of symbolic link for AWS credentials and other files.**

For additional security, using Linux, is a good practice to link files with sensitive content (like credentials) into [Encrypted Private Directory](https://help.ubuntu.com/community/EncryptedPrivateDirectory). These changes allow to use this configurations without fail `fileExistsSync()` check.

**Add [aws-sdk](https://www.npmjs.com/package/aws-sdk) package as dependency**

This is required in order to [assume a role](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) using AWS STS client.

**Makes `loadInstanceCredentials()` asynchronous**

If I have not misunderstood the `loadInstanceCredentials()` function is always called with await operator even though the function was not declared as async. These change will force this declaration in order to wait AWS STS call to retrieve credentials.

**Add support for AWS Profile with assume role functionality**

Closes issue #506

## Steps to verify

- Add into `~/.aws/credentials` a profile section with role_arn
```
[mycompanyprofile]
aws_access_key_id = xxxxxxxxxxxxxxxxxxxx
aws_secret_access_key = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

[myprofile]
role_arn = arn:aws:iam::000000000000:role/MyOrganizationAccountAccessRole
source_profile = mycompanyprofile
```
- Set environment variable `AWS_PROFILE` or add it into `.env` file
```
AWS_PROFILE=myprofile
```
- Run `serverless deploy` command

## Todos:

- [ ] Write tests
- [x] Write / update documentation
- [x] Run Prettier
