### PR TITLE
fix: check invalid inline comments in env file

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -107,19 +107,24 @@ module.exports = async () => {
 
   // Check env file whether or not containing an inline comment, which is invalid for the dotenv package's parsing: https://github.com/motdotla/dotenv/issues/484
   if (dotEnvContent && dotEnvContent.parsed) {
+    const regexForComment = / #+.*$/g;
     const envKeys = Object.keys(dotEnvContent.parsed);
     envKeys.forEach((key) => {
       const envValue = dotEnvContent.parsed[key];
-      if (envValue.includes('#')) {
+      if (regexForComment.test(envValue)) {
         if (isChinaUser()) {
-          cli.log(`${key}的值为:${envValue}, 含有不正确内容，请修改后重试(不支持行内注释)`, 'red');
+          cli.log(
+            chalk.yellow(
+              `在dotenv配置中字段${key}发现 #,请确保注释都写在单独由#开头的新一行, 不支持行内注释。详情查看：https://github.com/motdotla/dotenv#rules`
+            )
+          );
         } else {
           cli.log(
-            `The value of ${key} is: ${envValue}, which contains invalid content, please retry it after changing(No support for inline comment)`,
-            'red'
+            chalk.yellow(
+              `Found field ${key} in dotenv file has # symbol, please ensure all comments begin with a # symbol on a new line，no support for inline comment. Detail: https://github.com/motdotla/dotenv#rules`
+            )
           );
         }
-        process.exit();
       }
     });
   }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -107,21 +107,21 @@ module.exports = async () => {
 
   // Check env file whether or not containing an inline comment, which is invalid for the dotenv package's parsing: https://github.com/motdotla/dotenv/issues/484
   if (dotEnvContent && dotEnvContent.parsed) {
-    const regexForComment = / #+.*$/g;
     const envKeys = Object.keys(dotEnvContent.parsed);
     envKeys.forEach((key) => {
+      const regexForComment = / #+.*$/g;
       const envValue = dotEnvContent.parsed[key];
       if (regexForComment.test(envValue)) {
         if (isChinaUser()) {
           cli.log(
             chalk.yellow(
-              `在dotenv配置中字段${key}发现 #,请确保注释都写在单独由#开头的新一行, 不支持行内注释。详情查看：https://github.com/motdotla/dotenv#rules`
+              `在dotenv配置中字段${key}发现 #,请确保注释都写在单独由#开头的新一行, 不支持行内注释。详情查看：https://github.com/motdotla/dotenv#rules\n`
             )
           );
         } else {
           cli.log(
             chalk.yellow(
-              `Found field ${key} in dotenv file has # symbol, please ensure all comments begin with a # symbol on a new line，no support for inline comment. Detail: https://github.com/motdotla/dotenv#rules`
+              `Found field ${key} in dotenv file has # symbol, please ensure all comments begin with a # symbol on a new line，no support for inline comment. Detail: https://github.com/motdotla/dotenv#rules\n`
             )
           );
         }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -105,6 +105,25 @@ module.exports = async () => {
     }
   }
 
+  // Check env file whether or not containing an inline comment, which is invalid for the dotenv package's parsing: https://github.com/motdotla/dotenv/issues/484
+  if (dotEnvContent && dotEnvContent.parsed) {
+    const envKeys = Object.keys(dotEnvContent.parsed);
+    envKeys.forEach((key) => {
+      const envValue = dotEnvContent.parsed[key];
+      if (envValue.includes('#')) {
+        if (isChinaUser()) {
+          cli.log(`${key}的值为:${envValue}, 含有不正确内容，请修改后重试(不支持行内注释)`, 'red');
+        } else {
+          cli.log(
+            `The value of ${key} is: ${envValue}, which contains invalid content, please retry it after changing(No support for inline comment)`,
+            'red'
+          );
+        }
+        process.exit();
+      }
+    });
+  }
+
   /**
    * Handle interactive onboarding when using the "serverless" command for China-based users
    */


### PR DESCRIPTION
## What has been implemented?

Closes https://github.com/serverless/roadmap-tencent/issues/787

Currently, the `dotenv` can not remove **# inline comment** in the env file: https://github.com/motdotla/dotenv/issues/484, which will cause error when users use inline comments. This PR will check this situation and throw an message.

**Question**: Is it possible that the value in the `env file` itself contains the # symbol?