### PR TITLE
feat: Add more useful info on clientUid

### DIFF
--- a/src/cli/commands-cn/telemtry/generatePayload.js
+++ b/src/cli/commands-cn/telemtry/generatePayload.js
@@ -96,7 +96,7 @@ module.exports = async ({
       return null;
     })();
 
-    const { value: clientUid } = await writeClientUid(undefined, ciName, command); // get client uid, if it doesn't exist, create one firstly.
+    const { value: clientUid } = await writeClientUid(undefined, { ciName, command }); // get client uid, if it doesn't exist, create one firstly.
 
     let payload = {
       event: `components.command.${command}`,

--- a/src/cli/commands-cn/telemtry/generatePayload.js
+++ b/src/cli/commands-cn/telemtry/generatePayload.js
@@ -74,8 +74,6 @@ module.exports = async ({
   serviceDir = process.cwd(),
 }) => {
   try {
-    const { value: clientUid } = await writeClientUid(); // get client uid, if it doesn't exist, create one firstly.
-
     if (!command) {
       throw new Error('command is required for sending metrics analytics');
     }
@@ -97,6 +95,8 @@ module.exports = async ({
       }
       return null;
     })();
+
+    const { value: clientUid } = await writeClientUid(undefined, ciName, command); // get client uid, if it doesn't exist, create one firstly.
 
     let payload = {
       event: `components.command.${command}`,

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -529,7 +529,7 @@ inputs:
 
 const clientUidDefaultPath = path.join(os.homedir(), '.serverless/tencent/client_uid-credentials');
 // If current machine does not have an uuid, create and save it, or load  and finally return the value.
-const writeClientUid = async (p = clientUidDefaultPath, ciName, command) => {
+const writeClientUid = async (p = clientUidDefaultPath, options = {}) => {
   let res = {};
   try {
     if (!fse.existsSync(p)) {
@@ -537,8 +537,7 @@ const writeClientUid = async (p = clientUidDefaultPath, ciName, command) => {
       res = {
         value: uuidv1(), // the value of client_uid
         downloadAt: Date.now(), // the created time of client_uid
-        ciName,
-        command,
+        ...options,
       };
       writeJsonToCredentials(p, {
         client_uid: res,

--- a/src/cli/commands-cn/utils.js
+++ b/src/cli/commands-cn/utils.js
@@ -529,7 +529,7 @@ inputs:
 
 const clientUidDefaultPath = path.join(os.homedir(), '.serverless/tencent/client_uid-credentials');
 // If current machine does not have an uuid, create and save it, or load  and finally return the value.
-const writeClientUid = async (p = clientUidDefaultPath) => {
+const writeClientUid = async (p = clientUidDefaultPath, ciName, command) => {
   let res = {};
   try {
     if (!fse.existsSync(p)) {
@@ -537,6 +537,8 @@ const writeClientUid = async (p = clientUidDefaultPath) => {
       res = {
         value: uuidv1(), // the value of client_uid
         downloadAt: Date.now(), // the created time of client_uid
+        ciName,
+        command,
       };
       writeJsonToCredentials(p, {
         client_uid: res,


### PR DESCRIPTION
 To add `ciName` and `command` info when creating and saving clientUid on machine and DB, it helps us to debug error