### PR TITLE
Display complete outputs

### DIFF
--- a/src/cli/CLI.js
+++ b/src/cli/CLI.js
@@ -477,6 +477,7 @@ class CLI {
               true: null,
               false: null,
             },
+            maxDepth: 10,
           },
           indent
         )


### PR DESCRIPTION
## What has been implemented?

https://app.asana.com/0/1200011502754281/1200168199767450

Previously

<img width="688" alt="Screen Shot 2021-04-12 at 12 43 11 PM" src="https://user-images.githubusercontent.com/5512552/114341589-b9364380-9b8c-11eb-90a7-618e3ae9aa5e.png">

After

<img width="668" alt="Screen Shot 2021-04-12 at 12 41 32 PM" src="https://user-images.githubusercontent.com/5512552/114341605-bf2c2480-9b8c-11eb-993d-a52f832cbcd1.png">
