### PR TITLE
refactor: Use `utils` instead of `platform-sdk` in `login`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.6.2](https://github.com/serverless/components/compare/v3.6.1...v3.6.2) (2021-02-04)
+
+- Use `@serverless/utils` to replace corresponding methods from `@serverless/platform-sdk`
+
 ## [3.6.1](https://github.com/serverless/components/compare/v3.6.0...v3.6.1) (2021-01-28)
 
 - Fix a bug when using dev mode and the src input is pointing to a parent directory

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@serverless/platform-client": "^3.1.5",
     "@serverless/platform-client-china": "^2.1.0",
     "@serverless/platform-sdk": "^2.3.2",
-    "@serverless/utils": "^2.2.0",
+    "@serverless/utils": "^3.1.0",
     "adm-zip": "^0.4.16",
     "ansi-escapes": "^4.3.1",
     "aws4": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "/templates"
   ],
   "dependencies": {
-    "@serverless/platform-client": "^3.1.5",
+    "@serverless/platform-client": "^3.9.1",
     "@serverless/platform-client-china": "^2.1.0",
     "@serverless/platform-sdk": "^2.3.2",
     "@serverless/utils": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/components",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "The Serverless Framework's new infrastructure provisioning technology — Build, compose, & deploy serverless apps in seconds...",
   "main": "./src/index.js",
   "bin": {

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const { ServerlessSDK } = require('@serverless/platform-client');
-const { urls, readConfigFile, writeConfigFile } = require('@serverless/platform-sdk');
+const { urls } = require('@serverless/platform-sdk');
 const open = require('open');
+const configUtils = require('@serverless/utils/config');
 
 module.exports = async (config, cli) => {
   // Offer nice presentation
@@ -32,27 +33,26 @@ module.exports = async (config, cli) => {
 
   loginData = await loginData;
 
-  const configFile = readConfigFile();
-
-  // prepare login data to save it in the FS
-  configFile.userId = loginData.id;
-  configFile.users = configFile.users || {};
-  configFile.users[loginData.id] = {
+  const loginDataToSaveInConfig = {
     userId: loginData.id,
-    name: loginData.name,
-    email: loginData.email,
-    username: loginData.username,
-    dashboard: {
-      refreshToken: loginData.refreshToken,
-      accessToken: loginData.accessToken,
-      idToken: loginData.idToken,
-      expiresAt: loginData.expiresAt,
-      username: loginData.username,
+    users: {
+      [loginData.id]: {
+        userId: loginData.id,
+        name: loginData.name,
+        email: loginData.email,
+        username: loginData.username,
+        dashboard: {
+          refreshToken: loginData.refreshToken,
+          accessToken: loginData.accessToken,
+          idToken: loginData.idToken,
+          expiresAt: loginData.expiresAt,
+          username: loginData.username,
+        },
+      },
     },
   };
-
   // save the login data in the rc file
-  writeConfigFile(configFile);
+  configUtils.set(loginDataToSaveInConfig);
 
   cli.sessionStop('success', `Successfully logged in as "${loginData.username}"`);
 

--- a/src/cli/commands/logout.js
+++ b/src/cli/commands/logout.js
@@ -1,20 +1,21 @@
 'use strict';
 
-const { getLoggedInUser, logout } = require('@serverless/platform-sdk');
+const configUtils = require('@serverless/utils/config');
+const accountUtils = require('@serverless/utils/account');
 
 module.exports = async (config, cli) => {
   cli.logLogo();
 
   cli.sessionStart('Logging out');
 
-  const user = getLoggedInUser();
+  const user = configUtils.getLoggedInUser();
 
   if (!user) {
     cli.sessionStop('error', 'You are already logged out');
     return null;
   }
 
-  await logout();
+  accountUtils.logout();
 
   cli.sessionStatus('Logged Out');
   cli.sessionStop('success', `Successfully logged out "${user.username}"`);

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -6,7 +6,6 @@
 
 const args = require('minimist')(process.argv.slice(2));
 const path = require('path');
-const { listTenants } = require('@serverless/platform-sdk');
 const { ServerlessSDK } = require('@serverless/platform-client');
 const configUtils = require('@serverless/utils/config');
 const accountUtils = require('@serverless/utils/account');
@@ -52,10 +51,12 @@ const getDefaultOrgName = async () => {
 
   // if defaultOrgName is not in RC file, fetch it from the platform
   if (!defaultOrgName) {
-    await accountUtils.refreshToken(new ServerlessSDK());
+    const sdk = new ServerlessSDK();
+    await accountUtils.refreshToken(sdk);
 
     const { username, idToken, userId } = configUtils.getLoggedInUser();
-    const orgsList = await listTenants({ username, idToken });
+    sdk.config({ accessKey: idToken });
+    const orgsList = await sdk.listOrgs(username);
 
     // filter by owner
     const filteredOrgsList = orgsList.filter((org) => org.role === 'owner');

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -6,8 +6,10 @@
 
 const args = require('minimist')(process.argv.slice(2));
 const path = require('path');
-const { refreshToken, listTenants } = require('@serverless/platform-sdk');
+const { listTenants } = require('@serverless/platform-sdk');
+const { ServerlessSDK } = require('@serverless/platform-client');
 const configUtils = require('@serverless/utils/config');
+const accountUtils = require('@serverless/utils/account');
 
 const { readdirSync, statSync } = require('fs');
 const { join, basename } = require('path');
@@ -50,7 +52,7 @@ const getDefaultOrgName = async () => {
 
   // if defaultOrgName is not in RC file, fetch it from the platform
   if (!defaultOrgName) {
-    await refreshToken();
+    await accountUtils.refreshToken(new ServerlessSDK());
 
     const { username, idToken, userId } = configUtils.getLoggedInUser();
     const orgsList = await listTenants({ username, idToken });
@@ -232,9 +234,9 @@ const getAccessKey = async (org = null) => {
   }
 
   // refresh token if it's expired.
-  // this platform-sdk method returns immediately if the idToken did not expire
+  // this accountUtils method returns immediately if the idToken did not expire
   // if it did expire, it'll refresh it and update the config file
-  await refreshToken();
+  await accountUtils.refreshToken(new ServerlessSDK());
 
   const loggedInUser = configUtils.getLoggedInUser();
 

--- a/src/cli/commands/utils.js
+++ b/src/cli/commands/utils.js
@@ -6,13 +6,7 @@
 
 const args = require('minimist')(process.argv.slice(2));
 const path = require('path');
-const {
-  readConfigFile,
-  writeConfigFile,
-  createAccessKeyForTenant,
-  refreshToken,
-  listTenants,
-} = require('@serverless/platform-sdk');
+const { readConfigFile, refreshToken, listTenants } = require('@serverless/platform-sdk');
 const configUtils = require('@serverless/utils/config');
 
 const { readdirSync, statSync } = require('fs');
@@ -266,38 +260,6 @@ const getAccessKey = async (org = null) => {
   return user.dashboard.idToken;
 };
 
-/**
- * Gets or creates an access key based on org
- * @param {*} org
- */
-const getOrCreateAccessKey = async (org) => {
-  if (process.env.SERVERLESS_ACCESS_KEY) {
-    return process.env.SERVERLESS_ACCESS_KEY;
-  }
-
-  // read config file from the user machine
-  const userConfigFile = readConfigFile();
-
-  // Verify config file
-  if (!userConfigFile || !userConfigFile.users || !userConfigFile.users[userConfigFile.userId]) {
-    return null;
-  }
-
-  const user = userConfigFile.users[userConfigFile.userId];
-
-  if (!user.dashboard.accessKeys[org]) {
-    // create access key and save it
-    const accessKey = await createAccessKeyForTenant(org);
-    userConfigFile.users[userConfigFile.userId].dashboard.accessKeys[org] = accessKey;
-    writeConfigFile(userConfigFile);
-    return accessKey;
-  }
-
-  // return the access key for the specified org
-  // return user.dashboard.accessKeys[org]
-  return user.dashboard.idToken;
-};
-
 const getTemplate = async (root) => {
   const directories = readdirSync(root).filter((f) => statSync(join(root, f)).isDirectory());
 
@@ -344,7 +306,6 @@ module.exports = {
   loadInstanceConfig: loadVendorInstanceConfig,
   getTemplate,
   loadInstanceCredentials,
-  getOrCreateAccessKey,
   getAccessKey,
   isLoggedIn,
   isLoggedInOrHasAccessKey,


### PR DESCRIPTION
## What has been implemented?

Addresses parts of: https://github.com/serverless/enterprise-plugin/issues/464

- replace `writeConfigFile` and `readConfigFile` + config-related logic with `configUtils` equivalents
- replace `platform-sdk`'s `listTenants` with `listOrgs`
- replace `platform-sdk`'s `refreshToken` with `utils` version of `refreshToken`
- remove dead code `getOrCreateAccessKey` - I've search for that in all projects in `serverless` and `serverlessinc` orgs and I didn't find anything that uses it


To make the review process easier, I've implemented all self-contained changes as separate commits. Unfortunatelly, there are not automated tests, so everything was verified by hand by running `login`, `logout`, `deploy` and `publish/unpublish` commands. 

## Steps to verify

In order to verify, I've run the following commands:

- Run `serverless login`
- Run `serverless logout`
- Run `serverless publish` with a new component and remove default org from `.serverlessrc` (so it is actually fetched via SDK call)

After each step, assess that the content of the `.serverlessrc` file looks like expected (functionally it should work the same as previously). 

