### PR TITLE
CI: Fix auto publication of release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,22 @@ jobs:
           node-version: 14.x
           registry-url: https://registry.npmjs.org
 
+      - name: Retrieve dependencies from cache
+        id: cacheNpm
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          key: npm-v14-${{ runner.os }}-refs/heads/master-${{ hashFiles('package.json') }}
+          restore-keys: npm-v14-${{ runner.os }}-refs/heads/master-
+
+      - name: Install dependencies
+        if: steps.cacheNpm.outputs.cache-hit != 'true'
+        run: |
+          npm update --no-save
+          npm update --save-dev --no-save
+
       - name: Publish new version
         run: |
           npm publish

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,23 +24,17 @@ jobs:
           git checkout master
           git checkout pr
 
-      - name: Retrieve ~/.npm from cache
-        uses: actions/cache@v1
+      - name: Retrieve dependencies from cache
+        id: cacheNpm
+        uses: actions/cache@v2
         with:
-          path: ~/.npm
+          path: |
+            ~/.npm
+            node_modules
           key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: |
             npm-v14-${{ runner.os }}-${{ github.ref }}-
             npm-v14-${{ runner.os }}-refs/heads/master-
-      - name: Retrieve node_modules from cache
-        id: cacheNodeModules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: node-modules-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: |
-            node-modules-v14-${{ runner.os }}-${{ github.ref }}-
-            node-modules-v14-${{ runner.os }}-refs/heads/master-
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
@@ -48,7 +42,7 @@ jobs:
           node-version: 14.x
 
       - name: Install dependencies
-        if: steps.cacheNodeModules.outputs.cache-hit != 'true'
+        if: steps.cacheNpm.outputs.cache-hit != 'true'
         run: |
           npm update --no-save
           npm update --save-dev --no-save
@@ -71,21 +65,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Retrieve ~/.npm from cache
-        uses: actions/cache@v1
+      - name: Retrieve dependencies from cache
+        id: cacheNpm
+        uses: actions/cache@v2
         with:
-          path: ~/.npm
+          path: |
+            ~/.npm
+            node_modules
           key: npm-v8-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: |
             npm-v8-${{ runner.os }}-${{ github.ref }}-
             npm-v8-${{ runner.os }}-refs/heads/master-
-      - name: Retrieve node_modules from cache
-        id: cacheNodeModules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: node-modules-prod-v8-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: node-modules-prod-v8-${{ runner.os }}-${{ github.ref }}-
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
@@ -93,7 +83,7 @@ jobs:
           node-version: 8.x
 
       - name: Install prod dependencies
-        if: steps.cacheSdkNodeModules.outputs.cache-hit != 'true'
+        if: steps.cacheNpm.outputs.cache-hit != 'true'
         run: npm update --no-save
 
       - name: Support check

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.npm
-          key: npm-v8-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('sdk/package.json') }}
+          key: npm-v8-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: |
             npm-v8-${{ runner.os }}-${{ github.ref }}-
             npm-v8-${{ runner.os }}-refs/heads/master-
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: node_modules
-          key: node-modules-prod-v8-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('sdk/package.json') }}
+          key: node-modules-prod-v8-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: node-modules-prod-v8-${{ runner.os }}-${{ github.ref }}-
 
       - name: Install Node.js and npm

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": "serverless/components",
   "scripts": {
     "lint": "eslint .",
     "lint:updated": "pipe-git-updated --ext=js -- eslint",


### PR DESCRIPTION
Auto publication of release notes was supposed to work since https://github.com/serverless/components/pull/740 was merged, but it wasn't due:

- Bug on `npx` side, due to which unexpected binary was invoked, reported at https://github.com/serverless/components/pull/740 (and that also prevented exposure of below issue)
- Lack of `repository` field on `package.json`

## What has been implemented?

- Ensure to have `github-release-from-cc-changelog` locally installed in _publish_ CI job (prior publication of release notes) That's a workaround for `npx` bug
- Add `repository` field to `package.json`
- Upgraded cache configuration to `actions/cache@v2 (and fixed discovered caching configuration issue)

