### PR TITLE
Detect invoking dir for templates

### DIFF
--- a/src/cli/commands-cn/invoke/index.js
+++ b/src/cli/commands-cn/invoke/index.js
@@ -22,26 +22,6 @@ const { runningTemplate } = require('../../utils');
  * --qualifier / -q SCF qualifier
  */
 module.exports = async (config, cli, command) => {
-  let instanceDir = process.cwd();
-  if (config.target) {
-    instanceDir = nodePath.join(instanceDir, config.target);
-  }
-
-  if (runningTemplate(instanceDir)) {
-    cli.log(
-      `Serverless: ${chalk.yellow('该命令暂不支持对多组件进行调用，请使用 --target 指定组件实例')}`
-    );
-    process.exit();
-  }
-
-  await utils.checkBasicConfigValidation(instanceDir);
-
-  const subCommand = config.params[0];
-
-  if (subCommand === 'local') {
-    return invokeLocal(config, cli, command);
-  }
-
   const {
     stage,
     s,
@@ -65,6 +45,28 @@ module.exports = async (config, cli, command) => {
   const functionAlias = originalFunctionAlias || f;
   const namespaceValue = namespace || n;
   const qualifierValue = qualifier || q;
+
+  let instanceDir = process.cwd();
+  if (config.target) {
+    instanceDir = nodePath.join(instanceDir, config.target);
+  }
+
+  if (runningTemplate(instanceDir)) {
+    try {
+      instanceDir = await utils.getDirForInvokeCommand(instanceDir, functionAlias);
+    } catch (e) {
+      cli.log(`Serverless: ${chalk.yellow(e.message)}`);
+      process.exit();
+    }
+  }
+
+  await utils.checkBasicConfigValidation(instanceDir);
+
+  const subCommand = config.params[0];
+
+  if (subCommand === 'local') {
+    return invokeLocal(config, cli, command, instanceDir);
+  }
 
   const instanceYaml = await utils.loadInstanceConfig(instanceDir, command);
   const telemtryData = await generatePayload({ command, rootConfig: instanceYaml });

--- a/src/cli/commands-cn/invoke/invoke-local/index.js
+++ b/src/cli/commands-cn/invoke/invoke-local/index.js
@@ -1,26 +1,15 @@
 'use strict';
 
 const path = require('path');
-const { runningTemplate } = require('../../../utils');
 const utils = require('../../utils');
 const { readAndParseSync, fileExistsSync } = require('../../../utils');
 const { colorLog, printOutput, summaryOptions, checkRuntime } = require('./utils');
 const runPython = require('./runPython');
 const { generatePayload, storeLocally } = require('../../telemtry');
-const chalk = require('chalk');
 
-module.exports = async (config, cli, command) => {
+module.exports = async (config, cli, command, instanceDir) => {
   const { config: ymlFilePath, c } = config;
-  let instanceDir = process.cwd();
-  if (config.target) {
-    instanceDir = path.join(instanceDir, config.target);
-  }
-  if (runningTemplate(instanceDir)) {
-    cli.log(
-      `Serverless: ${chalk.yellow('该命令暂不支持对多组件进行调用，请使用 --target 指定组件实例')}`
-    );
-    process.exit();
-  }
+
   let instanceYml = await utils.loadInstanceConfig(instanceDir, command);
   const telemtryData = await generatePayload({ command: 'invoke_local', rootConfig: instanceYml });
 


### PR DESCRIPTION
When users execute `sls invoke` or `sls invoke local` in a template folder, try to detect `scf`/`multi-scf` instance directory.

### Related ticket
https://app.asana.com/0/1200011502754281/1200578828969029