### PR TITLE
Fix: fix help info for template

### DIFF
--- a/src/legacy.js
+++ b/src/legacy.js
@@ -17,7 +17,7 @@ const {
 // These keywords are intercepted by the Serverless Components CLI
 const componentKeywords = new Set(['registry', 'init', 'publish']);
 // These keywords are allowed for nested templates
-const nestedTemplateKeywords = new Set(['deploy', 'remove', 'info']);
+const nestedTemplateKeywords = new Set(['deploy', 'remove', 'info', 'help', '--help']);
 
 const runningComponents = () => {
   const args = minimist(process.argv.slice(2));
@@ -28,6 +28,7 @@ const runningComponents = () => {
   // load components if user runs a keyword command, or "sls --all" or "sls --target" (that last one for china)
   if (
     componentKeywords.has(process.argv[2]) ||
+    // run sls help or sls --help inside a template, will get help information from components.
     (nestedTemplateKeywords.has(process.argv[2]) && runningTemplate(process.cwd())) ||
     args.target ||
     args['help-components'] // if user runs "serverless --help-components" in ANY context, show components help


### PR DESCRIPTION
When running `help command` within a template project, should print help info from help of components.