### PR TITLE
fix permission lost issue when `sls init`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@serverless/platform-client": "^4.2.0",
     "@serverless/platform-client-china": "^2.1.6",
     "@serverless/utils": "^3.1.0",
-    "adm-zip": "^0.4.16",
+    "adm-zip": "^0.5.4",
     "ansi-escapes": "^4.3.1",
     "chalk": "^4.1.0",
     "child-process-ext": "^2.1.1",


### PR DESCRIPTION
[This bug](https://github.com/cthackers/adm-zip/issues/342) in adm-zip is fixed in v0.5.x
We need to update adm-zip version to close: #872