### PR TITLE
feat: Store `user_uid` as `userId` in local config

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "/templates"
   ],
   "dependencies": {
-    "@serverless/platform-client": "^4.2.0",
+    "@serverless/platform-client": "^4.2.1",
     "@serverless/platform-client-china": "^2.1.6",
     "@serverless/utils": "^3.1.0",
     "adm-zip": "^0.5.4",

--- a/src/cli/commands/login.js
+++ b/src/cli/commands/login.js
@@ -28,11 +28,14 @@ module.exports = async (config, cli) => {
 
   loginData = await loginData;
 
+  // In `.serverlessrc`, we want to use `user_uid` as `userId` if it's available
+  const userId = loginData.user_uid || loginData.id;
+
   const loginDataToSaveInConfig = {
-    userId: loginData.id,
+    userId,
     users: {
-      [loginData.id]: {
-        userId: loginData.id,
+      [userId]: {
+        userId,
         name: loginData.name,
         email: loginData.email,
         username: loginData.username,


### PR DESCRIPTION
## What has been implemented?

Use `user_uid` if available as `userId` persisted in local `.serverlessrc` file

Related Asana ticket: https://app.asana.com/0/1200011721510709/1200049124629396

## Steps to verify

Manually test login/logout 

