### PR TITLE
Add support for serverless.template.yml

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -1061,7 +1061,7 @@ Components 依赖云服务作为状态的来源，并用其存储状态信息。
 
 ### 如何分享（发布）项目模板
 
-要将你的基于 Serverless Component 部署的项目作为模板发布非常简单，你不需要对项目进行任何改造，只需要添加一个`serverless.yml`文件（或者修改已有的`serverless.yml`文件），在其中添加一些需要告诉注册中心的模板元信息即可。详细说明如下：
+要将你的基于 Serverless Component 部署的项目作为模板发布非常简单，你不需要对项目进行任何改造，只需要添加一个`serverless.template.yml`文件（或者修改已有的`serverless.template.yml`文件），在其中添加一些需要告诉注册中心的模板元信息即可。详细说明如下：
 
 ```yaml
 name: fullstack # 项目模板的名字
@@ -1084,7 +1084,7 @@ src: # 描述项目中的哪些文件需要作为模板发布
     - '**/package-lock.json'
 ```
 
-一旦你准备好了描述项目模板元信息的`serverless.yml`文件，便可以使用发布命令`sls publish`将此项目作为模板发布到注册中心。
+一旦你准备好了描述项目模板元信息的`serverless.template.yml`文件，便可以使用发布命令`sls publish`将此项目作为模板发布到注册中心。
 
 # CLI 命令列表
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@serverless/platform-client": "^3.1.1",
-    "@serverless/platform-client-china": "^2.0.0",
+    "@serverless/platform-client-china": "^2.0.3",
     "@serverless/platform-sdk": "^2.3.2",
     "@serverless/utils": "^2.0.0",
     "adm-zip": "^0.4.16",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "/templates"
   ],
   "dependencies": {
-    "@serverless/platform-client": "^2.1.0",
+    "@serverless/platform-client": "^3.1.1",
     "@serverless/platform-client-china": "^2.0.0",
     "@serverless/platform-sdk": "^2.3.2",
     "@serverless/utils": "^2.0.0",

--- a/src/cli/commands-cn/registry.js
+++ b/src/cli/commands-cn/registry.js
@@ -38,14 +38,13 @@ const publish = async (config, cli) => {
 
   let finalServerlessFile;
 
-  // Publishing a component
   if (serverlessComponentFile) {
+    // Publishing a component
     finalServerlessFile = serverlessComponentFile;
     finalServerlessFile.src = serverlessComponentFile.main;
     finalServerlessFile.type = 'component';
-
-  // Publishing a template
   } else {
+    // Publishing a template
     finalServerlessFile = serverlessTemplateFile || serverlessFile;
     finalServerlessFile.type = 'template';
     finalServerlessFile.version = '0.0.0';
@@ -65,7 +64,9 @@ const publish = async (config, cli) => {
   // Presentation
   cli.logRegistryLogo();
   cli.log(
-    `Publishing "${finalServerlessFile.name}@${config.dev ? 'dev' : finalServerlessFile.version}"...`,
+    `Publishing "${finalServerlessFile.name}@${
+      config.dev ? 'dev' : finalServerlessFile.version
+    }"...`,
     'grey'
   );
 
@@ -92,7 +93,8 @@ const publish = async (config, cli) => {
 
   cli.sessionStop(
     'success',
-    `Successfully published ${registryPackage.name}${registryPackage.type === 'template' ? '' : `@${registryPackage.version}`
+    `Successfully published ${registryPackage.name}${
+      registryPackage.type === 'template' ? '' : `@${registryPackage.version}`
     }`
   );
   return null;

--- a/src/cli/commands-cn/registry.js
+++ b/src/cli/commands-cn/registry.js
@@ -32,7 +32,7 @@ const publish = async (config, cli) => {
 
   if (!serverlessTemplateFile && !serverlessComponentFile && !serverlessFile) {
     throw new Error(
-      'Publish failed. The current working directory does not contain a "serverless.template.yml" or "serverless.component.yml" or "serverless.yml"'
+      'Publish failed. The current working directory does not contain a "serverless.template.yml" or "serverless.component.yml"'
     );
   }
 

--- a/src/cli/commands-cn/registry.js
+++ b/src/cli/commands-cn/registry.js
@@ -6,7 +6,7 @@
 
 const { ServerlessSDK } = require('@serverless/platform-client-china');
 const utils = require('./utils');
-const { loadComponentConfig } = require('../utils');
+const { loadComponentConfig, loadTemplateConfig } = require('../utils');
 const { loadServerlessFile } = require('../serverlessFile');
 
 /**
@@ -23,36 +23,49 @@ const publish = async (config, cli) => {
 
   await utils.login();
 
-  // Load YAML and normalize
-  let serverlessFile = await loadServerlessFile(process.cwd());
-  if (!serverlessFile) {
-    // keeping serverless.component.yml for backward compatability
-    const serverlessComponentFile = await loadComponentConfig(process.cwd());
-    serverlessFile = serverlessComponentFile;
-    serverlessFile.src = serverlessComponentFile.main;
+  // We want to check the existence of serverless.template.yml and serverless.component.yml first
+  // If both of them did not show up, we will check serverless.yml for backward compatibility
+  // Why not check the existence of serverless.yml first? serverless.template.yml and serverless.yml may be in the same folder
+  const serverlessTemplateFile = await loadTemplateConfig(process.cwd());
+  const serverlessComponentFile = await loadComponentConfig(process.cwd());
+  const serverlessFile = await loadServerlessFile(process.cwd());
+
+  if (!serverlessTemplateFile && !serverlessComponentFile && !serverlessFile) {
+    throw new Error(
+      'Publish failed. The current working directory does not contain a "serverless.template.yml" or "serverless.component.yml" or "serverless.yml"'
+    );
   }
-  if (serverlessFile.type === 'template' || (!serverlessFile.type && !serverlessFile.version)) {
-    // if the user did not specify a type nor a version, it's a template
-    serverlessFile.type = 'template';
-    serverlessFile.version = '0.0.0';
+
+  let finalServerlessFile;
+
+  // Publishing a component
+  if (serverlessComponentFile) {
+    finalServerlessFile = serverlessComponentFile;
+    finalServerlessFile.src = serverlessComponentFile.main;
+    finalServerlessFile.type = 'component';
+
+  // Publishing a template
   } else {
-    serverlessFile.type = 'component';
+    finalServerlessFile = serverlessTemplateFile || serverlessFile;
+    finalServerlessFile.type = 'template';
+    finalServerlessFile.version = '0.0.0';
   }
+
   // fall back to service name for framework v1
-  serverlessFile.name = serverlessFile.name || serverlessFile.service;
+  finalServerlessFile.name = finalServerlessFile.name || finalServerlessFile.service;
 
   // If "--dev" flag is used, set the version the API expects
   // default version is dev
-  if (!serverlessFile.version || config.dev) {
-    serverlessFile.version = 'dev';
+  if (!finalServerlessFile.version || config.dev) {
+    finalServerlessFile.version = 'dev';
   }
 
-  serverlessFile.org = serverlessFile.org || (await utils.getDefaultOrgName());
+  finalServerlessFile.org = finalServerlessFile.org || (await utils.getDefaultOrgName());
 
   // Presentation
   cli.logRegistryLogo();
   cli.log(
-    `Publishing "${serverlessFile.name}@${config.dev ? 'dev' : serverlessFile.version}"...`,
+    `Publishing "${finalServerlessFile.name}@${config.dev ? 'dev' : finalServerlessFile.version}"...`,
     'grey'
   );
 
@@ -63,7 +76,7 @@ const publish = async (config, cli) => {
 
   let registryPackage;
   try {
-    registryPackage = await sdk.publishPackage(serverlessFile);
+    registryPackage = await sdk.publishPackage(finalServerlessFile);
   } catch (error) {
     if (error.message.includes('409')) {
       error.message = error.message.replace('409 - ', '');
@@ -79,8 +92,7 @@ const publish = async (config, cli) => {
 
   cli.sessionStop(
     'success',
-    `Successfully published ${registryPackage.name}${
-      registryPackage.type === 'template' ? '' : `@${registryPackage.version}`
+    `Successfully published ${registryPackage.name}${registryPackage.type === 'template' ? '' : `@${registryPackage.version}`
     }`
   );
   return null;

--- a/src/cli/commands-cn/runAll.js
+++ b/src/cli/commands-cn/runAll.js
@@ -1,3 +1,5 @@
+/* eslint no-restricted-syntax: 0 */
+
 'use strict';
 
 const { ServerlessSDK, utils: tencentUtils } = require('@serverless/platform-client-china');
@@ -95,6 +97,29 @@ module.exports = async (config, cli, command) => {
     options
   );
 
+  // Check for errors
+  const succeeded = [];
+  const failed = [];
+  for (const component in allComponentsWithOutputs) {
+    if (Object.prototype.hasOwnProperty.call(allComponentsWithOutputs, component)) {
+      const c = allComponentsWithOutputs[component];
+      if (c.error) {
+        failed.push(c.name);
+      }
+      if (c.outputs) {
+        succeeded.push(c.name);
+      }
+    }
+  }
+
+  if (failed.length) {
+    cli.sessionStop(
+      'error',
+      `Errors: "${command}" ran for ${succeeded.length} apps successfully. ${failed.length} failed.`
+    );
+    return null;
+  }
+
   // don't show outputs if removing
   if (command !== 'remove') {
     const outputs = getOutputs(allComponentsWithOutputs);
@@ -108,7 +133,7 @@ module.exports = async (config, cli, command) => {
     }
   }
 
-  cli.sessionStop('success', 'Success');
+  cli.sessionStop('success', `"${command}" ran for ${succeeded.length} apps successfully.`);
 
   if (deferredNotificationsData) printNotification(cli, await deferredNotificationsData);
 

--- a/src/cli/commands/registry.js
+++ b/src/cli/commands/registry.js
@@ -53,7 +53,7 @@ const publish = async (config, cli) => {
 
   if (!serverlessTemplateFile && !serverlessComponentFile && !serverlessFile) {
     throw new Error(
-      'Publish failed. The current working directory does not contain a "serverless.yml" or "serverless.component.yml"'
+      'Publish failed. The current working directory does not contain a "serverless.template.yml" or "serverless.component.yml"'
     );
   }
 

--- a/src/cli/commands/registry.js
+++ b/src/cli/commands/registry.js
@@ -16,7 +16,12 @@ const {
   getTemplate,
   isLoggedInOrHasAccessKey,
 } = require('./utils');
-const { fileExists, loadComponentConfig, loadTemplateConfig, validateNodeModules } = require('../utils');
+const {
+  fileExists,
+  loadComponentConfig,
+  loadTemplateConfig,
+  validateNodeModules,
+} = require('../utils');
 const { loadServerlessFile } = require('../serverlessFile');
 const { remove } = require('fs-extra');
 
@@ -54,14 +59,13 @@ const publish = async (config, cli) => {
 
   let finalServerlessFile;
 
-  // Publishing a component
   if (serverlessComponentFile) {
+    // Publishing a component
     finalServerlessFile = serverlessComponentFile;
     finalServerlessFile.src = serverlessComponentFile.src || serverlessComponentFile.main;
     finalServerlessFile.type = 'component';
-
-  // Publishing a template
   } else {
+    // Publishing a template
     finalServerlessFile = serverlessTemplateFile || serverlessFile;
     finalServerlessFile.type = 'template';
   }
@@ -87,7 +91,11 @@ const publish = async (config, cli) => {
 
   // validate serverless.js & node_modules if component
   if (finalServerlessFile.type === 'component') {
-    const serverlessJsFilePath = path.resolve(process.cwd(), finalServerlessFile.src, 'serverless.js');
+    const serverlessJsFilePath = path.resolve(
+      process.cwd(),
+      finalServerlessFile.src,
+      'serverless.js'
+    );
 
     if (!(await fileExists(serverlessJsFilePath))) {
       throw new Error(
@@ -122,7 +130,12 @@ const publish = async (config, cli) => {
 
   // silently remove @serverless/core to avoid conflict with components v1
   // if it already does not exist, it just moves on
-  const coreDependencyPath = path.join(finalServerlessFile.src, 'node_modules', '@serverless', 'core');
+  const coreDependencyPath = path.join(
+    finalServerlessFile.src,
+    'node_modules',
+    '@serverless',
+    'core'
+  );
   await remove(coreDependencyPath);
 
   // Publish

--- a/src/cli/commands/registry.js
+++ b/src/cli/commands/registry.js
@@ -16,7 +16,7 @@ const {
   getTemplate,
   isLoggedInOrHasAccessKey,
 } = require('./utils');
-const { fileExists, loadComponentConfig, validateNodeModules } = require('../utils');
+const { fileExists, loadComponentConfig, loadTemplateConfig, validateNodeModules } = require('../utils');
 const { loadServerlessFile } = require('../serverlessFile');
 const { remove } = require('fs-extra');
 
@@ -42,56 +42,52 @@ const publish = async (config, cli) => {
   // Get access key
   const accessKey = await getAccessKey();
 
-  let serverlessFile = await loadServerlessFile(process.cwd());
+  const serverlessTemplateFile = await loadTemplateConfig(process.cwd());
+  const serverlessComponentFile = await loadComponentConfig(process.cwd());
+  const serverlessFile = await loadServerlessFile(process.cwd());
 
-  if (!serverlessFile) {
-    // keeping serverless.component.yml for backward compatability
-    const serverlessComponentFile = await loadComponentConfig(process.cwd());
-
-    // If no serverless.yml and no serverless.component.yml, there is nothing to publish in this cwd
-    if (!serverlessFile && !serverlessComponentFile) {
-      throw new Error(
-        'Publish failed. The current working directory does not contain a "serverless.yml" or "serverless.component.yml"'
-      );
-    }
-
-    serverlessFile = serverlessComponentFile;
-    serverlessFile.src = serverlessComponentFile.src || serverlessComponentFile.main;
-  } else if (serverlessFile.version || serverlessFile.type === 'component') {
+  if (!serverlessTemplateFile && !serverlessComponentFile && !serverlessFile) {
     throw new Error(
-      'Publish failed. Components could only be defined with a "serverless.component.yml" file.'
+      'Publish failed. The current working directory does not contain a "serverless.yml" or "serverless.component.yml"'
     );
   }
 
-  if (serverlessFile.type === 'template' || (!serverlessFile.type && !serverlessFile.version)) {
-    // if the user did not specify a type nor a version, it's a template
-    serverlessFile.type = 'template';
+  let finalServerlessFile;
+
+  // Publishing a component
+  if (serverlessComponentFile) {
+    finalServerlessFile = serverlessComponentFile;
+    finalServerlessFile.src = serverlessComponentFile.src || serverlessComponentFile.main;
+    finalServerlessFile.type = 'component';
+
+  // Publishing a template
   } else {
-    serverlessFile.type = 'component';
+    finalServerlessFile = serverlessTemplateFile || serverlessFile;
+    finalServerlessFile.type = 'template';
   }
 
   // fall back to service name for framework v1
-  serverlessFile.name = serverlessFile.name || serverlessFile.service;
+  finalServerlessFile.name = finalServerlessFile.name || finalServerlessFile.service;
 
   // default version is dev
-  if (!serverlessFile.version || config.dev) {
-    serverlessFile.version = 'dev';
+  if (!finalServerlessFile.version || config.dev) {
+    finalServerlessFile.version = 'dev';
   }
 
-  serverlessFile.org = serverlessFile.org || (await getDefaultOrgName());
+  finalServerlessFile.org = finalServerlessFile.org || (await getDefaultOrgName());
 
-  if (!serverlessFile.org) {
+  if (!finalServerlessFile.org) {
     throw new Error('"org" property is required in serverless.yml');
   }
 
   // cwd is the default src
-  if (!serverlessFile.src) {
-    serverlessFile.src = process.cwd();
+  if (!finalServerlessFile.src) {
+    finalServerlessFile.src = process.cwd();
   }
 
   // validate serverless.js & node_modules if component
-  if (serverlessFile.type === 'component') {
-    const serverlessJsFilePath = path.resolve(process.cwd(), serverlessFile.src, 'serverless.js');
+  if (finalServerlessFile.type === 'component') {
+    const serverlessJsFilePath = path.resolve(process.cwd(), finalServerlessFile.src, 'serverless.js');
 
     if (!(await fileExists(serverlessJsFilePath))) {
       throw new Error(
@@ -100,18 +96,18 @@ const publish = async (config, cli) => {
     }
 
     // make sure user ran "npm install" if applicable
-    await validateNodeModules(serverlessFile.src);
+    await validateNodeModules(finalServerlessFile.src);
   } else {
     // validate the template
     await getTemplate(process.cwd());
   }
 
   // log message in case of component
-  let initialStatus = `Publishing "${serverlessFile.name}@${serverlessFile.version}" to the Serverless Framework Registry`;
+  let initialStatus = `Publishing "${finalServerlessFile.name}@${finalServerlessFile.version}" to the Serverless Framework Registry`;
 
   // log message in case of template
-  if (serverlessFile.type === 'template') {
-    initialStatus = `Publishing "${serverlessFile.name}" to the Serverless Framework Registry`;
+  if (finalServerlessFile.type === 'template') {
+    initialStatus = `Publishing "${finalServerlessFile.name}" to the Serverless Framework Registry`;
   }
 
   // Presentation
@@ -121,25 +117,25 @@ const publish = async (config, cli) => {
 
   const readmeFilePath = path.join(process.cwd(), 'README.md');
   if (await fileExists(readmeFilePath)) {
-    serverlessFile.readme = await readFile(readmeFilePath, 'utf-8');
+    finalServerlessFile.readme = await readFile(readmeFilePath, 'utf-8');
   }
 
   // silently remove @serverless/core to avoid conflict with components v1
   // if it already does not exist, it just moves on
-  const coreDependencyPath = path.join(serverlessFile.src, 'node_modules', '@serverless', 'core');
+  const coreDependencyPath = path.join(finalServerlessFile.src, 'node_modules', '@serverless', 'core');
   await remove(coreDependencyPath);
 
   // Publish
   cli.sessionStatus(initialStatus);
 
   try {
-    await sdk.publishToRegistry(serverlessFile);
+    await sdk.publishToRegistry(finalServerlessFile);
     // log message in case of component
-    let successLogMsg = `Successfully published "${serverlessFile.name}@${serverlessFile.version}" to the Serverless Framework Registry.`;
+    let successLogMsg = `Successfully published "${finalServerlessFile.name}@${finalServerlessFile.version}" to the Serverless Framework Registry.`;
 
     // log message in case of template
-    if (serverlessFile.type === 'template') {
-      successLogMsg = `Successfully published "${serverlessFile.name}" to the Serverless Framework Registry`;
+    if (finalServerlessFile.type === 'template') {
+      successLogMsg = `Successfully published "${finalServerlessFile.name}" to the Serverless Framework Registry`;
     }
 
     cli.sessionStop('success', successLogMsg);

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -549,7 +549,6 @@ const legacyLoadComponentConfig = (directoryPath) => {
   return componentFile;
 };
 
-
 const possibleConfigurationFiles = [
   'serverless.yml',
   'serverless.yaml',

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -163,7 +163,7 @@ const loadComponentConfig = (directoryPath) => {
     filePath = jsonFilePath;
   }
   if (!filePath) {
-    throw new Error('No serverless config file was found in the current working directory.');
+    return null;
   }
 
   // Read file
@@ -183,6 +183,54 @@ const loadComponentConfig = (directoryPath) => {
   }
 
   return componentFile;
+};
+
+/**
+ * Reads a serverless template config file in a given directory path
+ * @param {*} directoryPath
+ */
+const loadTemplateConfig = (directoryPath) => {
+  directoryPath = path.resolve(directoryPath);
+  const ymlFilePath = path.join(directoryPath, 'serverless.template.yml');
+  const yamlFilePath = path.join(directoryPath, 'serverless.template.yaml');
+  const jsonFilePath = path.join(directoryPath, 'serverless.template.json');
+  let filePath;
+  let isYaml = false;
+  let templateFile;
+
+  // Check to see if exists and is yaml or json file
+  if (fileExistsSync(ymlFilePath)) {
+    filePath = ymlFilePath;
+    isYaml = true;
+  }
+  if (fileExistsSync(yamlFilePath)) {
+    filePath = yamlFilePath;
+    isYaml = true;
+  }
+  if (fileExistsSync(jsonFilePath)) {
+    filePath = jsonFilePath;
+  }
+  if (!filePath) {
+    return null;
+  }
+
+  // Read file
+  if (isYaml) {
+    try {
+      templateFile = readAndParseSync(filePath);
+    } catch (e) {
+      // todo currently our YAML parser does not support
+      // CF schema (!Ref for example). So we silent that error
+      // because the framework can deal with that
+      if (e.name !== 'YAMLException') {
+        throw e;
+      }
+    }
+  } else {
+    templateFile = readAndParseSync(filePath);
+  }
+
+  return templateFile;
 };
 
 const getDirSize = async (p) => {
@@ -500,6 +548,7 @@ const legacyLoadComponentConfig = (directoryPath) => {
 
   return componentFile;
 };
+
 
 const possibleConfigurationFiles = [
   'serverless.yml',
@@ -891,6 +940,7 @@ module.exports = {
   pack,
   getInstanceDashboardUrl,
   loadComponentConfig,
+  loadTemplateConfig,
   loadInstanceConfig,
   loadInstanceConfigUncached,
   legacyLoadComponentConfig,


### PR DESCRIPTION
## What has been implemented?

- Support publishing templates using `serverless.template.yml`
- Ignore `serverless.template.yml`
- Backward compatibility (support publishing template using `serverless.yml`)
- Update Chinese README
- Test in China

## TODO

- [ ] English README
- [ ] Test outside China

## Related issue

https://github.com/serverless/roadmap-tencent/issues/569