### PR TITLE
Trim app, name and stage for serverless.yml

### DIFF
--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -359,6 +359,7 @@ const loadInstanceConfigUncached = (directoryPath) => {
 
   instanceFile.app = instanceFile.app.trim();
   instanceFile.name = instanceFile.name.trim();
+  instanceFile.stage = instanceFile.stage.trim();
 
   return instanceFile;
 };

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -357,6 +357,9 @@ const loadInstanceConfigUncached = (directoryPath) => {
     instanceFile.app = instanceFile.name;
   }
 
+  instanceFile.app = instanceFile.app.trim();
+  instanceFile.name = instanceFile.name.trim();
+
   return instanceFile;
 };
 


### PR DESCRIPTION
## What has been implemented?

When there are two space keys before the `name`, `app` or `stage` value, the extra space key will be recognized as part of  them. Which leads to a bug copying assets on COS/S3 (we use these values to form the key to store users' code on COS/S3 `${orgUid}/${stageName}/${appName}/${instanceName}` )
<img width="212" alt="Screen Shot 2021-12-06 at 4 29 29 PM" src="https://user-images.githubusercontent.com/5512552/144953648-1fb63a11-8f96-4e6f-a8f5-6436778d5501.png">

Related issue: https://app.asana.com/0/1200011502754281/1200844911571302
