### PR TITLE
release: 3.7.2 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 3.7.2 (2021-03-03)
+
+- Show warning messgae for inline comments in the `dotenv` file: https://github.com/serverless/components/pull/898
+- Fix the bug which can't request new login permission without a `dotenv` file: https://github.com/serverless/components/pull/899
+
 ## 3.7.1 (2021-02-24)
 
 - unsupported command error message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## 3.7.2 (2021-03-03)
+## [3.7.2](https://github.com/serverless/components/compare/v3.7.1...v3.7.2) (2021-03-03)
 
-- Show warning messgae for inline comments in the `dotenv` file: https://github.com/serverless/components/pull/898
+- Show warning message for inline comments in the `dotenv` file: https://github.com/serverless/components/pull/898
 - Fix the bug which can't request new login permission without a `dotenv` file: https://github.com/serverless/components/pull/899
 
-## 3.7.1 (2021-02-24)
+## [3.7.1](https://github.com/serverless/components/compare/v3.7.0...v3.7.1) (2021-02-24)
 
 - unsupported command error message
 - Force cancel dev mode can't enter dev mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/components",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "The Serverless Framework's new infrastructure provisioning technology — Build, compose, & deploy serverless apps in seconds...",
   "main": "./src/index.js",
   "bin": {


### PR DESCRIPTION
- Show warning messgae for inline comments in the `dotenv` file: https://github.com/serverless/components/pull/898
- Fix the bug which can't request new login permission without a `dotenv` file: https://github.com/serverless/components/pull/899