### PR TITLE
feat: Add traceId field when request apigw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.2.4](https://github.com/serverless/components/compare/v3.2.2...v3.2.4) (2020-10-17)
+
+- Feat: Add a traceId into proxy for tracing a full-chain request
+
 ## [3.2.3](https://github.com/serverless/components/compare/v3.2.2...v3.2.3) (2020-10-16)
 
 - Bug fix: Parsing CLI inputs with key-value object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/components",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "The Serverless Framework's new infrastructure provisioning technology — Build, compose, & deploy serverless apps in seconds...",
   "main": "./src/index.js",
   "bin": {
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@serverless/platform-client": "^3.1.1",
-    "@serverless/platform-client-china": "^2.0.3",
+    "@serverless/platform-client-china": "^2.0.4",
     "@serverless/platform-sdk": "^2.3.2",
     "@serverless/utils": "^2.0.0",
     "adm-zip": "^0.4.16",
@@ -60,7 +60,8 @@
     "ramda": "^0.27.1",
     "semver": "^7.3.2",
     "strip-ansi": "^6.0.0",
-    "traverse": "^0.6.6"
+    "traverse": "^0.6.6",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@serverless/eslint-config": "^3.0.0",

--- a/src/cli/commands-cn/dev.js
+++ b/src/cli/commands-cn/dev.js
@@ -9,6 +9,7 @@ const { Writable } = require('stream');
 const ansiEscapes = require('ansi-escapes');
 const chokidar = require('chokidar');
 const { ServerlessSDK, utils: chinaUtils } = require('@serverless/platform-client-china');
+const { v4: uuidv4 } = require('uuid');
 const utils = require('./utils');
 
 class LogForwardingOutput extends Writable {
@@ -168,6 +169,7 @@ module.exports = async (config, cli, command) => {
   const sdk = new ServerlessSDK({
     context: {
       orgName: instanceYaml.org,
+      traceId: uuidv4(),
     },
   });
 

--- a/src/cli/commands-cn/info.js
+++ b/src/cli/commands-cn/info.js
@@ -6,6 +6,7 @@
 
 const path = require('path');
 const { ServerlessSDK } = require('@serverless/platform-client-china');
+const { v4: uuidv4 } = require('uuid');
 const utils = require('./utils');
 const chalk = require('chalk');
 const moment = require('moment');
@@ -30,7 +31,7 @@ module.exports = async (config, cli, command) => {
   cli.sessionStatus('Initializing', instanceYaml.name);
 
   // initialize SDK
-  const sdk = new ServerlessSDK();
+  const sdk = new ServerlessSDK({ context: { traceId: uuidv4() } });
 
   // don't show the status in debug mode due to formatting issues
   if (!config.debug) {

--- a/src/cli/commands-cn/init.js
+++ b/src/cli/commands-cn/init.js
@@ -10,6 +10,7 @@ const { promisify } = require('util');
 const path = require('path');
 const stream = require('stream');
 const AdmZip = require('adm-zip');
+const { v4: uuidv4 } = require('uuid');
 const got = require('got');
 const { ServerlessSDK } = require('@serverless/platform-client-china');
 const spawn = require('child-process-ext/spawn');
@@ -99,7 +100,7 @@ const init = async (config, cli) => {
     }
   }
 
-  const sdk = new ServerlessSDK();
+  const sdk = new ServerlessSDK({ context: { traceId: uuidv4() } });
   const registryPackage = await sdk.getPackage(packageName);
   if (!registryPackage) {
     throw new Error(`Serverless Registry Package "${packageName}" does not exist.`);

--- a/src/cli/commands-cn/param.js
+++ b/src/cli/commands-cn/param.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const { ServerlessSDK, utils: tencentUtils } = require('@serverless/platform-client-china');
+const { v4: uuidv4 } = require('uuid');
 const chalk = require('chalk');
 const utils = require('./utils');
 const { version } = require('../../../package.json');
@@ -90,6 +91,7 @@ module.exports = async (config, cli, command) => {
     context: {
       orgUid,
       orgName: instanceYaml.org,
+      traceId: uuidv4(),
     },
     agent: `ComponentsCLI_${version}`,
   });

--- a/src/cli/commands-cn/registry.js
+++ b/src/cli/commands-cn/registry.js
@@ -5,6 +5,7 @@
  */
 
 const { ServerlessSDK } = require('@serverless/platform-client-china');
+const { v4: uuidv4 } = require('uuid');
 const utils = require('./utils');
 const { loadComponentConfig, loadTemplateConfig } = require('../utils');
 const { loadServerlessFile } = require('../serverlessFile');
@@ -160,7 +161,7 @@ const listFeatured = async (config, cli) => {
   cli.sessionStart('Loading');
   cli.logRegistryLogo();
 
-  const sdk = new ServerlessSDK();
+  const sdk = new ServerlessSDK({ context: { traceId: uuidv4() } });
   const {
     components: featuredComponents,
     templates: featuredTemplates,

--- a/src/cli/commands-cn/run.js
+++ b/src/cli/commands-cn/run.js
@@ -7,6 +7,7 @@
 const path = require('path');
 const { runningTemplate } = require('../utils');
 const { ServerlessSDK, utils: tencentUtils } = require('@serverless/platform-client-china');
+const { v4: uuidv4 } = require('uuid');
 const utils = require('./utils');
 const runAll = require('./runAll');
 const chalk = require('chalk');
@@ -57,6 +58,7 @@ module.exports = async (config, cli, command) => {
     context: {
       orgUid,
       orgName: instanceYaml.org,
+      traceId: uuidv4(),
     },
     agent: `ComponentsCLI_${version}`,
   });

--- a/src/cli/commands-cn/runAll.js
+++ b/src/cli/commands-cn/runAll.js
@@ -12,6 +12,7 @@ const {
 } = require('../utils');
 const { login, loadInstanceCredentials, getTemplate, handleDebugLogMessage } = require('./utils');
 const generateNotificationsPayload = require('../notifications/generate-payload');
+const { v4: uuidv4 } = require('uuid');
 const requestNotification = require('../notifications/request');
 const printNotification = require('../notifications/print-notification');
 
@@ -48,6 +49,7 @@ module.exports = async (config, cli, command) => {
     context: {
       orgUid,
       orgName: templateYaml.org,
+      traceId: uuidv4(),
     },
   });
 

--- a/src/cli/interactive-onboarding/cn.js
+++ b/src/cli/interactive-onboarding/cn.js
@@ -5,6 +5,7 @@ const chalk = require('chalk');
 const inquirer = require('@serverless/utils/inquirer');
 const confirm = require('@serverless/utils/inquirer/confirm');
 const { ServerlessSDK } = require('@serverless/platform-client-china');
+const { v4: uuidv4 } = require('uuid');
 const { isProjectPath } = require('../utils');
 const { initTemplateFromCli } = require('../commands-cn/init');
 
@@ -101,7 +102,7 @@ module.exports = async (config, cli) => {
   ) {
     return null;
   }
-  const sdk = new ServerlessSDK();
+  const sdk = new ServerlessSDK({ context: { traceId: uuidv4() } });
 
   // Fetch latest templates from registry
   const { templatesChoices, scfTemplatesChoices } = await getTemplatesFromRegistry(sdk);


### PR DESCRIPTION
## What has been implemented?
We need to use `traceId` to track the request for `apigw`, we create it in client
Closes #XXXXX

## Steps to verify

- Run X
- ...

## Todos:

- [ ] Write tests
- [ ] Write / update documentation
- [ ] Run Prettier
