### PR TITLE
Fix dev mode deployment outputs

### DIFF
--- a/src/cli/commands/dev.js
+++ b/src/cli/commands/dev.js
@@ -186,7 +186,7 @@ module.exports = async (config, cli) => {
       if (event.data.path && event.data.httpMethod) {
         transactionType = `transaction - ${event.data.httpMethod.toUpperCase()} - ${
           event.data.path
-          }`;
+        }`;
       }
       // Default
       else {

--- a/src/cli/commands/dev.js
+++ b/src/cli/commands/dev.js
@@ -29,6 +29,18 @@ const deploy = async (sdk, cli, instanceYaml, instanceCredentials, options = {})
     cli.logError(error);
   }
 
+  const d = new Date();
+  const header = `${d.toLocaleTimeString()} - ${instanceYaml.name} - deployment`;
+
+  cli.log();
+  cli.log(header, 'grey');
+
+  if (result.outputs) {
+    cli.logOutputs(result.outputs);
+  }
+
+  cli.sessionStatus('Watching');
+
   return result;
 };
 
@@ -102,15 +114,6 @@ module.exports = async (config, cli) => {
   const onEvent = (event) => {
     const d = new Date();
 
-    // Deployment
-    if (event.event === 'instance.deployment.succeeded') {
-      const header = `${d.toLocaleTimeString()} - ${event.instance_name} - deployment`;
-      cli.log();
-      cli.log(header, 'grey');
-      cli.logOutputs(event.data.outputs);
-      cli.sessionStatus('Watching');
-    }
-
     // Logs
     if (event.event === 'instance.logs') {
       if (event.data.logs && Array.isArray(event.data.logs)) {
@@ -183,7 +186,7 @@ module.exports = async (config, cli) => {
       if (event.data.path && event.data.httpMethod) {
         transactionType = `transaction - ${event.data.httpMethod.toUpperCase()} - ${
           event.data.path
-        }`;
+          }`;
       }
       // Default
       else {


### PR DESCRIPTION
## What has been implemented?

The Platform now emits 2 new events `instance.action.succeeded` and `instance.action.failed` to simplify things, instead of `instance.deployment...` and `instance.removal....`.

This broken `dev` mode as it was waiting for the `instance.deployment.succeeded` event which has now been deprecated, to show outputs in the CLI after each deployment during `dev` mode.

This fixes that, but also does it by not relying on websockets events to show the message, and instead relies on the response from the `sdk.deploy()` method to log outputs.  Users will see no difference in the experience as a result, but they will have to upgrade.

## Steps to verify

- Run dev mode and do a deploy via the watcher by saving.

