### PR TITLE
Add --target support for 3 commands in template dir

### DIFF
--- a/src/cli/commands-cn/help.js
+++ b/src/cli/commands-cn/help.js
@@ -98,6 +98,7 @@ ${description(`    --stage / -s             指定环境名称，默认使用配
     'logs': `
 ${command2('logs')}                      查看应用日志
 ${description(`    --function / -f          查看多函数组件的指定函数日志(单函数组件无需指定)
+    --target                 指定要查看的组件实例路径
     --stage / -s             指定环境名称，默认使用配置环境
     --startTime              指定开始时间，如：3h, 20130208T080910，默认10m
     --tail / -t              启动监听模式
@@ -137,6 +138,7 @@ ${command2('bind role')}                 重新为当前用户分配使用 Serve
     'invoke': `
 ${command2('invoke')}                    调用函数
 ${description(`    --function / -f          调用的多函数组件的函数名称(单函数组件无需指定)
+    --target                 指定要调用的组件实例路径
     --stage / -s             指定环境名称，默认使用配置环境
     --region / -r            指定地区名称，默认使用配置地区
     --data / -d              指定传入函数的事件(event)参数数据，需要使用序列化的 JSON 格式
@@ -147,6 +149,7 @@ ${description(`    --function / -f          调用的多函数组件的函数名
     'invoke local': `
 ${command2('invoke local')}              本地调用函数
 ${description(`    --function / -f          调用的多函数组件的函数名称(单函数组件无需指定)
+    --target                 指定要调用的组件实例路径
     --data / -d              指定传入函数的事件(event)参数数据，需要使用序列化的 JSON 格式
     --path / -p              指定传入还输的事件(event)参数的 JSON 文件路径
     --context                指定传入函数的上下文(context)参数数据，需要使用序列化的 JSON 格式

--- a/src/cli/commands-cn/invoke/index.js
+++ b/src/cli/commands-cn/invoke/index.js
@@ -10,7 +10,7 @@ const { generatePayload, storeLocally } = require('../telemtry');
 const chalk = require('chalk');
 const { inspect } = require('util');
 const { v4: uuidv4 } = require('uuid');
-const { runningTemplate, checkTemplateAppAndStage } = require('../../utils');
+const { runningTemplate } = require('../../utils');
 
 /**
  * --stage / -s Set stage
@@ -27,7 +27,7 @@ module.exports = async (config, cli, command) => {
     instanceDir = nodePath.join(instanceDir, config.target);
   }
 
-  if (runningTemplate(instanceDir) && checkTemplateAppAndStage(instanceDir)) {
+  if (runningTemplate(instanceDir)) {
     cli.log(
       `Serverless: ${chalk.yellow('该命令暂不支持对多组件进行调用，请使用 --target 指定组件实例')}`
     );

--- a/src/cli/commands-cn/invoke/index.js
+++ b/src/cli/commands-cn/invoke/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const nodePath = require('path');
 const utils = require('../utils');
 const { isJson } = require('../../utils');
 const { ServerlessSDK, utils: chinaUtils } = require('@serverless/platform-client-china');
@@ -9,6 +10,7 @@ const { generatePayload, storeLocally } = require('../telemtry');
 const chalk = require('chalk');
 const { inspect } = require('util');
 const { v4: uuidv4 } = require('uuid');
+const { runningTemplate, checkTemplateAppAndStage } = require('../../utils');
 
 /**
  * --stage / -s Set stage
@@ -20,7 +22,17 @@ const { v4: uuidv4 } = require('uuid');
  * --qualifier / -q SCF qualifier
  */
 module.exports = async (config, cli, command) => {
-  const instanceDir = process.cwd();
+  let instanceDir = process.cwd();
+  if (config.target) {
+    instanceDir = nodePath.join(instanceDir, config.target);
+  }
+
+  if (runningTemplate(instanceDir) && checkTemplateAppAndStage(instanceDir)) {
+    cli.log(
+      `Serverless: ${chalk.yellow('该命令暂不支持对多组件进行调用，请使用 --target 指定组件实例')}`
+    );
+  }
+
   await utils.checkBasicConfigValidation(instanceDir);
 
   const subCommand = config.params[0];

--- a/src/cli/commands-cn/invoke/index.js
+++ b/src/cli/commands-cn/invoke/index.js
@@ -31,6 +31,7 @@ module.exports = async (config, cli, command) => {
     cli.log(
       `Serverless: ${chalk.yellow('该命令暂不支持对多组件进行调用，请使用 --target 指定组件实例')}`
     );
+    process.exit();
   }
 
   await utils.checkBasicConfigValidation(instanceDir);

--- a/src/cli/commands-cn/invoke/invoke-local/index.js
+++ b/src/cli/commands-cn/invoke/invoke-local/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const { runningTemplate, checkTemplateAppAndStage } = require('../../../utils');
+const { runningTemplate } = require('../../../utils');
 const utils = require('../../utils');
 const { readAndParseSync, fileExistsSync } = require('../../../utils');
 const { colorLog, printOutput, summaryOptions, checkRuntime } = require('./utils');
@@ -15,7 +15,7 @@ module.exports = async (config, cli, command) => {
   if (config.target) {
     instanceDir = path.join(instanceDir, config.target);
   }
-  if (runningTemplate(instanceDir) && checkTemplateAppAndStage(instanceDir)) {
+  if (runningTemplate(instanceDir)) {
     cli.log(
       `Serverless: ${chalk.yellow('该命令暂不支持对多组件进行调用，请使用 --target 指定组件实例')}`
     );

--- a/src/cli/commands-cn/invoke/invoke-local/index.js
+++ b/src/cli/commands-cn/invoke/invoke-local/index.js
@@ -1,22 +1,32 @@
 'use strict';
 
 const path = require('path');
-
+const { runningTemplate, checkTemplateAppAndStage } = require('../../../utils');
 const utils = require('../../utils');
 const { readAndParseSync, fileExistsSync } = require('../../../utils');
 const { colorLog, printOutput, summaryOptions, checkRuntime } = require('./utils');
 const runPython = require('./runPython');
 const { generatePayload, storeLocally } = require('../../telemtry');
+const chalk = require('chalk');
 
 module.exports = async (config, cli, command) => {
   const { config: ymlFilePath, c } = config;
-  let instanceYml = await utils.loadInstanceConfig(process.cwd(), command);
+  let instanceDir = process.cwd();
+  if (config.target) {
+    instanceDir = path.join(instanceDir, config.target);
+  }
+  if (runningTemplate(instanceDir) && checkTemplateAppAndStage(instanceDir)) {
+    cli.log(
+      `Serverless: ${chalk.yellow('该命令暂不支持对多组件进行调用，请使用 --target 指定组件实例')}`
+    );
+  }
+  let instanceYml = await utils.loadInstanceConfig(instanceDir, command);
   const telemtryData = await generatePayload({ command: 'invoke_local', rootConfig: instanceYml });
 
   if (ymlFilePath || c) {
     const customizedConfigFile = ymlFilePath || c;
 
-    if (!fileExistsSync(path.join(process.cwd(), customizedConfigFile))) {
+    if (!fileExistsSync(path.join(instanceDir, customizedConfigFile))) {
       await storeLocally({
         ...telemtryData,
         outcome: 'failure',
@@ -50,7 +60,7 @@ module.exports = async (config, cli, command) => {
     checkRuntime(runtime, cli);
 
     if (runtime.includes('Nodejs')) {
-      const invokeFromFile = path.join(process.cwd(), handlerFile);
+      const invokeFromFile = path.join(instanceDir, handlerFile);
       const exportedVars = require(invokeFromFile);
       const finalInvokedFunc = exportedVars[handlerFunc];
       if (!finalInvokedFunc) {

--- a/src/cli/commands-cn/invoke/invoke-local/index.js
+++ b/src/cli/commands-cn/invoke/invoke-local/index.js
@@ -19,6 +19,7 @@ module.exports = async (config, cli, command) => {
     cli.log(
       `Serverless: ${chalk.yellow('该命令暂不支持对多组件进行调用，请使用 --target 指定组件实例')}`
     );
+    process.exit();
   }
   let instanceYml = await utils.loadInstanceConfig(instanceDir, command);
   const telemtryData = await generatePayload({ command: 'invoke_local', rootConfig: instanceYml });

--- a/src/cli/commands-cn/logs.js
+++ b/src/cli/commands-cn/logs.js
@@ -10,7 +10,7 @@ const relativeTime = require('dayjs/plugin/relativeTime');
 const utc = require('dayjs/plugin/utc');
 const timezone = require('dayjs/plugin/timezone');
 const { v4: uuidv4 } = require('uuid');
-const { runningTemplate, checkTemplateAppAndStage } = require('../utils');
+const { runningTemplate } = require('../utils');
 
 dayjs.extend(utc);
 dayjs.extend(timezone); // dependent on utc plugin
@@ -83,7 +83,7 @@ module.exports = async (config, cli, command) => {
   if (config.target) {
     instanceDir = path.join(instanceDir, config.target);
   }
-  if (runningTemplate(instanceDir) && checkTemplateAppAndStage(instanceDir)) {
+  if (runningTemplate(instanceDir)) {
     cli.log(
       `Serverless: ${chalk.yellow('该命令暂不支持对多组件进行调用，请使用 --target 指定组件实例')}`
     );

--- a/src/cli/commands-cn/logs.js
+++ b/src/cli/commands-cn/logs.js
@@ -87,6 +87,7 @@ module.exports = async (config, cli, command) => {
     cli.log(
       `Serverless: ${chalk.yellow('该命令暂不支持对多组件进行调用，请使用 --target 指定组件实例')}`
     );
+    process.exit();
   }
   await utils.checkBasicConfigValidation(instanceDir);
   await utils.login(config);


### PR DESCRIPTION
- [x] `--target` support for for `invoke`, `invoke local` and `logs` command
- [x] `--target` in help doc for the above commands
- [x] Notify users to use `--target` option if they are using these commands directly in a composite project 

### Related tickets
https://app.asana.com/0/1200011502754281/1200578828969029