### PR TITLE
--function param for invoke/logs command

### DIFF
--- a/src/cli/commands-cn/help.js
+++ b/src/cli/commands-cn/help.js
@@ -94,7 +94,7 @@ ${description(`    --profile                使用指定身份的全局授权信
 `)}`,
     'logs': `
 ${command2('logs')}                      查看应用日志
-${description(`    --function / -f          查看指定函数的日志，默认使用配置的函数
+${description(`    --function / -f          查看多函数组件的指定函数日志(单函数组件无需指定)
     --startTime              指定开始时间，如：3h, 20130208T080910，默认10m
     --tail / -t              启动监听模式
     --intervial / -i         监听模式的刷新时间 默认：2000ms
@@ -130,7 +130,7 @@ ${command2('bind role')}                 重新为当前用户分配使用 Serve
 `,
     'invoke': `
 ${command2('invoke')}                    调用函数
-${description(`    --function / -f          调用的函数名称，默认使用配置的函数
+${description(`    --function / -f          调用的多函数组件的函数名称(单函数组件无需指定)
     --stage / -s             指定环境名称，默认使用配置环境
     --region / -r            指定地区名称，默认使用配置地区
     --data / -d              指定传入函数的事件(event)参数数据，需要使用序列化的 JSON 格式
@@ -138,7 +138,7 @@ ${description(`    --function / -f          调用的函数名称，默认使用
 `)}`,
     'invoke local': `
 ${command2('invoke local')}              本地调用函数
-${description(`    --function / -f          调用的函数名称，默认使用配置的函数
+${description(`    --function / -f          调用的多函数组件的函数名称(单函数组件无需指定)
     --data / -d              指定传入函数的事件(event)参数数据，需要使用序列化的 JSON 格式
     --path / -p              指定传入还输的事件(event)参数的 JSON 文件路径
     --context                指定传入函数的上下文(context)参数数据，需要使用序列化的 JSON 格式

--- a/src/cli/commands-cn/invoke/index.js
+++ b/src/cli/commands-cn/invoke/index.js
@@ -25,7 +25,7 @@ module.exports = async (config, cli, command) => {
     return invokeLocal(config, cli, command);
   }
 
-  const { stage, s, region, r, data, d, path, p, function: originalFunctionAlias, f} = config;
+  const { stage, s, region, r, data, d, path, p, function: originalFunctionAlias, f } = config;
   const stageValue = stage || s;
   const regionValue = region || r;
   let dataValue = data || d;

--- a/src/cli/commands-cn/invoke/index.js
+++ b/src/cli/commands-cn/invoke/index.js
@@ -56,14 +56,14 @@ module.exports = async (config, cli, command) => {
   const regionInYml = instanceYaml && instanceYaml.inputs && instanceYaml.inputs.region;
   const componentType = instanceYaml && instanceYaml.component;
 
-  if (componentType !== 'scf' || componentType !== 'multi-scf') {
+  if (!componentType.startsWith('scf') || !componentType.startsWith('multi-scf')) {
     cli.log(`Serverless: ${chalk.yellow('Inovke 命令仅能在 scf 或者 multi-scf 组件目录中调用')}`);
     process.exit();
   }
 
   let functionName;
   try {
-    if (componentType === 'multi-scf') {
+    if (componentType.startsWith('multi-scf')) {
       functionName = utils.getFunctionNameOfMultiScf(instanceYaml, stageValue, functionAlias);
     } else {
       functionName = utils.getFunctionName(instanceYaml, stageValue);

--- a/src/cli/commands-cn/invoke/index.js
+++ b/src/cli/commands-cn/invoke/index.js
@@ -13,6 +13,7 @@ const { inspect } = require('util');
  * --region / -r Set region
  * --data / -d Data sent to SCF
  * --path / -p Data path sent to SCF
+ * --function / -f function alias
  */
 module.exports = async (config, cli, command) => {
   const instanceDir = process.cwd();
@@ -24,11 +25,12 @@ module.exports = async (config, cli, command) => {
     return invokeLocal(config, cli, command);
   }
 
-  const { stage, s, region, r, data, d, path, p } = config;
+  const { stage, s, region, r, data, d, path, p, function: originalFunctionAlias, f} = config;
   const stageValue = stage || s;
   const regionValue = region || r;
   let dataValue = data || d;
   const pathValue = path || p;
+  const functionAlias = originalFunctionAlias || f;
 
   if (dataValue && pathValue) {
     cli.log(`Serverless: ${chalk.yellow('不能同时指定 data 与 path, 请检查后重试')}`);
@@ -54,32 +56,23 @@ module.exports = async (config, cli, command) => {
   const regionInYml = instanceYaml && instanceYaml.inputs && instanceYaml.inputs.region;
   const componentType = instanceYaml && instanceYaml.component;
 
-  if (componentType !== 'scf') {
-    cli.log(`Serverless: ${chalk.yellow('Inovke 命令仅能在 SCF 组件目录中调用')}`);
+  if (componentType !== 'scf' || componentType !== 'multi-scf') {
+    cli.log(`Serverless: ${chalk.yellow('Inovke 命令仅能在 scf 或者 multi-scf 组件目录中调用')}`);
     process.exit();
   }
 
   let functionName;
-  if (instanceYaml && instanceYaml.inputs && instanceYaml.inputs.name) {
-    functionName = instanceYaml.inputs.name.trim();
-    functionName = functionName.replace('${name}', instanceYaml.name);
-    functionName = functionName.replace('${app}', instanceYaml.app);
-    if (typeof functionName === 'string' && !functionName.includes('${stage}') && stageValue) {
-      cli.log(
-        `Serverless: ${chalk.yellow(
-          '当前应用自定义 SCF 实例名称无法指定 stage 信息, 请检查后重试'
-        )}`
-      );
-      process.exit();
+  try {
+    if (componentType === 'multi-scf') {
+      functionName = utils.getFunctionNameOfMultiScf(instanceYaml, stageValue, functionAlias);
+    } else {
+      functionName = utils.getFunctionName(instanceYaml, stageValue);
     }
-    functionName = functionName.replace('${stage}', stageValue || instanceYaml.stage);
-    if (functionName.match(/\${(\w*:?[\w\d.-]+)}/g)) {
-      cli.log(`Serverless: ${chalk.yellow('目前 inputs.name 只支持 stage, name, app 三种变量')}`);
-      process.exit();
-    }
-  } else {
-    functionName = `${instanceYaml.name}-${stageValue || instanceYaml.stage}-${instanceYaml.app}`;
+  } catch (error) {
+    cli.log(`Serverless: ${chalk.yellow(error.message)}`);
+    process.exit();
   }
+
   const client = new FaaS({
     secretId: process.env.TENCENT_SECRET_ID,
     secretKey: process.env.TENCENT_SECRET_KEY,

--- a/src/cli/commands-cn/invoke/index.js
+++ b/src/cli/commands-cn/invoke/index.js
@@ -56,7 +56,7 @@ module.exports = async (config, cli, command) => {
   const regionInYml = instanceYaml && instanceYaml.inputs && instanceYaml.inputs.region;
   const componentType = instanceYaml && instanceYaml.component;
 
-  if (!componentType.startsWith('scf') || !componentType.startsWith('multi-scf')) {
+  if (!componentType.startsWith('scf') && !componentType.startsWith('multi-scf')) {
     cli.log(`Serverless: ${chalk.yellow('Inovke 命令仅能在 scf 或者 multi-scf 组件目录中调用')}`);
     process.exit();
   }

--- a/src/cli/commands-cn/logs.js
+++ b/src/cli/commands-cn/logs.js
@@ -81,7 +81,7 @@ module.exports = async (config, cli, command) => {
   // Get function name
   let finalFunctionName;
   try {
-    if (componentType === 'multi-scf') {
+    if (componentType.startsWith('multi-scf')) {
       finalFunctionName = utils.getFunctionNameOfMultiScf(instanceYaml, stageValue, functionAlias);
     } else {
       finalFunctionName = utils.getFunctionName(instanceYaml, stageValue);

--- a/src/cli/commands-cn/logs.js
+++ b/src/cli/commands-cn/logs.js
@@ -26,7 +26,19 @@ function printLogMessages(logList, cli) {
  */
 module.exports = async (config, cli, command) => {
   // Parse commands
-  const { stage, s, region, r, startTime, tail, t, interval, i, function: originalFunctionAlias, f } = config;
+  const {
+    stage,
+    s,
+    region,
+    r,
+    startTime,
+    tail,
+    t,
+    interval,
+    i,
+    function: originalFunctionAlias,
+    f,
+  } = config;
   const stageValue = stage || s;
   const regionValue = region || r;
   const intervalValue = interval || i;

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -474,7 +474,7 @@ function getFunctionName(instanceYaml, stageValue) {
 
 function getFunctionNameOfMultiScf(instanceYaml, stageValue, functionAlias) {
   if (!functionAlias) {
-    throw new Error('请通过 --function/-f 指定函数');
+    throw new Error('请使用 --function / -f 指定要调用的函数');
   }
 
   if (

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -493,7 +493,9 @@ function getFunctionNameOfMultiScf(instanceYaml, stageValue, functionAlias) {
       throw new Error('目前 inputs.name 只支持 stage, name, app 三种变量');
     }
   } else {
-    functionName = `${instanceYaml.name}-${stageValue || instanceYaml.stage}-${instanceYaml.app}-${functionAlias}`;
+    functionName = `${instanceYaml.name}-${stageValue || instanceYaml.stage}-${
+      instanceYaml.app
+    }-${functionAlias}`;
   }
 
   return functionName;

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -452,6 +452,53 @@ inputs:
   throw new Error('当前目录未检测到 Serverless 配置文件');
 };
 
+function getFunctionName(instanceYaml, stageValue) {
+  let functionName;
+  if (instanceYaml && instanceYaml.inputs && instanceYaml.inputs.name) {
+    functionName = instanceYaml.inputs.name.trim();
+    functionName = functionName.replace('${name}', instanceYaml.name);
+    functionName = functionName.replace('${app}', instanceYaml.app);
+    if (typeof functionName === 'string' && !functionName.includes('${stage}') && stageValue) {
+      throw new Error('当前应用自定义 SCF 实例名称无法指定 stage 信息，请检查后重试');
+    }
+    functionName = functionName.replace('${stage}', stageValue || instanceYaml.stage);
+    if (functionName.match(/\${(\w*:?[\w\d.-]+)}/g)) {
+      throw new Error('目前 inputs.name 只支持 stage, name, app 三种变量');
+    }
+  } else {
+    functionName = `${instanceYaml.name}-${stageValue || instanceYaml.stage}-${instanceYaml.app}`;
+  }
+
+  return functionName;
+}
+
+function getFunctionNameOfMultiScf(instanceYaml, stageValue, functionAlias) {
+  if (!functionAlias) {
+    throw new Error('请通过 --function 指定函数');
+  }
+  if (!instanceYaml.inputs || !instanceYaml.inputs[functionAlias]) {
+    throw new Error('未找到指定函数，请检查后重试');
+  }
+
+  let functionName;
+  if (instanceYaml.inputs[functionAlias].name) {
+    functionName = instanceYaml.inputs[functionAlias].name.trim();
+    functionName = functionName.replace('${name}', instanceYaml.name);
+    functionName = functionName.replace('${app}', instanceYaml.app);
+    if (typeof functionName === 'string' && !functionName.includes('${stage}') && stageValue) {
+      throw new Error('当前应用自定义 SCF 实例名称无法指定 stage 信息，请检查后重试');
+    }
+    functionName = functionName.replace('${stage}', stageValue || instanceYaml.stage);
+    if (functionName.match(/\${(\w*:?[\w\d.-]+)}/g)) {
+      throw new Error('目前 inputs.name 只支持 stage, name, app 三种变量');
+    }
+  } else {
+    functionName = `${instanceYaml.name}-${stageValue || instanceYaml.stage}-${instanceYaml.app}-${functionAlias}`;
+  }
+
+  return functionName;
+}
+
 module.exports = {
   loadInstanceConfig: loadTencentInstanceConfig,
   loadInstanceCredentials,
@@ -460,6 +507,8 @@ module.exports = {
   getTemplate,
   getInstanceDashboardUrl,
   getTemplateDashboardUrl,
+  getFunctionName,
+  getFunctionNameOfMultiScf,
   handleDebugLogMessage,
   parseYaml,
   saveYaml,

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -474,15 +474,16 @@ function getFunctionName(instanceYaml, stageValue) {
 
 function getFunctionNameOfMultiScf(instanceYaml, stageValue, functionAlias) {
   if (!functionAlias) {
-    throw new Error('请通过 --function 指定函数');
+    throw new Error('请通过 --function/-f 指定函数');
   }
-  if (!instanceYaml.inputs || !instanceYaml.inputs[functionAlias]) {
+
+  if (!instanceYaml.inputs || !instanceYaml.inputs.functions || !instanceYaml.inputs.functions[functionAlias]) {
     throw new Error('未找到指定函数，请检查后重试');
   }
 
   let functionName;
-  if (instanceYaml.inputs[functionAlias].name) {
-    functionName = instanceYaml.inputs[functionAlias].name.trim();
+  if (instanceYaml.inputs.functions[functionAlias].name) {
+    functionName = instanceYaml.inputs.functions[functionAlias].name.trim();
     functionName = functionName.replace('${name}', instanceYaml.name);
     functionName = functionName.replace('${app}', instanceYaml.app);
     if (typeof functionName === 'string' && !functionName.includes('${stage}') && stageValue) {

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -477,7 +477,11 @@ function getFunctionNameOfMultiScf(instanceYaml, stageValue, functionAlias) {
     throw new Error('请通过 --function/-f 指定函数');
   }
 
-  if (!instanceYaml.inputs || !instanceYaml.inputs.functions || !instanceYaml.inputs.functions[functionAlias]) {
+  if (
+    !instanceYaml.inputs ||
+    !instanceYaml.inputs.functions ||
+    !instanceYaml.inputs.functions[functionAlias]
+  ) {
     throw new Error('未找到指定函数，请检查后重试');
   }
 


### PR DESCRIPTION
For the newly added [`multi-scf`](https://github.com/serverless-components/tencent-multi-scf) component, we need to enable the following commands
- [x] `sls invoke -f functionKey`
- [x] `sls logs -f functionKey`

Related tickets: 
- https://app.asana.com/0/1200011502754281/1200394700504537
- https://app.asana.com/0/1200011502754281/1200394700504540
- https://app.asana.com/0/1200011502754281/1200394700504545

