### PR TITLE
Don't auto generate serverless.yml when sls deploy --target

### DIFF
--- a/src/cli/commands-cn/run.js
+++ b/src/cli/commands-cn/run.js
@@ -25,7 +25,12 @@ module.exports = async (config, cli, command) => {
 
   const hasPackageJson = await fileExists(path.join(process.cwd(), 'package.json'));
 
-  if (command === 'deploy' && !getServerlessFilePath(process.cwd()) && hasPackageJson) {
+  if (
+    command === 'deploy' &&
+    !getServerlessFilePath(process.cwd()) &&
+    hasPackageJson &&
+    !config.target
+  ) {
     const generatedYML = await utils.generateYMLForNodejsProject(cli);
     await fs.promises.writeFile(path.join(process.cwd(), 'serverless.yml'), generatedYML, 'utf8');
     loadInstanceConfig.clear();


### PR DESCRIPTION
When user run `sls deploy --target subFolder` in a folder, if there's no `serverless.yml` but a `package.json` file in the current folder. This command will try to auto-generate a serverless.yml. Which is not right.