### PR TITLE
Catch a 401 on the backend and handle the error on the CLI

### DIFF
--- a/src/cli/commands/dev.js
+++ b/src/cli/commands/dev.js
@@ -230,6 +230,13 @@ module.exports = async (config, cli) => {
       onEvent,
     });
   } catch (error) {
+    if (error.message.includes('401')) {
+      cli.sessionStop(
+        'error',
+        `Your credentials do not have access to the Organization with the name of: ${instanceYaml.org}.  Try logging into a different account.`
+      );
+      return null;
+    }
     throw new Error(error);
   }
 

--- a/src/cli/commands/runAll.js
+++ b/src/cli/commands/runAll.js
@@ -74,32 +74,42 @@ module.exports = async (config, cli, command) => {
 
     // Connect to Serverless Platform Events, if in debug mode
     if (options.debug) {
-      await sdk.connect({
-        filter: {
-          stageName: templateYaml.stage,
-          appName: templateYaml.app,
-        },
-        onEvent: (evt) => {
-          if (evt.event !== 'instance.run.logs') {
-            return;
-          }
-          if (evt.data.logs && Array.isArray(evt.data.logs)) {
-            evt.data.logs.forEach((log) => {
-              // Remove strange formatting that comes from stderr
-              if (typeof log.data === 'string' && log.data.startsWith("'")) {
-                log.data = log.data.substr(1);
-              }
-              if (typeof log.data === 'string' && log.data.endsWith("'")) {
-                log.data = log.data.substring(0, log.data.length - 1);
-              }
-              if (typeof log.data === 'string' && log.data.endsWith('\\n')) {
-                log.data = log.data.substring(0, log.data.length - 2);
-              }
-              cli.log(log.data);
-            });
-          }
-        },
-      });
+      try {
+        await sdk.connect({
+          filter: {
+            stageName: templateYaml.stage,
+            appName: templateYaml.app,
+          },
+          onEvent: (evt) => {
+            if (evt.event !== 'instance.run.logs') {
+              return;
+            }
+            if (evt.data.logs && Array.isArray(evt.data.logs)) {
+              evt.data.logs.forEach((log) => {
+                // Remove strange formatting that comes from stderr
+                if (typeof log.data === 'string' && log.data.startsWith("'")) {
+                  log.data = log.data.substr(1);
+                }
+                if (typeof log.data === 'string' && log.data.endsWith("'")) {
+                  log.data = log.data.substring(0, log.data.length - 1);
+                }
+                if (typeof log.data === 'string' && log.data.endsWith('\\n')) {
+                  log.data = log.data.substring(0, log.data.length - 2);
+                }
+                cli.log(log.data);
+              });
+            }
+          },
+        });
+      } catch (error) {
+        if (error.message.includes('401')) {
+          cli.sessionStop(
+            'error',
+            `Your credentials do not have access to the Organization with the name of: ${instanceYaml.org}.  Try logging into a different account.`
+          );
+          return null;
+        }
+      }
     }
 
     const deferredNotificationsData =

--- a/src/cli/commands/runAll.js
+++ b/src/cli/commands/runAll.js
@@ -105,7 +105,7 @@ module.exports = async (config, cli, command) => {
         if (error.message.includes('401')) {
           cli.sessionStop(
             'error',
-            `Your credentials do not have access to the Organization with the name of: ${instanceYaml.org}.  Try logging into a different account.`
+            `Your credentials do not have access to the Organization with the name of: ${templateYaml.org}.  Try logging into a different account.`
           );
           return null;
         }


### PR DESCRIPTION
## What has been implemented?

Closes #812

## Steps to verify

- Run `sls deploy`, `sls dev`, or other commands with an organization that does not exist
- [ ] You see a helpful error message, instead of `internal server error`

![image](https://user-images.githubusercontent.com/1598537/94849328-d8d4fe00-03ea-11eb-95cc-85977b1df7c3.png)

There may be a better way to do this, and I'm totally open to suggestions - but I believe our websockets implementation only provides a string error.

Alternatively we could refactor the SDK to throw errors with status codes, and then inspect them here.