### PR TITLE
reserve comments for templates

### DIFF
--- a/src/cli/commands-cn/init.js
+++ b/src/cli/commands-cn/init.js
@@ -73,7 +73,7 @@ const initTemplateFromCli = async (targetPath, packageName, registryPackage, cli
   const ymlParsed = await parseYaml(serverlessFilePath);
 
   if (appName && ymlParsed.app) {
-    const newYmlContent = ymlOriginal.replace(/^app:\s\S*/m, `app: ${appName}`, 'm');
+    const newYmlContent = ymlOriginal.replace(/^app:\s\S*/m, `app: ${appName}`);
     await fse.writeFile(serverlessFilePath, newYmlContent, 'utf8');
   }
 

--- a/src/cli/commands-cn/init.js
+++ b/src/cli/commands-cn/init.js
@@ -73,7 +73,7 @@ const initTemplateFromCli = async (targetPath, packageName, registryPackage, cli
   const ymlParsed = await parseYaml(serverlessFilePath);
 
   if (appName && ymlParsed.app) {
-    const newYmlContent = ymlOriginal.replace(/^app:\s(.*)/i, `app: ${appName}`);
+    const newYmlContent = ymlOriginal.replace(/^app:\s\S*/m, `app: ${appName}`, 'm');
     await fse.writeFile(serverlessFilePath, newYmlContent, 'utf8');
   }
 

--- a/src/cli/commands-cn/init.js
+++ b/src/cli/commands-cn/init.js
@@ -68,12 +68,19 @@ const initTemplateFromCli = async (targetPath, packageName, registryPackage, cli
       await fse.createFile(serverlessFilePath);
     }
   }
-  const serverlessFile = await parseYaml(serverlessFilePath);
-  if (appName) {
-    serverlessFile.app = appName;
+
+  const ymlOriginal = await fse.readFile(serverlessFilePath, 'utf8');
+  const ymlParsed = await parseYaml(serverlessFilePath);
+
+  if (appName && ymlParsed.app) {
+    const newYmlContent = ymlOriginal.replace(/^app:\s(.*)/i, `app: ${appName}`);
+    await fse.writeFile(serverlessFilePath, newYmlContent, 'utf8');
   }
 
-  await saveYaml(serverlessFilePath, serverlessFile);
+  if (appName && !ymlParsed.app) {
+    ymlParsed.app = appName;
+    await saveYaml(serverlessFilePath, ymlParsed);
+  }
 
   cli.sessionStatus('app.YAML processd end');
 


### PR DESCRIPTION
> issue: https://app.asana.com/0/1200011502754281/1200078207478206

This PR helps to reserve the comments in the serverless.yml of templates

## Before

`sls init eggjs-starter`
<img width="396" alt="Screen Shot 2021-03-23 at 1 25 58 PM" src="https://user-images.githubusercontent.com/5512552/112097713-757a9a80-8bdb-11eb-9316-c12528d7ffdb.png">

## After

<img width="793" alt="Screen Shot 2021-03-23 at 1 26 42 PM" src="https://user-images.githubusercontent.com/5512552/112097727-7b707b80-8bdb-11eb-81ac-df84d748c539.png">
