### PR TITLE
remove extra debugStart initialization

### DIFF
--- a/src/cli/commands-cn/dev.js
+++ b/src/cli/commands-cn/dev.js
@@ -290,12 +290,6 @@ module.exports = async (config, cli, command) => {
             namespace: namespaceInfo,
             runtime: runtimeInfo,
           };
-          // FIXME: we need to call start debug method here, due to we bind stopAll function in the startTencentRemoteLogAndDebug method and the stopAll is used in stopDebug method, if we want to stop debug mode that we must has stopAll firstly
-          await chinaUtils.startTencentRemoteLogAndDebug(
-            functionInfoStore,
-            regionStore,
-            cliEventCallback
-          );
         }
       }
 


### PR DESCRIPTION
## What has been implemented?

We do not need to init a `debug` before we want to close debug mode due to this [PR](https://github.com/serverlessinc/platform-cn/pull/213)
Closes https://app.asana.com/0/0/1200995050585991/f

## Steps to verify

- Run X
- ...

## Todos:

- [ ] Write tests
- [ ] Write / update documentation
- [ ] Run Prettier
