### PR TITLE
Check latest components version and ask users to upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "https-proxy-agent": "^5.0.0",
     "inquirer-autocomplete-prompt": "^1.3.0",
     "js-yaml": "^3.14.1",
-    "latest-version": "^5.1.0",
     "memoizee": "^0.4.14",
     "minimist": "^1.2.5",
     "moment": "^2.29.1",
@@ -59,6 +58,7 @@
     "semver": "^7.3.4",
     "strip-ansi": "^6.0.0",
     "traverse": "^0.6.6",
+    "update-notifier": "^5.1.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "https-proxy-agent": "^5.0.0",
     "inquirer-autocomplete-prompt": "^1.3.0",
     "js-yaml": "^3.14.1",
+    "latest-version": "^5.1.0",
     "memoizee": "^0.4.14",
     "minimist": "^1.2.5",
     "moment": "^2.29.1",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -14,7 +14,6 @@ const chalk = require('chalk');
 const HttpsProxyAgent = require('https-proxy-agent');
 const CLI = require('./CLI');
 const { loadInstanceConfig, fileExistsSync, isProjectPath, isChinaUser } = require('./utils');
-const updateNotifier = require('update-notifier');
 
 module.exports = async () => {
   const args = minimist(process.argv.slice(2));
@@ -147,6 +146,7 @@ module.exports = async () => {
       "检测到当前目录下已有 serverless 项目，请通过 'sls deploy' 进行部署，或在新路径下完成 serverless 项目初始化";
 
     // For non China versions we have upgrade notifications configured through backend notifications service
+    const updateNotifier = require('update-notifier');
     const notifier = updateNotifier({
       pkg: require('../../package.json'),
       // Show update notification one time a day at most, this is done to not be annoying to the user

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -204,11 +204,7 @@ module.exports = async () => {
           )
         );
       } else {
-        cli.log(
-          chalk.yellow(
-            '发现新的 CLI 版本，建议通过 npm install -g serverless 进行升级'
-          )
-        ); 
+        cli.log(chalk.yellow('发现新的 CLI 版本，建议通过 npm install -g serverless 进行升级'));
       }
     }
   } catch (error) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -12,6 +12,7 @@ const dotenv = require('dotenv');
 const semver = require('semver');
 const chalk = require('chalk');
 const HttpsProxyAgent = require('https-proxy-agent');
+const getLatestVersion = require('latest-version');
 const CLI = require('./CLI');
 const { loadInstanceConfig, fileExistsSync, isProjectPath, isChinaUser } = require('./utils');
 
@@ -183,6 +184,32 @@ module.exports = async () => {
       await commands[command](config, cli, command);
     } else {
       await commands.run(config, cli, command);
+    }
+
+    // Check if there is new version of components
+    const latestVersion = await getLatestVersion('@serverless/components');
+    const currentVersion = require('../../package.json').version;
+    const latestVersionData = semver.parse(latestVersion);
+    const currentVersionData = semver.parse(currentVersion);
+
+    if (
+      latestVersionData.major > currentVersionData.major ||
+      latestVersionData.minor > currentVersionData.minor
+    ) {
+      // TODO: Better message for users
+      if (!isChinaUser()) {
+        cli.log(
+          chalk.yellow(
+            `New version of serverless components CLI available! Run npm install -g serverless to update!`
+          )
+        );
+      } else {
+        cli.log(
+          chalk.yellow(
+            `发现新的 CLI 版本，建议通过 npm install -g serverless 进行升级`
+          )
+        ); 
+      }
     }
   } catch (error) {
     process.exitCode = 1;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -186,7 +186,7 @@ module.exports = async () => {
       await commands.run(config, cli, command);
     }
 
-    // Check if there is new version of components
+    // Check if there is newer version of Components
     const latestVersion = await getLatestVersion('@serverless/components');
     const currentVersion = require('../../package.json').version;
     const latestVersionData = semver.parse(latestVersion);
@@ -200,13 +200,13 @@ module.exports = async () => {
       if (!isChinaUser()) {
         cli.log(
           chalk.yellow(
-            `New version of serverless components CLI available! Run npm install -g serverless to update!`
+            'New version of serverless components CLI available! Run npm install -g serverless to update!'
           )
         );
       } else {
         cli.log(
           chalk.yellow(
-            `发现新的 CLI 版本，建议通过 npm install -g serverless 进行升级`
+            '发现新的 CLI 版本，建议通过 npm install -g serverless 进行升级'
           )
         ); 
       }


### PR DESCRIPTION
> https://app.asana.com/0/1200011502754281/1200090410758582

## What has been implemented?

Check the latest Components version and recommend users to upgrade if they are using an older version.
It works similar to npm, when a user is using an older version of npm, npm will recommend the user to upgrade the CLI:

<img width="587" alt="Screen Shot 2021-03-25 at 11 38 19 AM" src="https://user-images.githubusercontent.com/5512552/112427865-413ae180-8d75-11eb-8896-323d2ea95ffd.png">


I am aware that for the traditional CLI, we have introduced an `autoUpdate.enabled` configuration for users, users can use this setting to decide if they would like the CLI to check the latest version and upgrade itself after executing commands. ([PR](https://github.com/serverless/serverless/pull/8428)). 

But as we don't have a global configuration file for Components to store user's settings, I think recommending users to upgrade the CLI themselves might be a good idea

## Other info
I used the [latest-version](https://github.com/sindresorhus/latest-version) package to check latest version of components, because directly requesting `registry.npmjs.org` may be slow for many Chinese users, and [latest-version](https://github.com/sindresorhus/latest-version) is able to request to the registry users configured for themselves.
