### PR TITLE
chore: Drop `@serverless/platform-sdk` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,8 @@
     "/templates"
   ],
   "dependencies": {
-    "@serverless/platform-client": "^4.0.0",
+    "@serverless/platform-client": "^4.2.0",
     "@serverless/platform-client-china": "^2.1.0",
-    "@serverless/platform-sdk": "^2.3.2",
     "@serverless/utils": "^3.1.0",
     "adm-zip": "^0.4.16",
     "ansi-escapes": "^4.3.1",

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { ServerlessSDK } = require('@serverless/platform-client');
-const { urls } = require('@serverless/platform-sdk');
 const open = require('open');
 const configUtils = require('@serverless/utils/config');
 
@@ -12,13 +11,9 @@ module.exports = async (config, cli) => {
 
   const sdk = new ServerlessSDK();
 
-  const loginConfig = {
-    ...urls,
-  };
-
   // for some reason this env var is required by the SDK in order to open the browser
   process.env.DISPLAY = true;
-  let { loginUrl, loginData } = await sdk.login(loginConfig); // eslint-disable-line
+  let { loginUrl, loginData } = await sdk.login(); // eslint-disable-line
 
   cli.log();
   cli.log(


### PR DESCRIPTION
## What has been implemented?

Removes dependency on `urls` as passing `loginBrokerUrl` explicitly to `platform-client`'s login is no longer needed. In turn, that allows us to drop `@serverless/platform-sdk` altogether.'

I tested it locally with `login` and `logout` commands.

## Steps to verify

- Manually login & logout
