### PR TITLE
Add timeout option from serverless command config

### DIFF
--- a/src/cli/commands/run.js
+++ b/src/cli/commands/run.js
@@ -66,6 +66,7 @@ module.exports = async (config, cli, command) => {
     const options = {};
     options.debug = config.debug;
     options.dev = config.dev;
+    options.timeout = config.timeout;
 
     // Connect to Serverless Platform Events, if in debug mode
     if (options.debug) {


### PR DESCRIPTION
## What has been implemented?

In some complex workflows, like for example, using the website component to automatically deploy a website on PR opening, we want to be able to cleanup completely on PR close and clean all resources. To do this, the cloudfront distributions need to be disabled and then deleted. It takes a variable amount of time from 2-15 minutes. But since component's CLI is not passing through the upstream option _timeout_ there is no way to configure it and it defaults to 60000 ms.

In order to overcome that I've added to the runner the option to read the command option _timeout_ and pass it through.

I could help with the documentation, but I think it is pretty outdated in the src/cli/commands/help.js

Closes #959

## Steps to verify

- Run _deploy_ or _remove_ command with the option _timeout_ as a value in ms from a directory where a component is used

`serverless remove --stage ISSUE-959 --timeout 900000`

## Todos:

- [X] Write / update documentation
