### PR TITLE
chore(command): throw error for null aws credentials

### DIFF
--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -157,8 +157,9 @@ const loadAwsCredentials = async () => {
   // get the credentials for that profile
   const credentials = parsedCredentialsFile[awsCredentialsProfile];
 
-  if (!credentials) return;
-
+  if (!credentials) {
+    throw new Error('Missing credentials. Please to create a .env file');
+  }
   // check if profile use assume role
   if (credentials.source_profile && credentials.role_arn) {
     const sourceCredentials = parsedCredentialsFile[credentials.source_profile];


### PR DESCRIPTION
## What has been implemented?

Throw an `Error` if credentials are not found  

Closes #495

## Steps to verify

- Run X
- ...

## Todos:

- [ ] Write tests
- [ ] Write / update documentation
- [ ] Run Prettier
