### PR TITLE
BUG FIX - dev mode does not watch parent directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.6.1](https://github.com/serverless/components/compare/v3.6.0...v3.6.1) (2021-01-28)
+
+- Fix a bug when using dev mode and the src input is pointing to a parent directory
+
 ## [3.6.0](https://github.com/serverless/components/compare/v3.5.1...v3.6.0) (2021-01-28)
 
 - [Remove support for loading AWS credentials from the ~/.aws/credentials file.](https://github.com/serverless/components/pull/878)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/components",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "The Serverless Framework's new infrastructure provisioning technology — Build, compose, & deploy serverless apps in seconds...",
   "main": "./src/index.js",
   "bin": {

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -939,6 +939,24 @@ const hasServerlessConfigFile = (inputPath) => {
   return false;
 };
 
+const getInstanceConfigPath = (inputPath) => {
+  const possibleConfigFiles = [
+    'serverless.yml',
+    'serverless.yaml',
+    'serverless.json',
+    'serverless.js',
+    'serverless.ts',
+  ];
+
+  for (const possibleConfigFile of possibleConfigFiles) {
+    const possibleConfigFilePath = path.join(inputPath, possibleConfigFile);
+    if (fileExistsSync(possibleConfigFilePath)) {
+      return possibleConfigFilePath;
+    }
+  }
+  return null;
+};
+
 module.exports = {
   sleep,
   fileExists,
@@ -968,4 +986,5 @@ module.exports = {
   validateNodeModules,
   parseCliInputs,
   hasServerlessConfigFile,
+  getInstanceConfigPath,
 };


### PR DESCRIPTION
## What has been implemented?
Closes #871 

Fixes a bug where dev mode does not watch parent directories.

## Steps to verify

Run dev mode on an instance with a src input pointing to a parent directory:

```yml
component: express
name: my-app

inputs:
  src: ../src
```

Then make changes to the src files. Without this PR changes, a redeploy will not be triggered. With this PR changes, a redeploy will be triggered.


