### PR TITLE
Minor fixes for publish, init and deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.3.0](https://github.com/serverless/components/compare/v3.2.7...v3.3.0) (2020-10-28)
+
+- Remove `app` property requirement from `sls publish` (because it's app is determined on `init`)
+- Remove `name` and `stage` properties from root level `serverless.yml`
+- Remove inputs from the yaml file when running `serverless remove`
+- Remove support for single command deploys.
+
 ## [3.2.7](https://github.com/serverless/components/compare/v3.2.6...v3.2.7) (2020-10-23)
 
 - For `sls registry` in China, use English description as fallback if no zh-cn description is found

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/components",
-  "version": "3.2.7",
+  "version": "3.3.0",
   "description": "The Serverless Framework's new infrastructure provisioning technology — Build, compose, & deploy serverless apps in seconds...",
   "main": "./src/index.js",
   "bin": {

--- a/src/cli/commands/runAll.js
+++ b/src/cli/commands/runAll.js
@@ -159,7 +159,7 @@ module.exports = async (config, cli, command) => {
     if (failed.length) {
       cli.sessionStop(
         'error',
-        `Errors: "${command}" ran for ${succeeded.length} apps successfully. ${failed.length} failed.`
+        `Errors: "${command}" ran for ${succeeded.length} apps successfully. But, ${failed.length} failed.`
       );
       return null;
     }

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -460,13 +460,9 @@ const getTemplate = async (root) => {
       componentDirectoryFound = true;
       const instanceYaml = await loadVendorInstanceConfig(directoryPath);
 
-      const errorMessage = 'Template instances must use the same org, app & stage properties';
+      const errorMessage = 'Template instances must use the same org & stage properties';
 
       if (template.org !== null && template.org !== instanceYaml.org) {
-        throw new Error(errorMessage);
-      }
-
-      if (template.app !== null && template.app !== instanceYaml.app) {
         throw new Error(errorMessage);
       }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -110,7 +110,7 @@ module.exports = async () => {
     commands = require('./commands');
   }
 
-  let command = args._[0] || 'deploy';
+  let command = args._[0];
 
   // handle "publish" command.
   if (command === 'publish') {
@@ -138,6 +138,11 @@ module.exports = async () => {
   }
 
   try {
+    if (!command) {
+      throw new Error(
+        'Please enter a valid command. Run "serverless help" to see all available commands.'
+      );
+    }
     if (commands[command]) {
       await commands[command](config, cli, command);
     } else {

--- a/src/cli/serverlessFile.js
+++ b/src/cli/serverlessFile.js
@@ -136,22 +136,12 @@ const rootServerlessFileExists = (dir) => {
 const createRootServerlessFile = async (rootDir, serviceName, appName, orgName) => {
   const rootServerlessYmlPath = path.join(rootDir, 'serverless.yml');
 
-  // set the name
-  let rootServerlessYml = `name: ${serviceName}`;
-
-  // if app name was specified, set it
-  if (appName) {
-    rootServerlessYml = `${rootServerlessYml}\napp: ${appName}`;
-  }
+  let rootServerlessYml = `app: ${appName}`;
 
   // if org name is specified, set it
   if (orgName) {
     rootServerlessYml = `${rootServerlessYml}\norg: ${orgName}`;
   }
-
-  // there's currently no way to specify a stage in init command
-  // so we just set a default one to let users know they can change it
-  rootServerlessYml = `${rootServerlessYml}\nstage: dev`;
 
   await writeFile(rootServerlessYmlPath, rootServerlessYml);
 };

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -731,6 +731,10 @@ const executeGraph = async (allComponents, command, graph, cli, sdk, credentials
 
       if (command === 'remove') {
         let instance;
+
+        // do not pass inputs to remove command
+        instanceYaml.inputs = {};
+
         try {
           instance = await sdk.remove(instanceYaml, credentials, options);
         } catch (error) {


### PR DESCRIPTION
- Remove `app` property requirement from `sls publish` (because the app is determined on `init`)
- Remove `name` and `stage` properties from root level `serverless.yml`
- Remove inputs from the yaml file when running `serverless remove`
- Remove support for single command deploys.