### PR TITLE
Set error status code when sessionStop reason = error

### DIFF
--- a/src/cli/CLI.js
+++ b/src/cli/CLI.js
@@ -127,6 +127,7 @@ class CLI {
     // Render error
     if (reason === 'error') {
       this.logError(messageOrError, { timer: this._.timerSeconds });
+      process.exitCode = 1;
     } else if (reason !== 'silent') {
       // Silent is used to skip the "Done" message
       // Write content


### PR DESCRIPTION
## What has been implemented?

Fix process error status code when a session is closed due to an error. 

## Steps to verify

- Run a deploy command that results in an error
- Run `echo $?` and validate that the result is `1`

