### PR TITLE
Enable multi-scf templates

### DIFF
--- a/src/cli/interactive-onboarding/cn.js
+++ b/src/cli/interactive-onboarding/cn.js
@@ -81,7 +81,7 @@ const getTemplatesFromRegistry = async (sdk) => {
 
   // only show the scf examples when user select the scf-starter in first step
   const templatesChoices = templates
-    .filter((item) => !item.name.includes('scf-') || item.name === 'scf-starter')
+    .filter((item) => !item.name.startsWith('scf-') || item.name === 'scf-starter')
     .map((item) => {
       let name = item.name;
 
@@ -99,7 +99,7 @@ const getTemplatesFromRegistry = async (sdk) => {
     });
 
   const scfTemplatesChoices = templates
-    .filter((item) => item.name.includes('scf-') && item.name !== 'scf-starter')
+    .filter((item) => item.name.startsWith('scf-') && item.name !== 'scf-starter')
     .map((item) => {
       let name = item.name;
 


### PR DESCRIPTION
Currently, the `multi-scf-nodejs` template will be ignored when users try to init templates interactively with `sls` command. This PR fixed the issue.


Related: https://app.asana.com/0/1200011502754281/1200515545968615