### PR TITLE
Fixing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ npm i -g serverless
 Login into the Serverless dashboard via the CLI:
 
 ```
-$ serverlesss login
+$ serverless login
 ```
 
 **Before you proceed, make sure you connect your AWS account by creating a provider in the settings page on the [Serverless Dashboard](https://app.serverless.com).**


### PR DESCRIPTION
## What has been implemented?

Fixing typo - serverless has an extra 's'