### PR TITLE
Ignore timeout issue when polling logs

### DIFF
--- a/src/cli/commands-cn/invoke/index.js
+++ b/src/cli/commands-cn/invoke/index.js
@@ -157,16 +157,8 @@ module.exports = async (config, cli, command) => {
       outcome: 'failure',
       failure_reason: error.message,
     });
-    if (error.code === '1001') {
-      cli.log(
-        `Serverless: ${chalk.yellow(
-          '无法找到指定 SCF 实例，请检查 SCF 实例名称和 Stage / Region 信息或重新部署后调用'
-        )}`
-      );
-      process.exit();
-    } else {
-      throw error;
-    }
+
+    throw error;
   }
 
   await storeLocally({

--- a/src/cli/commands-cn/logs.js
+++ b/src/cli/commands-cn/logs.js
@@ -116,26 +116,10 @@ module.exports = async (config, cli, command) => {
       return logs;
     } catch (error) {
       telemtryData.outcome = 'failure';
-
-      if (error.code === '1001') {
-        telemtryData.failure_reason =
-          '无法找到指定 SCF 实例，请检查 SCF 实例名称和 Stage / Region 信息或重新部署后调用';
-
-        cli.log(
-          `Serverless: ${chalk.yellow(
-            '无法找到指定 SCF 实例，请检查 SCF 实例名称和 Stage / Region 信息或重新部署后调用'
-          )}`
-        );
-        await storeLocally(telemtryData);
-        process.exit();
-      } else {
-        telemtryData.failure_reason = error.message;
-        await storeLocally(telemtryData);
-        throw error;
-      }
+      telemtryData.failure_reason = error.message;
+      await storeLocally(telemtryData);
+      throw error;
     }
-
-    return 0;
   }
 
   if (!tail && !t) {
@@ -156,7 +140,13 @@ module.exports = async (config, cli, command) => {
 
     cli.sessionStart('监听中');
     setInterval(async () => {
-      const newLogList = await getLogList();
+      let newLogList;
+      // ignore timeout issue when polling new logs
+      try {
+        newLogList = await getLogList();
+      } catch (error) {
+        return 0;
+      }
 
       if (newLogList.length > 0 && lastLogList.length <= 0) {
         printLogMessages(newLogList, cli);
@@ -185,6 +175,7 @@ module.exports = async (config, cli, command) => {
           lastLogList = newLogList;
         }
       }
+      return 0;
     }, Number(intervalValue) || 2000);
   }
 };


### PR DESCRIPTION
- [x] Ignore errors when polling logs with `sls logs -t`
- [x] Remove unnecessary code blocks

Related ticket
- https://app.asana.com/0/1200011502754281/1200601499823399