### PR TITLE
Do not automatically load credentials when deploying the express component

### DIFF
--- a/src/cli/commands/dev.js
+++ b/src/cli/commands/dev.js
@@ -94,7 +94,7 @@ module.exports = async (config, cli) => {
   instanceYaml = await loadInstanceConfig(process.cwd(), { disableCache: true });
 
   // Load Instance Credentials
-  instanceCredentials = await loadInstanceCredentials(instanceYaml.stage);
+  instanceCredentials = await loadInstanceCredentials(instanceYaml);
 
   // Get access key
   const accessKey = await getAccessKey(instanceYaml.org);

--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -53,7 +53,7 @@ module.exports = async (config, cli, command) => {
   }
 
   // Load Instance Credentials
-  const instanceCredentials = await loadInstanceCredentials(instanceYaml.stage);
+  const instanceCredentials = await loadInstanceCredentials(instanceYaml);
 
   // initialize SDK
   const sdk = new ServerlessSDK({

--- a/src/cli/commands/runAll.js
+++ b/src/cli/commands/runAll.js
@@ -54,7 +54,7 @@ module.exports = async (config, cli, command) => {
   }
 
   // Load Instance Credentials
-  const credentials = await loadInstanceCredentials(templateYaml.stage);
+  const credentials = await loadInstanceCredentials(templateYaml);
 
   cli.sessionStatus('Initializing');
 

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -128,11 +128,14 @@ const getDefaultOrgName = async () => {
 /**
  * Load AWS credentials from the aws credentials file
  */
-const loadAwsCredentials = async () => {
+const loadAwsCredentials = async (instanceYaml) => {
   const awsCredsInEnv = process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY;
 
-  if (awsCredsInEnv) {
+  const componentName = instanceYaml.component.split('@')[0];
+
+  if (awsCredsInEnv || componentName === 'express') {
     // exit if the user already has aws credentials in env or .env file
+    // or if user is trying to run the express component
     return;
   }
 
@@ -216,9 +219,9 @@ const loadAwsCredentials = async () => {
  * @param {*} stage
  */
 
-const loadInstanceCredentials = async () => {
+const loadInstanceCredentials = async (instanceYaml) => {
   // load aws credentials if found
-  await loadAwsCredentials();
+  await loadAwsCredentials(instanceYaml);
 
   // Known Provider Environment Variables and their SDK configuration properties
   const providers = {};
@@ -319,7 +322,7 @@ const loadVendorInstanceConfig = async (directoryPath, options = { disableCache:
 
   if (instanceFile.inputs) {
     // load credentials to process .env files before resolving env variables
-    await loadInstanceCredentials(instanceFile.stage);
+    await loadInstanceCredentials(instanceFile);
     instanceFile = resolveVariables(instanceFile);
 
     if (instanceFile.inputs.src) {


### PR DESCRIPTION
Only allows the user to explicitly set credentials with `.env` file, or providers.