### PR TITLE
fix invoke lcoal for python runtime

### DIFF
--- a/src/cli/commands-cn/invoke/invoke-local/index.js
+++ b/src/cli/commands-cn/invoke/invoke-local/index.js
@@ -27,14 +27,14 @@ module.exports = async (config, cli, command) => {
     colorLog('当前命令只支持 SCF 组件，请在 SCF 组件目录内使用', 'yellow', cli);
   }
 
-  const runtime = inputs.runtime;
-  checkRuntime(runtime, cli);
-
   const [eventData, contextData, handlerFile, handlerFunc] = summaryOptions(
     config,
     instanceYml,
     cli
   );
+
+  const runtime = inputs.runtime;
+  checkRuntime(runtime, cli);
 
   if (runtime.includes('Nodejs')) {
     const invokeFromFile = path.join(process.cwd(), handlerFile);

--- a/src/cli/commands-cn/invoke/invoke-local/runPython.js
+++ b/src/cli/commands-cn/invoke/invoke-local/runPython.js
@@ -12,6 +12,7 @@ module.exports = async (event, context, handlerFile, handlerFunc, cli) => {
   fse.createFileSync(tempResFile);
 
   const tempPyFileContent = `
+# -*- coding: utf-8 -*-
 import json
 from ${handlerFile} import ${handlerFunc}
 
@@ -22,7 +23,9 @@ f.close()`;
 
   fse.writeFileSync(tempPyFile, tempPyFileContent);
   try {
-    const res = spawn('python', [path.join(process.cwd(), tempPyFile)]);
+    const res = spawn(`${process.env.INVOKE_LOCAL_PYTHON || 'python'}`, [
+      path.join(process.cwd(), tempPyFile),
+    ]);
     res.stdout.on('data', (d) => {
       console.log(d.toString());
     });

--- a/src/cli/commands-cn/invoke/invoke-local/utils.js
+++ b/src/cli/commands-cn/invoke/invoke-local/utils.js
@@ -30,7 +30,11 @@ const checkRuntime = (requiredRuntime, cli) => {
   } else if (requiredRuntime.includes('Python')) {
     let pythonInfo;
     try {
-      pythonInfo = execSync('python -c "import platform; print(platform.python_version())"');
+      pythonInfo = execSync(
+        `${
+          process.env.INVOKE_LOCAL_PYTHON || 'python'
+        } -c "import platform; print(platform.python_version())"`
+      );
       pythonInfo = Buffer.from(pythonInfo).toString();
     } catch (e) {
       throw new Error(`检查当前环境的Python 运行时出错，错误信息: ${e.message}`);
@@ -63,6 +67,7 @@ const summaryOptions = (config, instanceYml, cli) => {
     context,
     contextPath,
     x,
+    py,
   } = config;
   const { inputs = {}, component } = instanceYml;
 
@@ -121,6 +126,11 @@ const summaryOptions = (config, instanceYml, cli) => {
     for (const [k, v] of Object.entries(inputs.environment.variables)) {
       process.env[k] = v;
     }
+  }
+
+  // For python runtime, users can set python execution by --py: sls invoke local --python python3
+  if (py) {
+    process.env.INVOKE_LOCAL_PYTHON = py;
   }
 
   // Deal with scf component(single instance situation)


### PR DESCRIPTION
1. 添加 **utf8** 编码格式，防止乱码
2. 允许用户指定 使用哪一个python