### PR TITLE
fix: CLI metrics analytics data collection

### DIFF
--- a/src/cli/commands-cn/run.js
+++ b/src/cli/commands-cn/run.js
@@ -99,9 +99,6 @@ module.exports = async (config, cli, command) => {
   const cliendUidResult = await utils.writeClientUid();
   if (!cliendUidResult[orgUid]) {
     options.client_uid = cliendUidResult.value;
-    writeJsonToCredentials(path.join(os.homedir(), '.serverless/tencent/client_uid-credentials'), {
-      client_uid: { ...cliendUidResult, [orgUid]: true },
-    });
   }
 
   // Connect to Serverless Platform Events, if in debug mode
@@ -152,6 +149,15 @@ module.exports = async (config, cli, command) => {
       cli.log(`${chalk.green(vendorMessage)}`);
     }
 
+    // Insert appId into client_uid-credentials to avoid repeatly searching database, no matter the status of instance is succ or fail
+    if (!cliendUidResult[orgUid]) {
+      writeJsonToCredentials(
+        path.join(os.homedir(), '.serverless/tencent/client_uid-credentials'),
+        {
+          client_uid: { ...cliendUidResult, [orgUid]: true },
+        }
+      );
+    }
     if (instance.instanceStatus === 'error') {
       telemtryData.outcome = 'failure';
       telemtryData.failure_reason = instance.deploymentError;

--- a/src/cli/commands-cn/runAll.js
+++ b/src/cli/commands-cn/runAll.js
@@ -73,9 +73,6 @@ module.exports = async (config, cli, command) => {
   const cliendUidResult = await writeClientUid();
   if (!cliendUidResult[orgUid]) {
     options.client_uid = cliendUidResult.value;
-    writeJsonToCredentials(path.join(os.homedir(), '.serverless/tencent/client_uid-credentials'), {
-      client_uid: { ...cliendUidResult, [orgUid]: true },
-    });
   }
 
   if (options.debug) {
@@ -138,6 +135,12 @@ module.exports = async (config, cli, command) => {
     }
   }
 
+  // Insert appId into client_uid-credentials to avoid repeatly searching database, no matter the status of instance is succ or fail
+  if (!cliendUidResult[orgUid] && command === 'deploy') {
+    writeJsonToCredentials(path.join(os.homedir(), '.serverless/tencent/client_uid-credentials'), {
+      client_uid: { ...cliendUidResult, [orgUid]: true },
+    });
+  }
   if (failed.length) {
     cli.sessionStop(
       'error',


### PR DESCRIPTION
Add appid cache in client_uid-credentials only when deployment completed, no matter deployment succ or fail
