### PR TITLE
Techdebt cleanup for instance credentials

### DIFF
--- a/src/cli/commands-cn/dev.js
+++ b/src/cli/commands-cn/dev.js
@@ -163,7 +163,7 @@ module.exports = async (config, cli) => {
   let instanceYaml = await utils.loadInstanceConfig(instanceDir);
 
   // Load Instance Credentials
-  const instanceCredentials = await utils.loadInstanceCredentials(instanceYaml.stage);
+  const instanceCredentials = utils.loadInstanceCredentials();
 
   const sdk = new ServerlessSDK({
     context: {

--- a/src/cli/commands-cn/run.js
+++ b/src/cli/commands-cn/run.js
@@ -44,7 +44,7 @@ module.exports = async (config, cli, command) => {
   cli.sessionStatus('Initializing', instanceYaml.name);
 
   // Load Instance Credentials
-  const instanceCredentials = await utils.loadInstanceCredentials(instanceYaml.stage);
+  const instanceCredentials = utils.loadInstanceCredentials();
 
   // initialize SDK
   const orgUid = await tencentUtils.getOrgId();

--- a/src/cli/commands-cn/runAll.js
+++ b/src/cli/commands-cn/runAll.js
@@ -31,7 +31,7 @@ module.exports = async (config, cli, command) => {
   }
 
   // Load Instance Credentials
-  const credentials = await loadInstanceCredentials(templateYaml.stage);
+  const credentials = loadInstanceCredentials();
 
   cli.sessionStatus('Initializing', templateYaml.name);
 

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -87,8 +87,6 @@ const loadTencentInstanceConfig = async (directoryPath) => {
   }
 
   if (instanceFile.inputs) {
-    // load credentials to process .env files before resolving env variables
-    await loadInstanceCredentials(instanceFile.stage);
     instanceFile = resolveVariables(instanceFile);
     if (instanceFile.inputs.src) {
       if (typeof instanceFile.inputs.src === 'string') {

--- a/src/cli/commands/dev.js
+++ b/src/cli/commands/dev.js
@@ -73,7 +73,7 @@ module.exports = async (config, cli) => {
   instanceYaml = await loadInstanceConfig(process.cwd(), { disableCache: true });
 
   // Load Instance Credentials
-  instanceCredentials = await loadInstanceCredentials(instanceYaml.stage);
+  instanceCredentials = loadInstanceCredentials();
 
   // Get access key
   const accessKey = await getAccessKey(instanceYaml.org);

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -54,7 +54,7 @@ module.exports = async (config, cli, command) => {
   }
 
   // Load Instance Credentials
-  const instanceCredentials = await loadInstanceCredentials(instanceYaml.stage);
+  const instanceCredentials = loadInstanceCredentials();
 
   // initialize SDK
   const sdk = new ServerlessSDK({

--- a/src/cli/commands/runAll.js
+++ b/src/cli/commands/runAll.js
@@ -54,7 +54,7 @@ module.exports = async (config, cli, command) => {
   }
 
   // Load Instance Credentials
-  const credentials = await loadInstanceCredentials(templateYaml.stage);
+  const credentials = loadInstanceCredentials();
 
   cli.sessionStatus('Initializing');
 

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -222,8 +222,6 @@ const loadVendorInstanceConfig = async (directoryPath, options = { disableCache:
   }
 
   if (instanceFile.inputs) {
-    // load credentials to process .env files before resolving env variables
-    await loadInstanceCredentials(instanceFile.stage);
     instanceFile = resolveVariables(instanceFile);
 
     if (instanceFile.inputs.src) {


### PR DESCRIPTION
- Removes syntactic sugar of `async` around non-asynchronous functions
- Removes unused argument
- Removes superfluous call to loadInstanceCredentials, unneeded by the registry command, and only used elsewhere in runAll, which calls loadInstanceCredentials itself