### PR TITLE
fix: customize command inputs

### DIFF
--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -224,7 +224,7 @@ const setInputsForCommand = (instanceYaml, command, config) => {
     const defaultInputs = command === 'deploy' ? instanceYaml.inputs : {};
     instanceYaml.inputs = instanceYaml.commandInputs[command] || defaultInputs;
   } else if (command !== 'deploy') {
-    instanceYaml.inputs = {};
+    // no op
   }
   // merging inputs from command args, e.g. slcc deploy --inputs.src="./new-src"
   // will be merged into inputs.src

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -224,7 +224,8 @@ const setInputsForCommand = (instanceYaml, command, config) => {
     const defaultInputs = command === 'deploy' ? instanceYaml.inputs : {};
     instanceYaml.inputs = instanceYaml.commandInputs[command] || defaultInputs;
   } else if (command !== 'deploy') {
-    // no op
+    // make src undefined, so no need to upload code for other commands
+    instanceYaml.inputs.src = undefined
   }
   // merging inputs from command args, e.g. slcc deploy --inputs.src="./new-src"
   // will be merged into inputs.src

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -225,7 +225,7 @@ const setInputsForCommand = (instanceYaml, command, config) => {
     instanceYaml.inputs = instanceYaml.commandInputs[command] || defaultInputs;
   } else if (command !== 'deploy') {
     // make src undefined, so no need to upload code for other commands
-    instanceYaml.inputs.src = undefined
+    instanceYaml.inputs.src = undefined;
   }
   // merging inputs from command args, e.g. slcc deploy --inputs.src="./new-src"
   // will be merged into inputs.src


### PR DESCRIPTION
When running command is not `deploy`, we can not reset `inputs` to `{}`, because customized commands may need to use `inputs` in `serverless.yml`.