### PR TITLE
Support console.info() in dev mode

### DIFF
--- a/src/cli/commands/dev.js
+++ b/src/cli/commands/dev.js
@@ -135,6 +135,9 @@ module.exports = async (config, cli) => {
           if (log.type === 'debug' || log.type === 'stderr') {
             type = 'log - debug';
           }
+          if (log.type === 'info') {
+            type = 'log - info';
+          }
           if (log.type === 'warn') {
             type = 'log - warn';
           }
@@ -152,7 +155,7 @@ module.exports = async (config, cli) => {
           if (log.type === 'log' || log.type === 'stdout') {
             cli.log(log.data);
           }
-          if (log.type === 'debug' || log.type === 'stderr') {
+          if (log.type === 'debug' || log.type === 'info' || log.type === 'stderr') {
             cli.log(log.data);
           }
           if (log.type === 'warn') {


### PR DESCRIPTION
## What has been implemented?

Not sure if it was intentionally left out, I noticed that any `console.info()` statements when in dev mode were not being intercepted. I've added support for it in the layer via serverlessinc/platform#76. This PR prints those intercepted log events out on to the user's console.

## Steps to verify

- Deploy a component instance with `console.info()` statements
- Start dev mode
- Invoke instance
- Ensure that `console.info()` statements are intercepted and printed out in dev console

## Todos:

- [ ] Write tests
- ~[ ] Write / update documentation~
- [x] Run Prettier
