### PR TITLE
fix: replace `jsome` with `util.inspect`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "https-proxy-agent": "^5.0.0",
     "inquirer-autocomplete-prompt": "^1.3.0",
     "js-yaml": "^3.14.1",
-    "jsome": "^2.5.0",
     "memoizee": "^0.4.14",
     "minimist": "^1.2.5",
     "open": "^7.3.1",

--- a/src/cli/commands-cn/invoke/index.js
+++ b/src/cli/commands-cn/invoke/index.js
@@ -6,7 +6,7 @@ const utils = require('../utils');
 const { isJson } = require('../../utils');
 const invokeLocal = require('./invoke-local');
 const chalk = require('chalk');
-const jsome = require('jsome');
+const { inspect } = require('util');
 
 /**
  * --stage / -s Set stage
@@ -105,7 +105,7 @@ module.exports = async (config, cli, command) => {
       cli.log();
       try {
         const retJson = JSON.parse(retMsg);
-        jsome(retJson);
+        cli.log(inspect(retJson, { depth: Infinity, colors: true, compact: 0 }));
       } catch (error) {
         cli.log(retMsg);
       }

--- a/src/cli/commands-cn/invoke/invoke-local/index.js
+++ b/src/cli/commands-cn/invoke/invoke-local/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const jsome = require('jsome');
+const { inspect } = require('util');
 
 const utils = require('../../utils');
 const { readAndParseSync, fileExistsSync } = require('../../../utils');
@@ -47,7 +47,7 @@ module.exports = async (config, cli, command) => {
       const result = await finalInvokedFunc(eventData, contextData);
       cli.log('---------------------------------------------');
       colorLog('调用成功', 'green', cli);
-      jsome(result);
+      cli.log(inspect(result, { depth: Infinity, colors: true, compact: 0 }));
       cli.log();
     } catch (e) {
       cli.log('---------------------------------------------');


### PR DESCRIPTION
## What has been implemented?

https://github.com/serverless/components/pull/948#issuecomment-845635059

`jsome` looks to be abandoned, and uses a vulnerable version of `yargs` (which is also not required in this context, since it's not being used as a cli).

This replaces `jsome` with Node's native `util.inspect` function, which should provide the same approximate functionality.

## Steps to verify

- Run `npm i`
- Check the output for `found 0 vulnerabilities` 🎉 

## Todos:

- [x] Write tests
- [x] Write / update documentation
- [x] Run Prettier
