### PR TITLE
fix: Do not try to close debug mode for non-nodejs runtime project

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@serverless/platform-client": "^4.2.0",
-    "@serverless/platform-client-china": "^2.1.0",
+    "@serverless/platform-client-china": "^2.1.6",
     "@serverless/utils": "^3.1.0",
     "adm-zip": "^0.4.16",
     "ansi-escapes": "^4.3.1",

--- a/src/cli/commands-cn/dev.js
+++ b/src/cli/commands-cn/dev.js
@@ -52,7 +52,12 @@ const getInstanceInfo = async (sdk, instance) => {
  */
 async function deploy(sdk, instance, credentials) {
   // The new debug api does not support deploying instance while it's in debugging mode, so stop it before deployment
-  if (functionInfoStore && regionStore && cliEventCallback) {
+  if (
+    functionInfoStore &&
+    regionStore &&
+    cliEventCallback &&
+    chinaUtils.doesRuntimeSupportDebug(functionInfoStore.runtime)
+  ) {
     await chinaUtils.stopTencentRemoteLogAndDebug(functionInfoStore, regionStore, cliEventCallback);
   }
   let instanceInfo = {};
@@ -243,7 +248,7 @@ module.exports = async (config, cli, command) => {
       if (!namespaceInfo && scf) {
         namespaceInfo = scf.namespace;
       }
-      if (lambdaArn && runtimeInfo && region) {
+      if (lambdaArn && runtimeInfo && region && chinaUtils.doesRuntimeSupportDebug(runtime)) {
         functionInfoStore = {
           functionName: lambdaArn,
           namespace: namespaceInfo,


### PR DESCRIPTION
## What has been implemented?

Closes https://github.com/serverless/roadmap-tencent/issues/795

## Steps to verify

- Run X
- ...

## Todos:

- [ ] Write tests
- [ ] Write / update documentation
- [ ] Run Prettier
