### PR TITLE
feat: add origin src to inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.2.5](https://github.com/serverless/components/compare/v3.2.4...v3.2.5) (2020-10-21)
+
+- Feat: Add original src in inputs
+
 ## [3.2.4](https://github.com/serverless/components/compare/v3.2.2...v3.2.4) (2020-10-17)
 
 - Feat: Add a traceId into proxy for tracing a full-chain request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file. See [standa
 ## [3.2.5](https://github.com/serverless/components/compare/v3.2.4...v3.2.5) (2020-10-21)
 
 - Feat: Add original src in inputs
+- Improve onboarding experience in cli:
+  - Only show featured templates on sls registry (remove components)
+  - Add hit about how to initialize template
+  - Use Chinese description for templates
 
 ## [3.2.4](https://github.com/serverless/components/compare/v3.2.2...v3.2.4) (2020-10-17)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/components",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "The Serverless Framework's new infrastructure provisioning technology — Build, compose, & deploy serverless apps in seconds...",
   "main": "./src/index.js",
   "bin": {

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -105,12 +105,15 @@ const loadTencentInstanceConfig = async (directoryPath, command) => {
     instanceFile = resolveVariables(instanceFile);
     if (instanceFile.inputs.src) {
       if (typeof instanceFile.inputs.src === 'string') {
+        instanceFile.inputs.originSrc = instanceFile.inputs.src;
         instanceFile.inputs.src = path.resolve(directoryPath, instanceFile.inputs.src);
       } else if (typeof instanceFile.inputs.src === 'object') {
         if (instanceFile.inputs.src.src) {
+          instanceFile.inputs.originSrc = instanceFile.inputs.src.src;
           instanceFile.inputs.src.src = path.resolve(directoryPath, instanceFile.inputs.src.src);
         }
         if (instanceFile.inputs.src.dist) {
+          instanceFile.inputs.originDist = instanceFile.inputs.src.dist;
           instanceFile.inputs.src.dist = path.resolve(directoryPath, instanceFile.inputs.src.dist);
         }
       }


### PR DESCRIPTION
`src` will be added `absolute path`, I add another field to save the original path(src and dist), so we can show the current info on website:
<img width="1494" alt="Screen Shot 2020-10-21 at 10 17 00" src="https://user-images.githubusercontent.com/11454175/96665038-9322aa00-1386-11eb-9247-af53dab08715.png">
